### PR TITLE
TSV cleanup scripts

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+### Remove duplicate entries, strip quotes, etc. in TSV files
+
+clean() {
+    python -m scripts.clean-tsv --in-place "$1" 2>"$2"
+}
+
+LGS=(
+  als
+  arb
+  bul
+  cow
+  cwn
+  dan
+  ell
+  eng
+  fas
+  fin
+  fra
+  heb
+  hrv
+  isl
+  ita
+  iwn
+  jpn
+  mcr
+  msa
+  nld
+  nor
+  pol
+  por
+  ron
+  slk
+  slv
+  swe
+  tha
+)
+
+for lg in ${LGS[*]}; do
+    echo "Cleaning ${lg}" >&2
+    tab="wns/${lg}/wn-data-${lg}.tab"
+    err="wns/${lg}/changes.tab"
+    clean "$tab" "$err"
+done

--- a/clean.sh
+++ b/clean.sh
@@ -3,43 +3,45 @@
 ### Remove duplicate entries, strip quotes, etc. in TSV files
 
 clean() {
-    python -m scripts.clean-tsv --in-place "$1" 2>"$2"
+    echo "Cleaning ${1} ${2}" >&2
+    tab="wns/${1}/wn-data-${2:-$1}.tab"
+    err="wns/${1}/${2:-$1}-changes.tab"
+    python -m scripts.clean-tsv --in-place "$tab" 2>"$err"
 }
 
-LGS=(
-  als
-  arb
-  bul
-  cow
-  cwn
-  dan
-  ell
-  eng
-  fas
-  fin
-  fra
-  heb
-  hrv
-  isl
-  ita
-  iwn
-  jpn
-  mcr
-  msa
-  nld
-  nor
-  pol
-  por
-  ron
-  slk
-  slv
-  swe
-  tha
-)
+# clean DIR [LG]
+#   If LG is omitted, DIR is used as the LG code
 
-for lg in ${LGS[*]}; do
-    echo "Cleaning ${lg}" >&2
-    tab="wns/${lg}/wn-data-${lg}.tab"
-    err="wns/${lg}/changes.tab"
-    clean "$tab" "$err"
-done
+clean als
+clean arb
+clean bul
+clean cow cmn
+clean cwn qcn
+clean dan
+clean ell
+clean eng
+clean fas
+clean fin
+clean fra
+clean heb
+clean hrv
+clean isl
+clean ita
+clean iwn ita
+clean jpn
+clean mcr cat
+clean mcr eus
+clean mcr glg
+clean mcr spa
+clean msa ind
+clean msa zsm
+clean nld
+clean nor nno
+clean nor nob
+clean pol
+clean por
+clean ron
+clean slk
+clean slv
+clean swe
+clean tha

--- a/scripts/clean-tsv.py
+++ b/scripts/clean-tsv.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 
 from .util import load_tsv, strip_quotes
@@ -9,23 +10,35 @@ def main(args: argparse.Namespace) -> int:
     header, rows = load_tsv(args.TSVFILE)
 
     seen_lemmas: dict[str, set[str]] = {}
-    with args.TSVFILE.open("wt", encoding="utf-8") as tabfile:
-        print(header, file=tabfile)
+
+    if args.in_place:
+        tabfile = args.TSVFILE.open("wt", encoding="utf-8")
+    else:
+        tabfile = nullcontext(sys.stdout)  # so we can use `with tabfile:`
+
+    logfile = nullcontext(sys.stderr)
+
+    with tabfile as out, logfile as err:
+        print(header, file=out)
 
         for row in rows:
             offset_pos, row_type, text, order = row
 
             lemma_set = seen_lemmas.setdefault(offset_pos, set())
             if row.is_lemma():
-                text = text.replace("_", " ")  # Use actual spaces
-                text = text.strip()  # strip spaces to help quote-stripping
-                lemma = strip_quotes(text)
+                lemma = text.replace("_", " ")  # Use actual spaces
+                lemma = lemma.strip()  # strip spaces to help quote-stripping
+                lemma = strip_quotes(lemma)
                 if lemma not in lemma_set:
-                    print(f"{offset_pos}\t{row_type}\t{lemma}", file=tabfile)
+                    if lemma != text:
+                        print("MODIFIED\t" + "\t".join(row[:3] + (lemma,)), file=err)
+                    print(f"{offset_pos}\t{row_type}\t{lemma}", file=out)
                     lemma_set.add(lemma)
+                else:
+                    print("REMOVED\t" + "\t".join(row[:3]), file=err)
 
             elif row_type.endswith((":def", "exe")):
