### PR TITLE
Fix issues with char escapes

### DIFF
--- a/scripts/util.py
+++ b/scripts/util.py
@@ -29,7 +29,7 @@ _custom_char_escapes = {
     '\\': '-bsol-',
     ']': '-rsqb-',
     '^': '-Hat-',
-    '_': '_',            # keep, even though it's conflated with ' ' -> '_'
+    '_': '-lowbar-',
     '`': '-grave-',
     '{': '-lbrace-',
     '|': '-vert-',
@@ -46,7 +46,7 @@ def escape_lemma(lemma: str) -> str:
                 or '0' <= c <= '9'  # not in initial position
                 # or c == ':'  # drop this for xsd:id compatibility
                 # or c in '-'  # blocked for special purpose (see below)
-                or c in '_.·'  # _ is special-purpose, but accept
+                or c in '.·'
                 or 0xC0 <= codepoint <= 0xD6
                 or 0xD8 <= codepoint <= 0xF6
                 or 0xF8 <= codepoint <= 0x2FF

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -65,7 +65,7 @@ def escape_lemma(lemma: str) -> str:
         elif c in _custom_char_escapes:
             chars.append(_custom_char_escapes[c])
         elif codepoint in codepoint2name:
-            chars.append(codepoint2name[codepoint])
+            chars.append(f"-{codepoint2name[codepoint]}-")
         else:
             esc = f'-{codepoint:04X}-'
             warnings.warn(f'no escape character defined for {c!r}; using {esc}')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,10 @@
+from scripts.util import escape_lemma
+
+def test_escape_lemma():
+    assert escape_lemma("abc") == "abc"
+    assert escape_lemma("a.b.c") == "a.b.c"
+    assert escape_lemma("protégé") == "protégé"
+    assert escape_lemma("a b c") == "a_b_c"
+    assert escape_lemma("a:b:c") == "a-colon-b-colon-c"
+    assert escape_lemma("a-b-c") == "a--b--c"
+    assert escape_lemma("a´b´c") == "a-acute-b-acute-c"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,3 +8,4 @@ def test_escape_lemma():
     assert escape_lemma("a:b:c") == "a-colon-b-colon-c"
     assert escape_lemma("a-b-c") == "a--b--c"
     assert escape_lemma("a´b´c") == "a-acute-b-acute-c"
+    assert escape_lemma("a_b_c") == "a-lowbar-b-lowbar-c"


### PR DESCRIPTION
Fixes #39
- `html.entities.codepoint2name` mappings now get dash escapes
- literal `_` in the lemma now maps to `-lowbar-`