-                print(f"{offset_pos}\t{row_type}\t{order}\t{text}", file=tabfile)
+                print(f"{offset_pos}\t{row_type}\t{order}\t{text}", file=out)
 
             else:
                 raise Exception(f"unexpected row type: {row_type}")
@@ -43,5 +56,11 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument("TSVFILE", type=Path, help="path to TSV file")
+    parser.add_argument(
+        "-i",
+        "--in-place",
+        action="store_true",
+        help="modify the original file instead of writing to stdout",
+    )
     args = parser.parse_args()
     sys.exit(main(args))

--- a/scripts/clean-tsv.py
+++ b/scripts/clean-tsv.py
@@ -1,0 +1,47 @@
+import argparse
+import sys
+from pathlib import Path
+
+from .util import load_tsv, strip_quotes
+
+
+def main(args: argparse.Namespace) -> int:
+    header, rows = load_tsv(args.TSVFILE)
+
+    seen_lemmas: dict[str, set[str]] = {}
+    with args.TSVFILE.open("wt", encoding="utf-8") as tabfile:
+        print(header, file=tabfile)
+
+        for row in rows:
+            offset_pos, row_type, text, order = row
+
+            lemma_set = seen_lemmas.setdefault(offset_pos, set())
+            if row.is_lemma():
+                text = text.replace("_", " ")  # Use actual spaces
+                text = text.strip()  # strip spaces to help quote-stripping
+                lemma = strip_quotes(text)
+                if lemma not in lemma_set:
+                    print(f"{offset_pos}\t{row_type}\t{lemma}", file=tabfile)
+                    lemma_set.add(lemma)
+
+            elif row_type.endswith((":def", "exe")):
+                print(f"{offset_pos}\t{row_type}\t{order}\t{text}", file=tabfile)
+
+            else:
+                raise Exception(f"unexpected row type: {row_type}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Remove duplicate lemmas and strip quotes from TSV files.",
+        epilog=(
+            "WARNING: This modifies the original TSVFILE! It is suggested that you "
+            "work with a file checked into version control so you can inspect the "
+            "diffs and revert if necessary."
+        ),
+    )
+    parser.add_argument("TSVFILE", type=Path, help="path to TSV file")
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/scripts/clean-tsv.py
+++ b/scripts/clean-tsv.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import sys
 from contextlib import nullcontext
 from pathlib import Path
@@ -16,6 +17,7 @@ def main(args: argparse.Namespace) -> int:
     else:
         tabfile = nullcontext(sys.stdout)  # so we can use `with tabfile:`
 
+    date = datetime.date.today().isoformat()  # for the log
     logfile = nullcontext(sys.stderr)
 
     with tabfile as out, logfile as err:
@@ -31,11 +33,14 @@ def main(args: argparse.Namespace) -> int:
                 lemma = strip_quotes(lemma)
                 if lemma not in lemma_set:
                     if lemma != text:
-                        print("MODIFIED\t" + "\t".join(row[:3] + (lemma,)), file=err)
+                        print(
+                            "\t".join((date, "MODIFIED") + row[:3] + (lemma,)),
+                            file=err
+                        )
                     print(f"{offset_pos}\t{row_type}\t{lemma}", file=out)
                     lemma_set.add(lemma)
                 else:
-                    print("REMOVED\t" + "\t".join(row[:3]), file=err)
+                    print("\t".join((date, "REMOVED") + row[:3]), file=err)
 
             elif row_type.endswith((":def", "exe")):
                 print(f"{offset_pos}\t{row_type}\t{order}\t{text}", file=out)
@@ -50,9 +55,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Remove duplicate lemmas and strip quotes from TSV files.",
         epilog=(
-            "WARNING: This modifies the original TSVFILE! It is suggested that you "
-            "work with a file checked into version control so you can inspect the "
-            "diffs and revert if necessary."
+            "WARNING: --in-place modifies the original TSVFILE! It is suggested "
+            "that you work with a file checked into version control so you can "
+            "inspect the diffs and revert if necessary."
         ),
     )
     parser.add_argument("TSVFILE", type=Path, help="path to TSV file")

--- a/scripts/clean-tsv.py
+++ b/scripts/clean-tsv.py
@@ -10,7 +10,7 @@ from .util import load_tsv, strip_quotes
 def main(args: argparse.Namespace) -> int:
     header, rows = load_tsv(args.TSVFILE)
 
-    seen_lemmas: dict[str, set[str]] = {}
+    seen_lemmas: dict[str, set[tuple[str, str]]] = {}
 
     if args.in_place:
         tabfile = args.TSVFILE.open("wt", encoding="utf-8")
@@ -31,14 +31,18 @@ def main(args: argparse.Namespace) -> int:
                 lemma = text.replace("_", " ")  # Use actual spaces
                 lemma = lemma.strip()  # strip spaces to help quote-stripping
                 lemma = strip_quotes(lemma)
-                if lemma not in lemma_set:
+
+                lemma_type = "" if args.ignore_lemma_type else row_type
+
+                key = (lemma, lemma_type)
+                if key not in lemma_set:
                     if lemma != text:
                         print(
                             "\t".join((date, "MODIFIED") + row[:3] + (lemma,)),
                             file=err
                         )
                     print(f"{offset_pos}\t{row_type}\t{lemma}", file=out)
-                    lemma_set.add(lemma)
+                    lemma_set.add(key)
                 else:
                     print("\t".join((date, "REMOVED") + row[:3]), file=err)
 
@@ -61,6 +65,11 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument("TSVFILE", type=Path, help="path to TSV file")
+    parser.add_argument(
+        "--ignore-lemma-type",
+        action="store_true",
+        help="don't consider the lemma type column in deduping",
+    )
     parser.add_argument(
         "-i",
         "--in-place",

--- a/scripts/tsv-duplicates.py
+++ b/scripts/tsv-duplicates.py
@@ -1,0 +1,114 @@
+import argparse
+from collections import defaultdict
+import csv
+import logging
+from pathlib import Path
+import sys
+import tempfile
+from typing import Tuple
+from unicodedata import normalize, combining
+
+
+logger = logging.getLogger('tsv-duplicates')
+
+Entry = Tuple[str, str, str]
+
+
+def normalize_lemma(s: str, args: argparse.Namespace) -> str:
+    norm = s
+    if args.ignore_case:
+        norm = norm.lower()
+    if args.underscore:
+        norm = norm.replace('_', ' ')
+    if args.diacritics:
+        norm = ''.join(c for c in normalize('NFKD', norm) if not combining(c))
+    return norm
+
+
+def load_tsv(path: Path) -> tuple[str, list[Entry]]:
+    with path.open(newline='') as csvfile:
+        reader = csv.reader(csvfile, dialect='excel-tab', quoting=csv.QUOTE_NONE)
+        header = next(reader)
+        entries: list[Entry] = []
+        for row in reader:
+            if not row or row[0].startswith('#'):
+                continue
+            if row[1].endswith("lemma"):
+                assert len(row) == 3, f"unexpected number of columns: {row}"
+                entries.append((row[0], row[1], row[2]))
+    return header, entries
+
+
+def check_duplicates(path: Path, args: argparse.Namespace) -> int:
+    header, entries = load_tsv(path)
+    seen: dict[str, dict[str, list[str]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for off_pos, _, lemma in entries:
+        seen[off_pos][normalize_lemma(lemma, args)].append(lemma)
+
+    synset_count = 0
+    lemma_count = 0
+    for off_pos, lemma_groups in seen.items():
+        for norm, lemmas in lemma_groups.items():
+            if len(lemmas) > 1:
+                synset_count += 1
+                lemma_count += len(lemmas)
+                logger.warning(
+                    f"duplicate of {off_pos}: " + ", ".join(map(repr, lemmas))
+                )
+
+    return synset_count, lemma_count
+
+
+def main(args: argparse.Namespace) -> int:
+    retcode = 0
+
+    synset_total = lemma_total = 0
+    for path in args.TSV:
+        synset_count, lemma_count = check_duplicates(path, args)
+        if synset_count or lemma_count:
+            print(
+                f"{path.name} duplicates"
+                f"\t{synset_count} synsets"
+                f"\t{lemma_count} lemmas"
+            )
+            synset_total += synset_count
+            lemma_total += lemma_count
+            retcode = 1
+
+    print(f"total duplicates\t{synset_total} synsets\t{lemma_total} lemmas")
+
+    return retcode
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("TSV", nargs='+', type=Path, help="path to TSV file")
+parser.add_argument(
+    '-v',
+    '--verbose',
+    action='store_true',
+    help='log warnings for each item',
+)
+parser.add_argument(
+    '-i',
+    '--ignore-case',
+    action='store_true',
+    help='ignore case distinctions in lemmas',
+)
+parser.add_argument(
+    '-u',
+    '--underscore',
+    action='store_true',
+    help='treat underscores as spaces in lemmas',
+)
+parser.add_argument(
+    '-d',
+    '--diacritics',
+    action='store_true',
+    help='ignore diacritics with NFKD normalization',
+)
+args = parser.parse_args()
+logging.basicConfig(level=logging.WARNING if args.verbose else logging.ERROR)
+
+sys.exit(main(args))

--- a/scripts/tsv-duplicates.py
+++ b/scripts/tsv-duplicates.py
@@ -1,114 +1,168 @@
 import argparse
-from collections import defaultdict
-import csv
 import logging
-from pathlib import Path
 import sys
-import tempfile
-from typing import Tuple
+from functools import partial
+from itertools import groupby
+from pathlib import Path
+from typing import Callable
 from unicodedata import normalize, combining
 
+from .util import load_tsv, strip_quotes
 
-logger = logging.getLogger('tsv-duplicates')
-
-Entry = Tuple[str, str, str]
-
-
-def normalize_lemma(s: str, args: argparse.Namespace) -> str:
-    norm = s
-    if args.ignore_case:
-        norm = norm.lower()
-    if args.underscore:
-        norm = norm.replace('_', ' ')
-    if args.diacritics:
-        norm = ''.join(c for c in normalize('NFKD', norm) if not combining(c))
-    return norm
+logger = logging.getLogger("tsv-duplicates")
 
 
-def load_tsv(path: Path) -> tuple[str, list[Entry]]:
-    with path.open(newline='') as csvfile:
-        reader = csv.reader(csvfile, dialect='excel-tab', quoting=csv.QUOTE_NONE)
-        header = next(reader)
-        entries: list[Entry] = []
-        for row in reader:
-            if not row or row[0].startswith('#'):
-                continue
-            if row[1].endswith("lemma"):
-                assert len(row) == 3, f"unexpected number of columns: {row}"
-                entries.append((row[0], row[1], row[2]))
-    return header, entries
+def make_normalizer(args: argparse.Namespace) -> Callable[[str], str]:
+
+    def normalize_lemma(s: str) -> str:
+        norm = s
+        if args.ignore_case:
+            norm = norm.lower()
+        if args.underscore:
+            norm = norm.replace("_", " ")
+        if args.diacritics:
+            norm = "".join(c for c in normalize("NFKD", norm) if not combining(c))
+        if args.quotes:
+            norm = strip_quotes(norm.strip())
+        return norm
+
+    return normalize_lemma
 
 
-def check_duplicates(path: Path, args: argparse.Namespace) -> int:
-    header, entries = load_tsv(path)
-    seen: dict[str, dict[str, list[str]]] = defaultdict(
-        lambda: defaultdict(list)
-    )
-    for off_pos, _, lemma in entries:
-        seen[off_pos][normalize_lemma(lemma, args)].append(lemma)
+def check_duplicates(
+    offset_pos: str,
+    lemmas: list[str],
+    normalizer: Callable[[str], str],
+    label: str,
+    verbose: bool,
+) -> int:
+    _sorted = sorted(lemmas, key=normalizer)
+    count = 0
+    for _, grp in groupby(_sorted, key=normalizer):
+        dupes = list(grp)
+        if len(dupes) > 1:
+            if verbose:
+                print(f"\t{offset_pos}\texact\t{'; '.join(dupes)}")
+            count += len(dupes) - 1
+    return count
 
-    synset_count = 0
-    lemma_count = 0
-    for off_pos, lemma_groups in seen.items():
-        for norm, lemmas in lemma_groups.items():
-            if len(lemmas) > 1:
-                synset_count += 1
-                lemma_count += len(lemmas)
-                logger.warning(
-                    f"duplicate of {off_pos}: " + ", ".join(map(repr, lemmas))
-                )
 
-    return synset_count, lemma_count
+def check_polysemy(
+    data: dict[str, list[str]],
+    polysemy_threshold: int,
+    verbose: bool,
+) -> int:
+    # map lemmas to synsets
+    _data: dict[str, list[str]] = {}
+    for offset_pos, lemmas in data.items():
+        for lemma in set(lemmas):
+            _data.setdefault(lemma, []).append(offset_pos)
+    polysem_count = 0
+    for lemma, offsets in _data.items():
+        if len(offsets) >= polysemy_threshold:
+            if verbose:
+                print(f"\t{lemma}\tpolysem\t{'; '.join(offsets)}")
+            polysem_count += 1
+    return polysem_count
+
+
+def load_data(path: Path) -> dict[str, list[str]]:
+    data: dict[str, list[str]] = {}
+    _, rows = load_tsv(path)
+    for row in rows:
+        if not row.is_lemma():
+            continue
+        data.setdefault(row.offset_pos, []).append(row.text)
+    return data
 
 
 def main(args: argparse.Namespace) -> int:
     retcode = 0
 
-    synset_total = lemma_total = 0
-    for path in args.TSV:
-        synset_count, lemma_count = check_duplicates(path, args)
-        if synset_count or lemma_count:
-            print(
-                f"{path.name} duplicates"
-                f"\t{synset_count} synsets"
-                f"\t{lemma_count} lemmas"
-            )
-            synset_total += synset_count
-            lemma_total += lemma_count
-            retcode = 1
+    check_exact = partial(
+        check_duplicates,
+        normalizer=str,
+        label="exact",
+        verbose=args.verbose,
+    )
+    check_normalized = partial(
+        check_duplicates,
+        normalizer=make_normalizer(args),
+        label="".join([
+            "i" if args.ignore_case else "",
+            "u" if args.underscore else "",
+            "d" if args.diacritics else "",
+            "q" if args.quotes else "",
+        ]),
+        verbose=args.verbose,
+    )
 
-    print(f"total duplicates\t{synset_total} synsets\t{lemma_total} lemmas")
+    for path in args.TSV:
+        print(f"Checking for duplicates in {path}")
+        data = load_data(path)
+
+        synsets: set[str] = set()
+        lemma_count = 0
+        for offset_pos, lemmas in data.items():
+            # exact duplicates
+            if cnt := check_exact(offset_pos, lemmas):
+                synsets.add(offset_pos)
+                lemma_count += cnt
+            # normalized duplicates minus exact duplicates
+            if cnt := check_normalized(offset_pos, set(lemmas)):
+                synsets.add(offset_pos)
+                lemma_count += cnt
+        print(f"  Synsets with redundant lemmas: {len(synsets)}")
+        print(f"  Total count of redundant lemmas: {lemma_count}")
+
+        if args.polysemy_threshold:
+            polysem_count = check_polysemy(data, args.polysemy_threshold, args.verbose)
+            print(f"  Lemmas with > {args.polysemy_threshold} senses: {polysem_count}")
 
     return retcode
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("TSV", nargs='+', type=Path, help="path to TSV file")
-parser.add_argument(
-    '-v',
-    '--verbose',
-    action='store_true',
-    help='log warnings for each item',
-)
-parser.add_argument(
-    '-i',
-    '--ignore-case',
-    action='store_true',
-    help='ignore case distinctions in lemmas',
-)
-parser.add_argument(
-    '-u',
-    '--underscore',
-    action='store_true',
-    help='treat underscores as spaces in lemmas',
-)
-parser.add_argument(
-    '-d',
-    '--diacritics',
-    action='store_true',
-    help='ignore diacritics with NFKD normalization',
-)
-args = parser.parse_args()
-logging.basicConfig(level=logging.WARNING if args.verbose else logging.ERROR)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("TSV", nargs="+", type=Path, help="path to TSV file")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="log warnings for each item",
+    )
+    parser.add_argument(
+        "-i",
+        "--ignore-case",
+        action="store_true",
+        help="ignore case distinctions in lemmas",
+    )
+    parser.add_argument(
+        "-u",
+        "--underscore",
+        action="store_true",
+        help="treat underscores as spaces in lemmas",
+    )
+    parser.add_argument(
+        "-d",
+        "--diacritics",
+        action="store_true",
+        help="ignore diacritics with NFKD normalization",
+    )
+    parser.add_argument(
+        "-q",
+        "--quotes",
+        action="store_true",
+        help="strip quote pairs from start/end of lemmas",
+    )
+    parser.add_argument(
+        "-p",
+        "--polysemy-threshold",
+        type=int,
+        metavar="N",
+        help="report lemmas that are used in N (>=2) or more synsets",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.WARNING if args.verbose else logging.ERROR)
 
-sys.exit(main(args))
+    sys.exit(main(args))


### PR DESCRIPTION
Making a separate PR from #33 just for the scripts, and actually cleaning up the data can go in other PRs.

This PR adds two scripts:

* `scripts/tsv-duplicates.py` finds exact and normalized redundant lemmas
* `scripts/clean-tsv.py` modifies TSV files (in-place to stdout) to strip quotes, replace `_` with a space, and remove duplicate lemmas in a synset.

The normalized duplicates of `tsv-duplicates.py` are probably best fixed by hand, so `clean-tsv.py` only looks for exact duplicates after some basic cleaning.

@fcbond I reused parts of your quote-stripping code from the other PR, so we might not need it in two places. Better to do it once and modify the TSV than to do it every time we create a WN-LMF file, I think.