### PR TITLE
Gh 24 unexpected identifiers

### DIFF
--- a/wns/cow/cmn-changes.tab
+++ b/wns/cow/cmn-changes.tab
@@ -1,0 +1,12 @@
+2025-04-22	REMOVED	14869976-n	cmn:lemma	污点
+2025-04-22	REMOVED	14869977-n	cmn:lemma	小斑
+2025-04-22	REMOVED	15168570-n	cmn:lemma	规定的睡觉时间
+2025-04-22	REMOVED	15171146-n	cmn:lemma	节日
+2025-04-22	REMOVED	15171147-n	cmn:lemma	纪念日
+2025-04-22	REMOVED	15171739-n	cmn:lemma	竞技状态不佳的日子
+2025-04-22	REMOVED	15171858-n	cmn:lemma	存取时间
+2025-04-22	REMOVED	15172882-n	cmn:lemma	选举日
+2025-04-22	REMOVED	15173065-n	cmn:lemma	教会年
+2025-04-22	REMOVED	15176162-n	cmn:lemma	雾月
+2025-04-22	REMOVED	15177867-n	cmn:lemma	希伯来历
+2025-04-22	REMOVED	15178842-n	cmn:lemma	回历

--- a/wns/cow/wn-data-cmn.tab
+++ b/wns/cow/wn-data-cmn.tab
@@ -19839,7 +19839,6 @@
 02004874-v	cmn:lemma	回到
 02723951-v	cmn:lemma	回到
 13937918-n	cmn:lemma	回到起点
-15178842-n	cmn:lemma	回历
 15218551-n	cmn:lemma	回历10月
 15218798-n	cmn:lemma	回历12月
 15217443-n	cmn:lemma	回历2月
@@ -24361,7 +24360,6 @@
 03744276-n	cmn:lemma	存储器
 02671224-n	cmn:lemma	存储器存取
 03744840-n	cmn:lemma	存储设备
-15171858-n	cmn:lemma	存取时间
 13957493-n	cmn:lemma	存在
 13962360-n	cmn:lemma	存在
 02603699-v	cmn:lemma	存在
@@ -26107,7 +26105,6 @@
 03007130-n	cmn:lemma	小教堂
 13736197-n	cmn:lemma	小数
 13254011-n	cmn:lemma	小数目
-14869977-n	cmn:lemma	小斑
 14286435-n	cmn:lemma	小斑
 13910019-n	cmn:lemma	小斑点
 03719560-n	cmn:lemma	小斗篷
@@ -27625,7 +27622,6 @@
 03039314-a	cmn:lemma	希伯来+的
 03039087-a	cmn:lemma	希伯来人+的
 03039314-a	cmn:lemma	希伯来人+的
-15177867-n	cmn:lemma	希伯来历
 03039087-a	cmn:lemma	希伯来语+的
 03039314-a	cmn:lemma	希伯来语+的
 02930765-a	cmn:lemma	希伯莱语+的
@@ -36107,7 +36103,6 @@
 02899486-a	cmn:lemma	教会+的
 03029197-n	cmn:lemma	教会塔
 03028785-n	cmn:lemma	教会帽子
-15173065-n	cmn:lemma	教会年
 15181718-n	cmn:lemma	教会年历
 03263338-n	cmn:lemma	教会服装
 13247818-n	cmn:lemma	教会的收入
@@ -44567,7 +44562,6 @@
 03669367-n	cmn:lemma	污水道
 14956661-n	cmn:lemma	污泥
 00422620-a	cmn:lemma	污浊的
-14869976-n	cmn:lemma	污点
 04694441-n	cmn:lemma	污点
 14856752-n	cmn:lemma	污物
 03212114-n	cmn:lemma	污物碾碎器
@@ -55995,7 +55989,6 @@
 03522003-n	cmn:lemma	竞技场
 08497107-n	cmn:lemma	竞技场
 13943740-n	cmn:lemma	竞技场
-15171739-n	cmn:lemma	竞技状态不佳的日子
 01168569-n	cmn:lemma	竞赛
 07456188-n	cmn:lemma	竞赛
 07458453-n	cmn:lemma	竞赛
@@ -57898,7 +57891,6 @@
 03743902-n	cmn:lemma	纪念堂
 03745571-n	cmn:lemma	纪念巨碑
 02864165-a	cmn:lemma	纪念性+的
-15171147-n	cmn:lemma	纪念日
 15200661-n	cmn:lemma	纪念日
 03074380-n	cmn:lemma	纪念柱
 03743902-n	cmn:lemma	纪念碑
@@ -62629,7 +62621,6 @@
 03757604-n	cmn:lemma	节拍器
 03141756-a	cmn:lemma	节拍器+的
 00982275-a	cmn:lemma	节拍或曲子微急+的
-15171146-n	cmn:lemma	节日
 00517728-n	cmn:lemma	节日
 15183428-n	cmn:lemma	节日
 12701178-n	cmn:lemma	节柄科
@@ -66350,7 +66341,6 @@
 02296824-a	cmn:lemma	规定+的
 15233778-n	cmn:lemma	规定时间
 13580909-n	cmn:lemma	规定浓度
-15168570-n	cmn:lemma	规定的睡觉时间
 02004838-a	cmn:lemma	规定费用+的
 13580909-n	cmn:lemma	规度
 03384706-n	cmn:lemma	规整式园林
@@ -71171,7 +71161,6 @@
 02717538-a	cmn:lemma	选举+的
 02454835-v	cmn:lemma	选举中获得
 10760340-n	cmn:lemma	选举人
-15172882-n	cmn:lemma	选举日
 05186306-n	cmn:lemma	选举权
 00800121-n	cmn:lemma	选举活动
 02400637-v	cmn:lemma	选出
@@ -75831,7 +75820,6 @@
 02262984-a	cmn:lemma	雾化+的
 02754103-n	cmn:lemma	雾化器
 03375171-n	cmn:lemma	雾号
-15176162-n	cmn:lemma	雾月
 11458314-n	cmn:lemma	雾气
 02549569-a	cmn:lemma	雾气覆盖+的
 00403052-r	cmn:lemma	雾浓+地

--- a/wns/hrv/hrv-changes.tab
+++ b/wns/hrv/hrv-changes.tab
@@ -1,2 +1,12 @@
 2025-02-01	MODIFIED	04812871-n	hrv:lemma	"Elana"	Elana
 2025-02-01	MODIFIED	12994979-n	hrv:lemma	"prave gljive"	prave gljive
+2025-04-22	REMOVED	01498548-a	hrv:lemma	amoralan
+2025-04-22	REMOVED	01498548-a	hrv:lemma	nemoralan
+2025-04-22	REMOVED	01505508-a	hrv:lemma	mnogo više
+2025-04-22	REMOVED	01505508-a	hrv:lemma	puno više
+2025-04-22	REMOVED	02002046-a	hrv:lemma	izuzev
+2025-04-22	REMOVED	02002046-a	hrv:lemma	izuzevši
+2025-04-22	REMOVED	02002046-a	hrv:lemma	izuzimajući
+2025-04-22	REMOVED	02002046-a	hrv:lemma	osim
+2025-04-22	REMOVED	02917945-a	hrv:lemma	mahunast
+2025-04-22	REMOVED	03202339-n	hrv:lemma	modne potrepštine

--- a/wns/hrv/wn-data-hrv.tab
+++ b/wns/hrv/wn-data-hrv.tab
@@ -14405,8 +14405,6 @@
 01498319-v	hrv:lemma	obilježiti
 01498319-v	hrv:lemma	označavati
 01498319-v	hrv:lemma	označiti
-01498548-a	hrv:lemma	amoralan
-01498548-a	hrv:lemma	nemoralan
 01498769-a	hrv:lemma	izmjeriv
 01498769-a	hrv:lemma	mjeriljiv
 01498769-a	hrv:lemma	mjerljiv
@@ -14449,8 +14447,6 @@
 01505254-v	hrv:lemma	privući
 01505462-a	hrv:lemma	glazben
 01505462-a	hrv:lemma	muzikalan
-01505508-a	hrv:lemma	mnogo više
-01505508-a	hrv:lemma	puno više
 01506157-v	hrv:lemma	odbijati
 01506945-a	hrv:lemma	smrznut
 01506945-a	hrv:lemma	zamrznut
@@ -18588,10 +18584,6 @@
 02001858-v	hrv:lemma	proganjati
 02001858-v	hrv:lemma	progoniti
 02001858-v	hrv:lemma	slijediti
-02002046-a	hrv:lemma	izuzev
-02002046-a	hrv:lemma	izuzevši
-02002046-a	hrv:lemma	izuzimajući
-02002046-a	hrv:lemma	osim
 02002075-n	hrv:lemma	roda
 02002227-a	hrv:lemma	ograničen
 02002720-v	hrv:lemma	goniti
@@ -26383,7 +26375,6 @@
 02916538-n	hrv:lemma	oglasna ploča
 02917377-n	hrv:lemma	megafon
 02917893-a	hrv:lemma	neurološki
-02917945-a	hrv:lemma	mahunast
 02918844-a	hrv:lemma	mikroskopski
 02919414-n	hrv:lemma	bala (sijena
 02919414-n	hrv:lemma	hrpa
@@ -27279,7 +27270,6 @@
 03201776-n	hrv:lemma	smoking
 03201776-n	hrv:lemma	večernje odijelo
 03202123-n	hrv:lemma	tanjur
-03202339-n	hrv:lemma	modne potrepštine
 03202760-n	hrv:lemma	dioda
 03203441-n	hrv:lemma	fenitoin
 03204810-n	hrv:lemma	diptih

--- a/wns/mcr/cat-changes.tab
+++ b/wns/mcr/cat-changes.tab
@@ -1,3 +1,4 @@
 2025-02-01	MODIFIED	04020744-n	cat:lemma	 es paga un dipòsit	es paga un dipòsit
 2025-03-03	REMOVED	03009016-a	cat:def	0	
 2025-03-03	REMOVED	13416897-n	cat:def	0	
+2025-04-22	REMOVED	00001837-n	cat:exe 0	187 DC

--- a/wns/mcr/glg-changes.tab
+++ b/wns/mcr/glg-changes.tab
@@ -1,1 +1,2 @@
 2025-02-01	MODIFIED	14240262-n	glg:lemma	hemanxiosarcoma 	hemanxiosarcoma
+2025-04-22	REMOVED	15300653-n	glg:lemma	métopa

--- a/wns/mcr/spa-changes.tab
+++ b/wns/mcr/spa-changes.tab
@@ -3,3 +3,4 @@
 2025-03-03	REMOVED	10153414-n	spa:def	0	
 2025-03-03	REMOVED	13416897-n	spa:def	0	
 2025-03-03	REMOVED	13419535-n	spa:def	0	
+2025-04-22	REMOVED	15300823-n	spa:exe 0	En 1850, el Dr. Green publicó un artículo en la revista Lancet en el cual niega la relación del "asma del heno" con el heno.

--- a/wns/mcr/wn-data-cat.tab
+++ b/wns/mcr/wn-data-cat.tab
@@ -107795,7 +107795,6 @@
 00001740-n	cat:exe	0	L'ontologia té com a objectiu descriure o posar les categories i relacions bàsiques entre les diferents entitats
 00001740-v	cat:exe	0	El pacient està respirant
 00001740-v	cat:exe	0	Puc respirar millor quan l'aire és net
-00001837-n	cat:exe	0	187 DC
 00002137-n	cat:exe	0	L'abstracció té sempre en compte les característiques comunes dun concepte
 00002684-n	cat:exe	0	el món es divideix en éssers i coses
 00003553-n	cat:exe	0	l'equip és una unitat

--- a/wns/mcr/wn-data-glg.tab
+++ b/wns/mcr/wn-data-glg.tab
@@ -53119,7 +53119,6 @@
 15296489-n	glg:lemma	shivá
 15296687-n	glg:lemma	época
 15299367-n	glg:lemma	6 de agosto
-15300653-n	glg:lemma	métopa
 00001740-a	glg:def	0	(xeralmente seguido de 'de') que ten os medios, as habilidades ou os coñecementos necesarios para facer algunha cousa
 00001740-n	glg:def	0	aquilo que se percibe ou se sabe ou se infire que ten a súa propia existencia distintiva (viva ou non-viva)
 00001930-n	glg:def	0	unha entidade que existencia física

--- a/wns/nld/wn-data-nld.tab
+++ b/wns/nld/wn-data-nld.tab
@@ -1140,7 +1140,7 @@
 03127937-a	nld:lemma	uvulair
 03131331-a	nld:lemma	Zambiaans
 02841066-a	nld:lemma	ruimtelijk
-01132515-s	nld:lemma	satanisch
+01132515-a	nld:lemma	satanisch
 10679845-n	nld:lemma	surrealistische
 04839676-n	nld:lemma	onrecht
 03361297-n	nld:lemma	appartamentje

--- a/wns/slk/wn-data-lit.tab
+++ b/wns/slk/wn-data-lit.tab
@@ -3,7 +3,7 @@
 07987380-n	lit:lemma	keturių grupė
 02084071-n	lit:lemma	šuo
 07704054-n	lit:lemma	tyrė
-01599898-s	lit:lemma	psichinis
+01599898-a	lit:lemma	psichinis
 00871418-n	lit:lemma	integravimas
 09285254-n	lit:lemma	šukė
 00057388-r	lit:lemma	smarkiai
@@ -13,15 +13,15 @@
 06876309-n	lit:lemma	judesys
 05019339-n	lit:lemma	nežymumas
 04317420-n	lit:lemma	lazda
-01155603-s	lit:lemma	apskaičiuojantis
-01695269-s	lit:lemma	uždengtas
-00084795-s	lit:lemma	žiaurus
+01155603-a	lit:lemma	apskaičiuojantis
+01695269-a	lit:lemma	uždengtas
+00084795-a	lit:lemma	žiaurus
 00021766-a	lit:lemma	atitinkantis
 10393909-n	lit:lemma	dažytojas
 01105840-a	lit:lemma	valstybinis
 05641556-n	lit:lemma	koordinavimas
-01367431-s	lit:lemma	džiugus
-02038126-s	lit:lemma	stiprus
+01367431-a	lit:lemma	džiugus
+02038126-a	lit:lemma	stiprus
 04879340-n	lit:lemma	nelojalumas
 02716739-a	lit:lemma	ūkinis
 00675701-a	lit:lemma	ciklinis
@@ -32,24 +32,24 @@
 15265518-n	lit:lemma	pradžia
 14405225-n	lit:lemma	pakili nuotaika
 13743605-n	lit:lemma	dvejetas
-02339577-s	lit:lemma	aukšto rango
+02339577-a	lit:lemma	aukšto rango
 09976728-n	lit:lemma	kreditorius
 04645943-n	lit:lemma	nenoras
-00727113-s	lit:lemma	priklausomas
+00727113-a	lit:lemma	priklausomas
 00248977-n	lit:lemma	pagerinimas
 00087542-r	lit:lemma	be galo
-00901060-s	lit:lemma	pagrindinis
+00901060-a	lit:lemma	pagrindinis
 07122118-n	lit:lemma	rėksmas
 00510050-a	lit:lemma	nusimanantis
 00356621-n	lit:lemma	išsekinimas
 09285254-n	lit:lemma	skeveldra
 06100778-n	lit:lemma	optika
-00710097-s	lit:lemma	beskeveldris
-01610261-s	lit:lemma	nematytas
+00710097-a	lit:lemma	beskeveldris
+01610261-a	lit:lemma	nematytas
 10709529-n	lit:lemma	metikas
 06797169-n	lit:lemma	požymis
 15122231-n	lit:lemma	laikas
-01111418-s	lit:lemma	nešykštus
+01111418-a	lit:lemma	nešykštus
 04108268-n	lit:lemma	trosas
 01522376-a	lit:lemma	paslankus
 00026061-r	lit:lemma	visur
@@ -66,21 +66,21 @@
 10186350-n	lit:lemma	sodininkas
 03517899-n	lit:lemma	didysis altorius
 02967791-a	lit:lemma	korėjietiškas
-01455732-s	lit:lemma	tylus
+01455732-a	lit:lemma	tylus
 13746672-n	lit:lemma	vienuolika
 00007015-r	lit:lemma	daugmaž
 13903079-n	lit:lemma	pakraštys
 06888944-n	lit:lemma	reginys
 00823316-n	lit:lemma	apsaugos priemonės
-00128733-s	lit:lemma	beprecedentis
+00128733-a	lit:lemma	beprecedentis
 08070850-n	lit:lemma	investicinė kompanija
 04191595-n	lit:lemma	slėptuvė
 04332243-n	lit:lemma	filtras
-01115635-s	lit:lemma	tikras
+01115635-a	lit:lemma	tikras
 11509377-n	lit:lemma	ledo kristalėlis
 02835481-a	lit:lemma	revoliucinis
-02059811-s	lit:lemma	pavojingas
-01025212-s	lit:lemma	užsispyręs
+02059811-a	lit:lemma	pavojingas
+01025212-a	lit:lemma	užsispyręs
 00507716-r	lit:lemma	vakar
 06609909-n	lit:lemma	beprasmybė
 07737081-n	lit:lemma	valgomas riešutas
@@ -100,34 +100,34 @@
 06615561-n	lit:lemma	renginys
 03098140-n	lit:lemma	valdymo skydas
 03047171-n	lit:lemma	laikrodžio mechanizmas
-00260695-s	lit:lemma	buržuazinis
+00260695-a	lit:lemma	buržuazinis
 00079617-r	lit:lemma	aktyviai
 06759349-n	lit:lemma	apsimetimas
-00651039-s	lit:lemma	pavojingas
+00651039-a	lit:lemma	pavojingas
 00896555-a	lit:lemma	aiškus
 01605081-a	lit:lemma	pietų
 02774152-n	lit:lemma	rankinukas
-01730444-s	lit:lemma	nesenas
+01730444-a	lit:lemma	nesenas
 15287830-n	lit:lemma	ciklas
 07199565-n	lit:lemma	atsakas
-00224515-s	lit:lemma	blogas
+00224515-a	lit:lemma	blogas
 07747055-n	lit:lemma	citrusinis vaisius
 14189837-n	lit:lemma	sepsis
 00161294-r	lit:lemma	ryškiai
 01048059-n	lit:lemma	atnaujinimas
 00957176-a	lit:lemma	neobjektyvus
-00522463-s	lit:lemma	nuodugnus
+00522463-a	lit:lemma	nuodugnus
 00039211-n	lit:lemma	sąveika
 09856401-n	lit:lemma	paukščių mėgėjas
 13732078-n	lit:lemma	trupmena
 00487653-a	lit:lemma	retas
 08337324-n	lit:lemma	valstybinė įstaiga
 00962129-n	lit:lemma	maištas
-01440574-s	lit:lemma	apyilgis
+01440574-a	lit:lemma	apyilgis
 01115866-n	lit:lemma	mažmeninė prekyba
 08277805-n	lit:lemma	akademija
 00380568-n	lit:lemma	sulydymas
-02132735-s	lit:lemma	intymus
+02132735-a	lit:lemma	intymus
 04393404-n	lit:lemma	apmušalai
 02810102-a	lit:lemma	žemės
 05085572-n	lit:lemma	artumas
@@ -138,7 +138,7 @@
 03443005-n	lit:lemma	vartininko aikštelė
 00610538-v	lit:lemma	priminti
 08381820-n	lit:lemma	ministrų kabinetas
-00016647-s	lit:lemma	žalias
+00016647-a	lit:lemma	žalias
 05107765-n	lit:lemma	suma
 00061677-r	lit:lemma	staiga
 02212825-v	lit:lemma	uždrausti
@@ -146,19 +146,19 @@
 10305802-n	lit:lemma	gydytojas
 14386022-n	lit:lemma	ksenofobija
 00126972-r	lit:lemma	techniškai
-01211296-s	lit:lemma	išplėstas
+01211296-a	lit:lemma	išplėstas
 03271260-n	lit:lemma	elektroninis laikrodis
 01686439-a	lit:lemma	originalus
 09385911-n	lit:lemma	dalis
 05653848-n	lit:lemma	eksterorecepcija
 00717358-v	lit:lemma	atsiliepti
-01486854-s	lit:lemma	vienodas
+01486854-a	lit:lemma	vienodas
 06367107-n	lit:lemma	grožinė literatūra
 05284132-n	lit:lemma	viršutinis žandikaulis
 00104539-n	lit:lemma	metimas
 02479323-v	lit:lemma	išduoti
 01070187-n	lit:lemma	dieta
-00602117-s	lit:lemma	diskusinis
+00602117-a	lit:lemma	diskusinis
 03731164-n	lit:lemma	matracas
 01120448-n	lit:lemma	apmokėjimas
 10626540-n	lit:lemma	burtininkė
@@ -170,7 +170,7 @@
 00060477-v	lit:lemma	sterilizuoti
 13290676-n	lit:lemma	žalos atlyginimas
 10053004-n	lit:lemma	imperatorius
-00552089-s	lit:lemma	įvykdytas
+00552089-a	lit:lemma	įvykdytas
 13676544-n	lit:lemma	forintas
 00665630-v	lit:lemma	įrodyti
 01256332-a	lit:lemma	karštas
@@ -183,7 +183,7 @@
 02941408-n	lit:lemma	taikos pypkė
 04694980-n	lit:lemma	pirštų atspaudas
 14825062-n	lit:lemma	dengiamoji medžiaga
-01294975-s	lit:lemma	kitas
+01294975-a	lit:lemma	kitas
 00002573-v	lit:lemma	atsikvėpti
 00372660-r	lit:lemma	diskretiškai
 04576211-n	lit:lemma	ratinė transporto priemonė
@@ -195,12 +195,12 @@
 00305570-r	lit:lemma	giliai
 07121157-n	lit:lemma	riksmas
 05476094-n	lit:lemma	jungtis
-02165432-s	lit:lemma	nesvarbus
-00505410-s	lit:lemma	neprilygstamas
+02165432-a	lit:lemma	nesvarbus
+00505410-a	lit:lemma	neprilygstamas
 14441498-n	lit:lemma	negarbė
 04213626-n	lit:lemma	šonas
 00288880-n	lit:lemma	žengimas
-01973311-s	lit:lemma	pridėtas
+01973311-a	lit:lemma	pridėtas
 00051590-r	lit:lemma	tiesiai
 01896031-n	lit:lemma	pūkas
 03045750-a	lit:lemma	australų
@@ -209,12 +209,12 @@
 10111023-n	lit:lemma	laisvas žmogus
 00034288-v	lit:lemma	daryti grimasas
 09979589-n	lit:lemma	kritikas
-01151951-s	lit:lemma	akmeninis
+01151951-a	lit:lemma	akmeninis
 05445668-n	lit:lemma	organoidas
 00470930-a	lit:lemma	išleistas
 14173484-n	lit:lemma	angina
 11463073-n	lit:lemma	gama spinduliai
-00335768-s	lit:lemma	neabejotinas
+00335768-a	lit:lemma	neabejotinas
 05647156-n	lit:lemma	beprotybė
 10727256-n	lit:lemma	iždininkas
 05303232-n	lit:lemma	gimdos kaklelis
@@ -226,14 +226,14 @@
 13903576-n	lit:lemma	išorinė siena
 08274565-n	lit:lemma	grupė
 13925340-n	lit:lemma	soties taškas
-01990653-s	lit:lemma	atkaklus
-01712753-s	lit:lemma	skaudus
+01990653-a	lit:lemma	atkaklus
+01712753-a	lit:lemma	skaudus
 09012297-n	lit:lemma	Estijos Respublika
 00002684-n	lit:lemma	daiktas
 14677778-n	lit:lemma	gipsas
 06427387-n	lit:lemma	enciklopedija
 09877951-n	lit:lemma	draugas
-00071242-s	lit:lemma	apimtas
+00071242-a	lit:lemma	apimtas
 02632838-v	lit:lemma	ne būti
 07028373-n	lit:lemma	melodija
 03974215-n	lit:lemma	smaigalys
@@ -242,17 +242,17 @@
 06643408-n	lit:lemma	įrodymas
 00187028-r	lit:lemma	gerai
 04981139-n	lit:lemma	garsas
-00522885-s	lit:lemma	visiškas
+00522885-a	lit:lemma	visiškas
 03025250-n	lit:lemma	batai su platforma
-00387392-s	lit:lemma	sidabruotas
+00387392-a	lit:lemma	sidabruotas
 02954340-n	lit:lemma	kepurė
 00183823-r	lit:lemma	oriai
-01163941-s	lit:lemma	harmoningas
+01163941-a	lit:lemma	harmoningas
 00003380-r	lit:lemma	apmaudžiai
 01237901-v	lit:lemma	praleisti
-00764484-s	lit:lemma	tiesus
+00764484-a	lit:lemma	tiesus
 04836268-n	lit:lemma	ambicija
-00012071-s	lit:lemma	konceptualus
+00012071-a	lit:lemma	konceptualus
 04871720-n	lit:lemma	atvirumas
 10180923-n	lit:lemma	plėšikas
 04675193-n	lit:lemma	odos tipas
@@ -260,7 +260,7 @@
 01767329-a	lit:lemma	asmeninis
 04650201-n	lit:lemma	humoras
 03214966-n	lit:lemma	sofa be atlošo
-02465350-s	lit:lemma	patikimas
+02465350-a	lit:lemma	patikimas
 06660396-n	lit:lemma	kvota (importo)
 13152742-n	lit:lemma	lapija
 02861886-n	lit:lemma	kėbulas
@@ -271,7 +271,7 @@
 04847482-n	lit:lemma	dorumas
 04409712-n	lit:lemma	kortas
 14328290-n	lit:lemma	strėnų skausmas
-00326608-s	lit:lemma	ūmus
+00326608-a	lit:lemma	ūmus
 03081021-n	lit:lemma	sudedamoji dalis
 03427656-n	lit:lemma	loginis elementas
 14477342-n	lit:lemma	sielvartas
@@ -279,15 +279,15 @@
 13776971-n	lit:lemma	daugybė
 07196075-n	lit:lemma	interviu
 13614764-n	lit:lemma	skysčių matavimo vienetas
-00115777-s	lit:lemma	įpykęs
-00120784-s	lit:lemma	nežinomas
+00115777-a	lit:lemma	įpykęs
+00120784-a	lit:lemma	nežinomas
 09916348-n	lit:lemma	generalinis direktorius
 10612210-n	lit:lemma	nevala
 00250153-r	lit:lemma	lygiai
 13979503-n	lit:lemma	bruzdėjimas
 00048268-r	lit:lemma	šiuo metu
-02111981-s	lit:lemma	genties
-01536094-s	lit:lemma	šiandieninis
+02111981-a	lit:lemma	genties
+01536094-a	lit:lemma	šiandieninis
 09731571-n	lit:lemma	pietų amerikietis
 06123363-n	lit:lemma	architektūra
 01123095-n	lit:lemma	migracija
@@ -319,7 +319,7 @@
 00099951-n	lit:lemma	fokusas
 03438071-n	lit:lemma	diržas
 04999401-n	lit:lemma	antsvoris
-02126430-s	lit:lemma	išdėstytas
+02126430-a	lit:lemma	išdėstytas
 05836468-n	lit:lemma	supratimas
 06831177-n	lit:lemma	a
 14360320-n	lit:lemma	pykinimas
@@ -342,7 +342,7 @@
 07307895-n	lit:lemma	elektros išlydis
 01157850-n	lit:lemma	privaloma karinė tarnyba
 08322981-n	lit:lemma	taryba
-00447472-s	lit:lemma	gretimas
+00447472-a	lit:lemma	gretimas
 00029836-v	lit:lemma	verkti iš juoko
 00015946-v	lit:lemma	žiemoti
 15133621-n	lit:lemma	trukimas
@@ -352,25 +352,25 @@
 08497294-n	lit:lemma	šaka (mokslo)
 00815686-v	lit:lemma	atsakyti
 05943066-n	lit:lemma	pasitikėjimas
-00724397-s	lit:lemma	patikimas
+00724397-a	lit:lemma	patikimas
 06090869-n	lit:lemma	fizika
 04955160-n	lit:lemma	žvilgesys
-02363811-s	lit:lemma	imunizuotas
+02363811-a	lit:lemma	imunizuotas
 09348236-n	lit:lemma	Masačusetso įlanka
 13331778-n	lit:lemma	resursai
-01141468-s	lit:lemma	nenatūralus
+01141468-a	lit:lemma	nenatūralus
 01102436-n	lit:lemma	publikacija
 01718867-a	lit:lemma	įstrižas
 01346003-v	lit:lemma	atsidaryti
 02006228-a	lit:lemma	tinkliškas
 00014405-v	lit:lemma	ilsėtis
 10428004-n	lit:lemma	fizikas
-02341864-s	lit:lemma	meistriškas
+02341864-a	lit:lemma	meistriškas
 01203277-n	lit:lemma	kolektyvinis naujų idėjų svarstymas
 07670731-n	lit:lemma	odelė
-00348018-s	lit:lemma	nekintantis
+00348018-a	lit:lemma	nekintantis
 09285254-n	lit:lemma	nuolauža
-01515280-s	lit:lemma	veikiantis
+01515280-a	lit:lemma	veikiantis
 02931227-a	lit:lemma	sakramentinis
 01064148-n	lit:lemma	poilsis
 10652954-n	lit:lemma	statistikas
@@ -391,12 +391,12 @@
 09393605-n	lit:lemma	laukas
 09005273-n	lit:lemma	Chabarovsko kraštas
 01835496-v	lit:lemma	keliauti
-00624576-s	lit:lemma	didokas
+00624576-a	lit:lemma	didokas
 02960338-a	lit:lemma	danų
-00028471-s	lit:lemma	tariamas
+00028471-a	lit:lemma	tariamas
 01234090-n	lit:lemma	nebuvimas
 07628870-n	lit:lemma	keksas
-02515001-s	lit:lemma	piktadariškas
+02515001-a	lit:lemma	piktadariškas
 00252430-n	lit:lemma	valymas
 03127718-a	lit:lemma	šlapimo
 14375890-n	lit:lemma	įtampa
@@ -407,15 +407,15 @@
 01145359-n	lit:lemma	apribojimas
 03076708-n	lit:lemma	prekė
 02623529-v	lit:lemma	darytis
-01279611-s	lit:lemma	svarbus
-00349894-s	lit:lemma	galutinis
+01279611-a	lit:lemma	svarbus
+00349894-a	lit:lemma	galutinis
 05165745-n	lit:lemma	konstruktyvumas
 13290676-n	lit:lemma	kompensacija
-01632066-s	lit:lemma	ginamasis
+01632066-a	lit:lemma	ginamasis
 00820976-v	lit:lemma	rodyti
-01520091-s	lit:lemma	absoliutus
+01520091-a	lit:lemma	absoliutus
 03148920-n	lit:lemma	šaligatvio bortelis
-02515001-s	lit:lemma	nedoras
+02515001-a	lit:lemma	nedoras
 00364787-n	lit:lemma	antplūdis
 00003826-v	lit:lemma	žagsėti
 02977438-n	lit:lemma	kasos aparatas
@@ -424,11 +424,11 @@
 02777734-n	lit:lemma	balkonas
 00482298-n	lit:lemma	tenisas
 09426788-n	lit:lemma	jūra
-01413763-s	lit:lemma	įtikimas
+01413763-a	lit:lemma	įtikimas
 10278128-n	lit:lemma	mamytė
 12123050-n	lit:lemma	miežis
-00301589-s	lit:lemma	suskaičiuojamas
-00865007-s	lit:lemma	bedarbis
+00301589-a	lit:lemma	suskaičiuojamas
+00865007-a	lit:lemma	bedarbis
 05690916-n	lit:lemma	užtvara
 07109196-n	lit:lemma	kalba
 03654576-n	lit:lemma	klešnė
@@ -441,23 +441,23 @@
 04806804-n	lit:lemma	vertingumas
 13385913-n	lit:lemma	pinigų sistema
 05928513-n	lit:lemma	interpretacija
-02465519-s	lit:lemma	patikimas
+02465519-a	lit:lemma	patikimas
 08779504-n	lit:lemma	Suomijos Respublika
 08738820-n	lit:lemma	Nikaragvos Respublika
 08900535-n	lit:lemma	Indijos Respublika
 08642632-n	lit:lemma	dalyvavimas
 09286630-n	lit:lemma	Gangas
-00032497-s	lit:lemma	atletinis
+00032497-a	lit:lemma	atletinis
 00444846-n	lit:lemma	nardymas
 01158064-n	lit:lemma	ėmimas
 10112591-n	lit:lemma	bičiulis
-01638962-s	lit:lemma	ilgaamžis
+01638962-a	lit:lemma	ilgaamžis
 08799271-n	lit:lemma	Judėja
 01430111-a	lit:lemma	logiškas
 14991712-n	lit:lemma	augalinė medžiaga
-02565425-s	lit:lemma	pasirengęs
+02565425-a	lit:lemma	pasirengęs
 15251336-n	lit:lemma	šimtmetis
-01610261-s	lit:lemma	nepastebėtas
+01610261-a	lit:lemma	nepastebėtas
 08544275-n	lit:lemma	kampas
 03075191-a	lit:lemma	Irano
 07543288-n	lit:lemma	meilė
@@ -472,23 +472,23 @@
 00107987-r	lit:lemma	žingsnis po žingsnio
 04395875-n	lit:lemma	smuklė
 02075296-n	lit:lemma	mėsėdis gyvūnas
-01335458-s	lit:lemma	gabus
+01335458-a	lit:lemma	gabus
 14662574-n	lit:lemma	mineralas
 00430140-n	lit:lemma	lošimas
-00035978-s	lit:lemma	judrus
+00035978-a	lit:lemma	judrus
 05565548-n	lit:lemma	kairė ranka
 02632838-v	lit:lemma	dingti
 02696920-a	lit:lemma	civilinis
 14373582-n	lit:lemma	psichologinė būsena
-02390724-s	lit:lemma	pašėlęs
+02390724-a	lit:lemma	pašėlęs
 09288769-n	lit:lemma	milžinas
-02408977-s	lit:lemma	regioninis
-00520892-s	lit:lemma	besąlyginis
+02408977-a	lit:lemma	regioninis
+00520892-a	lit:lemma	besąlyginis
 03568818-n	lit:lemma	indukcijos ritė
 07535532-n	lit:lemma	sielvartas
 00498387-r	lit:lemma	tarp
 01326015-n	lit:lemma	skiauterė
-02336904-s	lit:lemma	varganas
+02336904-a	lit:lemma	varganas
 06722453-n	lit:lemma	tvirtinimas
 03717447-n	lit:lemma	liukas
 00074095-r	lit:lemma	prieš
@@ -496,13 +496,13 @@
 00285092-r	lit:lemma	švariai
 00798539-v	lit:lemma	atmesti
 06552639-n	lit:lemma	dovanojimas
-00373493-s	lit:lemma	vario spalvos
-00661640-s	lit:lemma	kapotas
+00373493-a	lit:lemma	vario spalvos
+00661640-a	lit:lemma	kapotas
 00594413-a	lit:lemma	tęstinis
 05284617-n	lit:lemma	stuburo diskas
 00081591-r	lit:lemma	kas savaitę
-01981009-s	lit:lemma	geometrinis
-01774483-s	lit:lemma	nelaidus riebalams
+01981009-a	lit:lemma	geometrinis
+01774483-a	lit:lemma	nelaidus riebalams
 05557723-n	lit:lemma	gyvulio papilvis
 08969291-n	lit:lemma	Marokas
 02761557-n	lit:lemma	automobilio variklis
@@ -518,10 +518,10 @@
 07429976-n	lit:lemma	invazija
 01789740-n	lit:lemma	naminis paukštis
 05154241-n	lit:lemma	nekompetentingumas
-02113191-s	lit:lemma	higieniškas
+02113191-a	lit:lemma	higieniškas
 06634376-n	lit:lemma	informacija
-01384212-s	lit:lemma	neaprėpiamas
-01431112-s	lit:lemma	beprasmiškas
+01384212-a	lit:lemma	neaprėpiamas
+01431112-a	lit:lemma	beprasmiškas
 07557434-n	lit:lemma	valgis
 02994312-a	lit:lemma	liturginis
 15290337-n	lit:lemma	laikotarpis
@@ -530,13 +530,13 @@
 09386422-n	lit:lemma	dalelė
 02966972-a	lit:lemma	Argentinos
 09837088-n	lit:lemma	plėšikas
-00421875-s	lit:lemma	nešvarus
+00421875-a	lit:lemma	nešvarus
 01319874-a	lit:lemma	nekaltas
 14877585-n	lit:lemma	dujos
 02765464-v	lit:lemma	absorbuoti
 00040547-r	lit:lemma	atsitiktinai
 04776699-n	lit:lemma	nepajudinamumas
-00193480-s	lit:lemma	gąsdinantis
+00193480-a	lit:lemma	gąsdinantis
 08152787-n	lit:lemma	dvasininkija
 02863247-a	lit:lemma	mistinis
 00039318-r	lit:lemma	aiškiai
@@ -550,32 +550,32 @@
 00024264-n	lit:lemma	požymis
 03073832-n	lit:lemma	Kolumbijos universitetas
 10533013-n	lit:lemma	varžovas
-01246388-s	lit:lemma	priešiškas
+01246388-a	lit:lemma	priešiškas
 09263087-n	lit:lemma	Dunojus
 05898568-n	lit:lemma	planas
 03499142-n	lit:lemma	liukas
-00813589-s	lit:lemma	pirmykštis
+00813589-a	lit:lemma	pirmykštis
 00004475-n	lit:lemma	gyva būtybė
-01152521-s	lit:lemma	plieno
-01462882-s	lit:lemma	išrinktasis
+01152521-a	lit:lemma	plieno
+01462882-a	lit:lemma	išrinktasis
 13327896-n	lit:lemma	finansinė žala
 03063689-n	lit:lemma	kavinukas
-00309740-s	lit:lemma	tikras
+00309740-a	lit:lemma	tikras
 02724417-v	lit:lemma	jungtis
-01876261-s	lit:lemma	inovacinis
+01876261-a	lit:lemma	inovacinis
 00088655-r	lit:lemma	nepasirengus
 04634833-n	lit:lemma	gyvybingumas
 14633781-n	lit:lemma	anglies atomas
 09614684-n	lit:lemma	saugotojas
-02405805-s	lit:lemma	įtemptas
+02405805-a	lit:lemma	įtemptas
 14034177-n	lit:lemma	fizinė būsena
 01019372-n	lit:lemma	kartojimas
 06674188-n	lit:lemma	slaptažodis
 03404251-n	lit:lemma	kailiniai
 04577769-n	lit:lemma	rimbas
-01894196-s	lit:lemma	išbandytas
+01894196-a	lit:lemma	išbandytas
 04199027-n	lit:lemma	batas
-01392249-s	lit:lemma	mažutis
+01392249-a	lit:lemma	mažutis
 00080304-r	lit:lemma	drauge
 01853461-a	lit:lemma	antraeilis
 09289709-n	lit:lemma	rutulėlis
@@ -589,42 +589,42 @@
 05643190-n	lit:lemma	įgudimas
 02879638-a	lit:lemma	popiežiaus
 04710127-n	lit:lemma	atšiaurumas
-01732601-s	lit:lemma	ateinantis
+01732601-a	lit:lemma	ateinantis
 06491786-n	lit:lemma	rodyklė
 02299437-a	lit:lemma	žvaigždėtas
 04658268-n	lit:lemma	agresyvumas
-00811536-s	lit:lemma	trokštantis
+00811536-a	lit:lemma	trokštantis
 06827219-n	lit:lemma	pusjuodis šriftas
 10289039-n	lit:lemma	kiekvienas
 05834567-n	lit:lemma	įkvėpimas
-01076145-s	lit:lemma	laisvas
-02369179-s	lit:lemma	rūgštus
+01076145-a	lit:lemma	laisvas
+02369179-a	lit:lemma	rūgštus
 00007846-n	lit:lemma	kažkas
 10315837-n	lit:lemma	kovotojas
 02704617-v	lit:lemma	sverti
 02758500-a	lit:lemma	makroekonominis
 01041061-v	lit:lemma	nutilti
-01287486-s	lit:lemma	pastebimas
+01287486-a	lit:lemma	pastebimas
 03110610-a	lit:lemma	iškvepiamasis
 09992837-n	lit:lemma	duktė
 09227839-n	lit:lemma	luitas
-00713853-s	lit:lemma	įkyrus
-01265308-s	lit:lemma	linksmas
-01648891-s	lit:lemma	jaunimo
-01827946-s	lit:lemma	bejėgiškas
+00713853-a	lit:lemma	įkyrus
+01265308-a	lit:lemma	linksmas
+01648891-a	lit:lemma	jaunimo
+01827946-a	lit:lemma	bejėgiškas
 13333833-n	lit:lemma	akcija
 00840189-n	lit:lemma	maukas
 04038727-n	lit:lemma	lentyna
 10045713-n	lit:lemma	auklėtojas
-01636363-s	lit:lemma	oficialus
+01636363-a	lit:lemma	oficialus
 05602982-n	lit:lemma	padribę žandai
-02552415-s	lit:lemma	sausas
-01754873-s	lit:lemma	pastovus
+02552415-a	lit:lemma	sausas
+01754873-a	lit:lemma	pastovus
 07303697-n	lit:lemma	didelis gaisras
 02871858-a	lit:lemma	teritorinis
 10086074-n	lit:lemma	patikėtinis
 01871949-a	lit:lemma	neapsimokantis
-02026629-s	lit:lemma	subankrutavęs
+02026629-a	lit:lemma	subankrutavęs
 11503968-n	lit:lemma	varža
 06880533-n	lit:lemma	pavyzdys
 15246853-n	lit:lemma	akimirka
@@ -646,12 +646,12 @@
 07041451-n	lit:lemma	duetas
 14450339-n	lit:lemma	trūkumas
 00339934-v	lit:lemma	įvykti
-00808822-s	lit:lemma	kintantis
+00808822-a	lit:lemma	kintantis
 00251013-n	lit:lemma	valymas
 01482071-n	lit:lemma	kremzlinė žuvis
 03533392-n	lit:lemma	kabliukas su kilpele
 10794014-n	lit:lemma	autorius
-01372948-s	lit:lemma	malonus
+01372948-a	lit:lemma	malonus
 09681351-n	lit:lemma	žydas
 07961480-n	lit:lemma	šūsnis
 08397255-n	lit:lemma	ginkluotosios pajėgos
@@ -664,7 +664,7 @@
 08482113-n	lit:lemma	flangas
 14488594-n	lit:lemma	ekonominė padėtis
 00772640-v	lit:lemma	liudyti
-00906099-s	lit:lemma	giriamas
+00906099-a	lit:lemma	giriamas
 02952622-a	lit:lemma	protestantiškas
 02753724-a	lit:lemma	teisinis
 02852523-n	lit:lemma	blokas
@@ -688,13 +688,13 @@
 08675967-n	lit:lemma	miesto teritorija
 14476290-n	lit:lemma	katastrofa
 02912065-n	lit:lemma	indauja
-01336837-s	lit:lemma	kvailas
+01336837-a	lit:lemma	kvailas
 00040547-r	lit:lemma	netikėtai
 13126684-n	lit:lemma	šakniaplaukis
 09014586-n	lit:lemma	Moldova
 08179689-n	lit:lemma	žmonija
 05692419-n	lit:lemma	lemiamas faktorius
-02328012-s	lit:lemma	nesugyvenamas
+02328012-a	lit:lemma	nesugyvenamas
 00117959-n	lit:lemma	mirksnis
 00575230-a	lit:lemma	liberalus
 11416988-n	lit:lemma	pasekmė
@@ -707,7 +707,7 @@
 01791625-n	lit:lemma	višta
 00789138-v	lit:lemma	nagrinėti
 03142431-n	lit:lemma	kripta
-01854129-s	lit:lemma	pridėtinis
+01854129-a	lit:lemma	pridėtinis
 09475925-n	lit:lemma	krantas
 09815790-n	lit:lemma	asistentė
 07191279-n	lit:lemma	pareikalavimas
@@ -719,7 +719,7 @@
 06834458-n	lit:lemma	delta
 02416030-v	lit:lemma	paviršutiniškai domėtis
 03580615-n	lit:lemma	internetas
-02577734-s	lit:lemma	daiktinis
+02577734-a	lit:lemma	daiktinis
 04844024-n	lit:lemma	nejautrumas
 06066555-n	lit:lemma	botanika
 04588986-n	lit:lemma	langelis
@@ -728,13 +728,13 @@
 02857295-a	lit:lemma	poetinis
 03519578-n	lit:lemma	greitkelis
 00625774-a	lit:lemma	nerealus
-00656507-s	lit:lemma	lemiamas
+00656507-a	lit:lemma	lemiamas
 14449405-n	lit:lemma	trūkumas
 01169317-n	lit:lemma	pasipriešinimas
 09816771-n	lit:lemma	sąjungininkas
 05699172-n	lit:lemma	neryžtingumas
 00372226-n	lit:lemma	kaupimas
-02503305-s	lit:lemma	betikslis
+02503305-a	lit:lemma	betikslis
 10185793-n	lit:lemma	žokėjus
 02698145-a	lit:lemma	antikinis
 01776974-a	lit:lemma	veikiantis psichiką
@@ -743,10 +743,10 @@
 03016202-a	lit:lemma	Graikijos
 01246086-n	lit:lemma	monetos metimas
 02236355-n	lit:lemma	vabalas
-00438909-s	lit:lemma	sumanus
+00438909-a	lit:lemma	sumanus
 00470966-n	lit:lemma	regbis
 01699831-n	lit:lemma	dinozauras
-01282510-s	lit:lemma	kraupus
+01282510-a	lit:lemma	kraupus
 00104990-r	lit:lemma	neskubant
 07509572-n	lit:lemma	nustebimas
 00191142-n	lit:lemma	keitimas
@@ -758,14 +758,14 @@
 01119169-v	lit:lemma	atakuoti
 01236164-v	lit:lemma	susidurti
 03112177-a	lit:lemma	romų
-01050088-s	lit:lemma	pražūtingas
+01050088-a	lit:lemma	pražūtingas
 15094053-n	lit:lemma	popieriaus atliekos
 03452741-n	lit:lemma	rojalis
 15122231-n	lit:lemma	metas
 00418615-n	lit:lemma	nepaisymas
 00383606-n	lit:lemma	atskyrimas
 00204125-r	lit:lemma	klaidingai
-01374183-s	lit:lemma	grubus
+01374183-a	lit:lemma	grubus
 09721883-n	lit:lemma	Malaizijos gyventoja
 06485261-n	lit:lemma	darbotvarkė
 04089152-n	lit:lemma	kraigas
@@ -778,9 +778,9 @@
 03197337-n	lit:lemma	elektroninis laikrodis
 03051540-n	lit:lemma	drabužiai
 00004032-v	lit:lemma	dūsauti
-00049879-s	lit:lemma	papildomas
+00049879-a	lit:lemma	papildomas
 00453939-r	lit:lemma	šonu
-00533452-s	lit:lemma	suvokiamas
+00533452-a	lit:lemma	suvokiamas
 00175135-r	lit:lemma	nevaldomai
 03003616-a	lit:lemma	anglų
 00069173-n	lit:lemma	kontrakto sulaužymas
@@ -790,7 +790,7 @@
 09095023-n	lit:lemma	Masačusetsas
 13518963-n	lit:lemma	natūralus procesas
 00907919-n	lit:lemma	kino filmų kūrimas
-00900071-s	lit:lemma	paslaptingas
+00900071-a	lit:lemma	paslaptingas
 09983572-n	lit:lemma	kunigas
 13943400-n	lit:lemma	atvejis
 00489108-a	lit:lemma	įprastas
@@ -801,25 +801,25 @@
 04403638-n	lit:lemma	žiūronas
 00073897-r	lit:lemma	pagrinde
 13903387-n	lit:lemma	kraštas
-00511739-s	lit:lemma	neproduktyvus
+00511739-a	lit:lemma	neproduktyvus
 03772077-n	lit:lemma	katedra
 00165942-n	lit:lemma	veiksmas
-01467534-s	lit:lemma	mažasis
+01467534-a	lit:lemma	mažasis
 13767822-n	lit:lemma	stiklainis
 06497459-n	lit:lemma	abėcėlė
-00935103-s	lit:lemma	prieinamas
-01827161-s	lit:lemma	galingas
+00935103-a	lit:lemma	prieinamas
+01827161-a	lit:lemma	galingas
 05680982-n	lit:lemma	nejautrumas
-02465115-s	lit:lemma	patikimas
-01009206-s	lit:lemma	pirmutinis
+02465115-a	lit:lemma	patikimas
+01009206-a	lit:lemma	pirmutinis
 00116510-r	lit:lemma	drauge
 06843520-n	lit:lemma	taškas
 04778401-n	lit:lemma	stabilumas
 07976936-n	lit:lemma	pora
 08715390-n	lit:lemma	Mianmaro Sąjungos Respublika
-01281695-s	lit:lemma	nereikšmingas
+01281695-a	lit:lemma	nereikšmingas
 00720565-n	lit:lemma	užduotis
-00590271-s	lit:lemma	sunerimęs
+00590271-a	lit:lemma	sunerimęs
 05000342-n	lit:lemma	nutukimas
 05943300-n	lit:lemma	pažiūrų sistema
 08102402-n	lit:lemma	genealoginis medis
@@ -831,14 +831,14 @@
 01101329-n	lit:lemma	reklamavimas
 09349797-n	lit:lemma	sistema
 00718924-a	lit:lemma	savavalis
-01501821-s	lit:lemma	saldžiabalsis
+01501821-a	lit:lemma	saldžiabalsis
 14961722-n	lit:lemma	laikraštinis popierius
 02828482-a	lit:lemma	provizorinis
 01209963-n	lit:lemma	vaikų priežiūra
 06876144-n	lit:lemma	gestas
 05772356-n	lit:lemma	loginis mąstymas
 14112855-n	lit:lemma	širdies smūgis
-01403760-s	lit:lemma	draudžiamas
+01403760-a	lit:lemma	draudžiamas
 00015498-v	lit:lemma	nusnūsti
 00064018-n	lit:lemma	pergalė
 05338410-n	lit:lemma	pamatinė arterija
@@ -856,20 +856,20 @@
 00905386-a	lit:lemma	etiškas
 03138856-n	lit:lemma	vainikas
 02171039-v	lit:lemma	įsiklausyti
-00974159-s	lit:lemma	senamadis
+00974159-a	lit:lemma	senamadis
 00911048-n	lit:lemma	statymas
 05614175-n	lit:lemma	įžvalgumas
 04690196-n	lit:lemma	šlykštumas
 01463965-a	lit:lemma	mylintis
 08521816-n	lit:lemma	centras
 09397607-n	lit:lemma	valka
-01136248-s	lit:lemma	irzlus
+01136248-a	lit:lemma	irzlus
 14418395-n	lit:lemma	vienybė
-00746451-s	lit:lemma	painus
+00746451-a	lit:lemma	painus
 01722529-a	lit:lemma	tėviškas
 14500341-n	lit:lemma	dezorganizacija
 04655649-n	lit:lemma	prieinamumas
-01816376-s	lit:lemma	mylimas
+01816376-a	lit:lemma	mylimas
 02623529-v	lit:lemma	rastis
 02665803-a	lit:lemma	biologinis
 01481612-a	lit:lemma	ištekėjusi
@@ -879,7 +879,7 @@
 13266892-n	lit:lemma	stipendija
 02704928-v	lit:lemma	tęstis
 10363913-n	lit:lemma	naujokas
-02450512-s	lit:lemma	nuodingas
+02450512-a	lit:lemma	nuodingas
 03032811-n	lit:lemma	apskritimas
 02828482-a	lit:lemma	išankstinis
 03056368-n	lit:lemma	akmens anglies kasykla
@@ -894,7 +894,7 @@
 00226133-r	lit:lemma	atsargiai
 00248977-n	lit:lemma	patobulinimas
 02882570-a	lit:lemma	raumens
-01010271-s	lit:lemma	paskutinis
+01010271-a	lit:lemma	paskutinis
 05154517-n	lit:lemma	pliusas
 02363358-a	lit:lemma	nejautrus
 01227190-n	lit:lemma	dovanojimas
@@ -902,49 +902,49 @@
 02164464-n	lit:lemma	vabalas
 05967977-n	lit:lemma	magija
 08191230-n	lit:lemma	armija
-02318728-s	lit:lemma	atviras
+02318728-a	lit:lemma	atviras
 09013074-n	lit:lemma	Latvijos Respublika
-00587376-s	lit:lemma	gailus
-00685113-s	lit:lemma	lemiamas
+00587376-a	lit:lemma	gailus
+00685113-a	lit:lemma	lemiamas
 05016171-n	lit:lemma	karštis
 08505018-n	lit:lemma	krūmynai
-01042703-s	lit:lemma	ceremoningas
+01042703-a	lit:lemma	ceremoningas
 00470988-r	lit:lemma	iš karto
 00678221-a	lit:lemma	dvimetis
 04742766-n	lit:lemma	skirtingumas
-01415219-s	lit:lemma	nedidelis
+01415219-a	lit:lemma	nedidelis
 10207681-n	lit:lemma	stacionaro ligonis
-01835409-s	lit:lemma	pragmatiškas
+01835409-a	lit:lemma	pragmatiškas
 07054336-n	lit:lemma	baletas
 00958334-v	lit:lemma	pakartoti
 00067545-v	lit:lemma	suprakaituoti
 13434120-n	lit:lemma	nelytinis dauginimasis
-01673946-s	lit:lemma	įprastas
+01673946-a	lit:lemma	įprastas
 00165942-n	lit:lemma	žingsnis
 08162860-n	lit:lemma	Lordų Rūmai
 00522145-n	lit:lemma	rodymas
 15020974-n	lit:lemma	geležies laužas
-02347086-s	lit:lemma	apgailėtinas
-01395821-s	lit:lemma	besilaikantis įstatymų
-02456157-s	lit:lemma	neramus
+02347086-a	lit:lemma	apgailėtinas
+01395821-a	lit:lemma	besilaikantis įstatymų
+02456157-a	lit:lemma	neramus
 02787831-a	lit:lemma	rekreacinis
 01098293-a	lit:lemma	finansuojamas
 00331950-n	lit:lemma	judesys
 06782680-n	lit:lemma	spėjimas
 04154152-n	lit:lemma	laivasraigtis
-01208738-s	lit:lemma	pažangus
+01208738-a	lit:lemma	pažangus
 02139544-v	lit:lemma	parodyti
 01348530-n	lit:lemma	bakterija
 00363260-n	lit:lemma	paaukštinimas
 00810598-n	lit:lemma	laikymas
-01762065-s	lit:lemma	priimtinas
+01762065-a	lit:lemma	priimtinas
 01201422-a	lit:lemma	homoseksualus
 07035870-n	lit:lemma	himnas
 00317569-v	lit:lemma	platinti
 00099439-n	lit:lemma	bisas
 01812866-n	lit:lemma	dryžauodegis karvelis
 03573005-n	lit:lemma	kamera
-01141595-s	lit:lemma	medinis
+01141595-a	lit:lemma	medinis
 00487228-n	lit:lemma	pagalvių mūšis
 04200800-n	lit:lemma	batų parduotuvė
 00453939-r	lit:lemma	įstrižai
@@ -960,8 +960,8 @@
 00031515-r	lit:lemma	jau nebe
 00044861-r	lit:lemma	akis į akį
 08245425-n	lit:lemma	mafija
-01344171-s	lit:lemma	įdomus
-02436995-s	lit:lemma	griežtas
+01344171-a	lit:lemma	įdomus
+02436995-a	lit:lemma	griežtas
 00124611-r	lit:lemma	teisėtai
 07308563-n	lit:lemma	sprogimas
 04633453-n	lit:lemma	gyvybingumas
@@ -974,9 +974,9 @@
 08008335-n	lit:lemma	organizacija
 02988281-a	lit:lemma	tautinis
 00520257-n	lit:lemma	pasirodymas
-00719328-s	lit:lemma	absoliutus
-02523092-s	lit:lemma	autonominis
-02110447-s	lit:lemma	izoliuotas
+00719328-a	lit:lemma	absoliutus
+02523092-a	lit:lemma	autonominis
+02110447-a	lit:lemma	izoliuotas
 13729428-n	lit:lemma	kompleksinis skaičius
 02774152-n	lit:lemma	krepšys
 00281462-n	lit:lemma	priartėjimas
@@ -988,10 +988,10 @@
 10020890-n	lit:lemma	gydytoja
 01189113-v	lit:lemma	reikėti
 09877951-n	lit:lemma	bičiulis
-02467559-s	lit:lemma	apverstas
+02467559-a	lit:lemma	apverstas
 07974025-n	lit:lemma	visuomenės grupė
 05689249-n	lit:lemma	kliūtis
-00697691-s	lit:lemma	neapibūdinamas
+00697691-a	lit:lemma	neapibūdinamas
 00501990-r	lit:lemma	vidun
 03314028-n	lit:lemma	kortų figūra
 00364221-r	lit:lemma	nepajudinamai
@@ -1001,9 +1001,9 @@
 04632157-n	lit:lemma	gyvybingumas
 08737716-n	lit:lemma	Hondūro Respublika
 02904075-a	lit:lemma	valdymo
-00792202-s	lit:lemma	vyraujantis
+00792202-a	lit:lemma	vyraujantis
 08578706-n	lit:lemma	geografinis taškas
-01573238-s	lit:lemma	padirbtas
+01573238-a	lit:lemma	padirbtas
 04344873-n	lit:lemma	miegamoji sofa
 00461782-n	lit:lemma	kėgliai
 03987079-n	lit:lemma	portretas
@@ -1012,11 +1012,11 @@
 15055633-n	lit:lemma	migla
 08764107-n	lit:lemma	Norvegija
 00427853-n	lit:lemma	maudymasis
-01568684-s	lit:lemma	pasaulinis
-02341864-s	lit:lemma	geriausias
-01375831-s	lit:lemma	garsus
+01568684-a	lit:lemma	pasaulinis
+02341864-a	lit:lemma	geriausias
+01375831-a	lit:lemma	garsus
 02154508-v	lit:lemma	atrasti
-02515214-s	lit:lemma	nuodėmingas
+02515214-a	lit:lemma	nuodėmingas
 04213626-n	lit:lemma	siena
 03717447-n	lit:lemma	anga
 00117959-n	lit:lemma	sumirksėjimas
@@ -1033,13 +1033,13 @@
 00403092-n	lit:lemma	žalojimas
 07409592-n	lit:lemma	prisilietimas
 03878674-n	lit:lemma	paletė
-00522885-s	lit:lemma	pilnas
-01940472-s	lit:lemma	žemiškas
-01263013-s	lit:lemma	laukinis
+00522885-a	lit:lemma	pilnas
+01940472-a	lit:lemma	žemiškas
+01263013-a	lit:lemma	laukinis
 05697363-n	lit:lemma	pasitikėjimas savimi
 13282007-n	lit:lemma	atlygis
 04202417-n	lit:lemma	prekyba
-00633581-s	lit:lemma	doras
+00633581-a	lit:lemma	doras
 00471945-r	lit:lemma	nepralenkiamai
 09994943-n	lit:lemma	numirėlis
 07233996-n	lit:lemma	prakeikimas
@@ -1048,29 +1048,29 @@
 05726596-n	lit:lemma	struktūra
 01270175-a	lit:lemma	skubus
 08544813-n	lit:lemma	valstybė
-01655538-s	lit:lemma	suspaustas
+01655538-a	lit:lemma	suspaustas
 00403092-n	lit:lemma	gadinimas
-00345494-s	lit:lemma	nepastovus
+00345494-a	lit:lemma	nepastovus
 05825245-n	lit:lemma	patvirtinimas
 04623612-n	lit:lemma	būdas
 15294607-n	lit:lemma	inkubacija
-02503216-s	lit:lemma	nereikšmingas
+02503216-a	lit:lemma	nereikšmingas
 07945657-n	lit:lemma	numirėliai
 05013461-n	lit:lemma	Kiuri taškas
 13526110-n	lit:lemma	organinis procesas
-00097674-s	lit:lemma	buvęs
+00097674-a	lit:lemma	buvęs
 04078747-n	lit:lemma	vandens saugykla
 13523208-n	lit:lemma	branduolinė reakcija
 03777283-n	lit:lemma	maketas
-00796715-s	lit:lemma	teatrališkas
+00796715-a	lit:lemma	teatrališkas
 09112282-n	lit:lemma	Naujasis Džersis
 01072949-v	lit:lemma	sužaisti
 02923510-a	lit:lemma	musulmonų
-00748359-s	lit:lemma	rimtas
+00748359-a	lit:lemma	rimtas
 00897746-v	lit:lemma	teirautis
 10323634-n	lit:lemma	mokytoja
 04339291-n	lit:lemma	juostelė
-01106129-s	lit:lemma	federalinis
+01106129-a	lit:lemma	federalinis
 00507819-r	lit:lemma	vakar
 09371151-n	lit:lemma	Nigeris
 02064745-a	lit:lemma	kitoniškas
@@ -1079,10 +1079,10 @@
 08227214-n	lit:lemma	klubas
 00151087-n	lit:lemma	aptikimas
 00884466-n	lit:lemma	kursas
-01977488-s	lit:lemma	atidus
+01977488-a	lit:lemma	atidus
 00829378-n	lit:lemma	globa
 05760202-n	lit:lemma	prisiminimas
-01313004-s	lit:lemma	apleistas
+01313004-a	lit:lemma	apleistas
 14944888-n	lit:lemma	makromolekulė
 00593837-n	lit:lemma	internatūra
 13356402-n	lit:lemma	bankas
@@ -1104,10 +1104,10 @@
 15210486-n	lit:lemma	vasaris
 00037090-n	lit:lemma	meistriškas darbas
 03558404-n	lit:lemma	pačiūža
-00830051-s	lit:lemma	protingas
-02341864-s	lit:lemma	puikus
-00431004-s	lit:lemma	miglotas
-00933415-s	lit:lemma	brangus
+00830051-a	lit:lemma	protingas
+02341864-a	lit:lemma	puikus
+00431004-a	lit:lemma	miglotas
+00933415-a	lit:lemma	brangus
 01028748-v	lit:lemma	pavadinti
 10053808-n	lit:lemma	darbuotojas
 10410815-n	lit:lemma	laukinis
@@ -1115,15 +1115,15 @@
 10371052-n	lit:lemma	siūlytojas
 05833022-n	lit:lemma	dalykas
 04635104-n	lit:lemma	veiklumas
-00348018-s	lit:lemma	statiškas
+00348018-a	lit:lemma	statiškas
 00437788-n	lit:lemma	kūliavirstis
 14333575-n	lit:lemma	dantenų skausmas
-01660444-s	lit:lemma	paruoštas
+01660444-a	lit:lemma	paruoštas
 14476290-n	lit:lemma	neganda
 10028123-n	lit:lemma	pacifistas
-01031602-s	lit:lemma	eiklus
+01031602-a	lit:lemma	eiklus
 09492123-n	lit:lemma	milžinas
-00854255-s	lit:lemma	jausmingas
+00854255-a	lit:lemma	jausmingas
 03538037-n	lit:lemma	arklys
 00144778-n	lit:lemma	glamonė
 07332956-n	lit:lemma	mirties atvejis
@@ -1145,45 +1145,45 @@
 10160770-n	lit:lemma	arfininkas
 05923983-n	lit:lemma	vertybė
 15259284-n	lit:lemma	viduramžiai
-02361848-s	lit:lemma	įtikinamas
+02361848-a	lit:lemma	įtikinamas
 04192858-n	lit:lemma	apsauginis gaubtas
 06200344-n	lit:lemma	polinkis
 05890249-n	lit:lemma	modelis
-00892243-s	lit:lemma	lygus
+00892243-a	lit:lemma	lygus
 06292000-n	lit:lemma	antraštinis žodis
 00468480-n	lit:lemma	futbolas
 00048739-r	lit:lemma	tučtuojau
 06769392-n	lit:lemma	apsirikimas
 15046900-n	lit:lemma	kietasis kūnas
 01104637-n	lit:lemma	rekonstrukcija
-01178134-s	lit:lemma	išblyškęs
-02298152-s	lit:lemma	antikinė (Graikija)
+01178134-a	lit:lemma	išblyškęs
+02298152-a	lit:lemma	antikinė (Graikija)
 11426125-n	lit:lemma	branduolinė energija
 07546973-n	lit:lemma	mizogamija
 11876976-n	lit:lemma	lapinis kopūstas
-00953127-s	lit:lemma	kambarinis
+00953127-a	lit:lemma	kambarinis
 00257864-r	lit:lemma	pažodžiui
-00301951-s	lit:lemma	begalinis
+00301951-a	lit:lemma	begalinis
 05802185-n	lit:lemma	apskaičiavimas
 06802571-n	lit:lemma	pirmtakas
 00005041-v	lit:lemma	įkvėpti
 01504130-v	lit:lemma	išdėstyti
 02810102-a	lit:lemma	sausumos
-00168910-s	lit:lemma	malonus
+00168910-a	lit:lemma	malonus
 11511523-n	lit:lemma	išlydis
 01484097-n	lit:lemma	pilkšvasis ryklys
 13669733-n	lit:lemma	Kuveito piniginis vienetas
 02858816-a	lit:lemma	asmeninis
 13766733-n	lit:lemma	pilnas puodukas
 10077593-n	lit:lemma	gerbėjas
-01155968-s	lit:lemma	plieninis
+01155968-a	lit:lemma	plieninis
 02905050-a	lit:lemma	molinis
 13134947-n	lit:lemma	vaisius
 00262743-n	lit:lemma	ornamentavimas
 13809207-n	lit:lemma	dalis
 09444100-n	lit:lemma	žvaigždė
 01235258-n	lit:lemma	revanšas
-01898722-s	lit:lemma	sumanus
+01898722-a	lit:lemma	sumanus
 00995119-a	lit:lemma	palankus
 03017922-a	lit:lemma	vykdomasis
 08583095-n	lit:lemma	pusrutulis
@@ -1192,9 +1192,9 @@
 10130686-n	lit:lemma	panelė
 05501185-n	lit:lemma	smegenų kamienas
 06149484-n	lit:lemma	ekonomika
-00968730-s	lit:lemma	egzotiškas
+00968730-a	lit:lemma	egzotiškas
 05221895-n	lit:lemma	teritorija
-00837977-s	lit:lemma	įtemptas
+00837977-a	lit:lemma	įtemptas
 15133621-n	lit:lemma	trukmė
 00054950-r	lit:lemma	siaubingai
 02386612-a	lit:lemma	žemas
@@ -1219,29 +1219,29 @@
 01887787-n	lit:lemma	karvė
 08955626-n	lit:lemma	Pietų Korėja
 06732169-n	lit:lemma	matematinis teiginys
-00440292-s	lit:lemma	kvaišas
+00440292-a	lit:lemma	kvaišas
 05779923-n	lit:lemma	spėjimas
 00291471-a	lit:lemma	broliškas
-00150505-s	lit:lemma	sklandus
-00965176-s	lit:lemma	puikiai veikiantis
+00150505-a	lit:lemma	sklandus
+00965176-a	lit:lemma	puikiai veikiantis
 07217782-n	lit:lemma	instruktažas
 02920503-n	lit:lemma	slėptuvė
 00259177-n	lit:lemma	atitaisymas
 05084201-n	lit:lemma	apimtis
 10028977-n	lit:lemma	projekto rengėjas
-00579622-s	lit:lemma	stambus
-01878870-s	lit:lemma	geras
-00116245-s	lit:lemma	įpykęs
-01947741-s	lit:lemma	mandagus
+00579622-a	lit:lemma	stambus
+01878870-a	lit:lemma	geras
+00116245-a	lit:lemma	įpykęs
+01947741-a	lit:lemma	mandagus
 15287830-n	lit:lemma	periodas
-01158180-s	lit:lemma	akmeninis
+01158180-a	lit:lemma	akmeninis
 01235258-n	lit:lemma	kerštas
 15275598-n	lit:lemma	retardacija
-00459553-s	lit:lemma	nuogutėlaitis
+00459553-a	lit:lemma	nuogutėlaitis
 08844279-n	lit:lemma	Naujoji Gvinėja
 03038281-n	lit:lemma	kabliukas
 09983572-n	lit:lemma	dvasininkas
-00015247-s	lit:lemma	apstus
+00015247-a	lit:lemma	apstus
 08684294-n	lit:lemma	kiemas
 05199869-n	lit:lemma	efektyvumas
 10694258-n	lit:lemma	pedagogas
@@ -1252,18 +1252,18 @@
 09288769-n	lit:lemma	žvaigždė
 15086545-n	lit:lemma	tungo aliejus
 02949691-n	lit:lemma	marihuana
-02436995-s	lit:lemma	reiklus
+02436995-a	lit:lemma	reiklus
 07223450-n	lit:lemma	paskala
 00610532-a	lit:lemma	atominis
 02904518-a	lit:lemma	nervinis
 00314835-r	lit:lemma	tiesą sakant
 00894552-n	lit:lemma	treniruotė
-00746047-s	lit:lemma	nemalonus
+00746047-a	lit:lemma	nemalonus
 00055315-n	lit:lemma	palikimas
 03380867-n	lit:lemma	avalynė
 01651896-a	lit:lemma	panaikintas
 00509566-n	lit:lemma	azartinis lošimas iš pinigų
-00015247-s	lit:lemma	vešlus
+00015247-a	lit:lemma	vešlus
 02549581-v	lit:lemma	pasirūpinti
 04577769-n	lit:lemma	botagas
 03117939-n	lit:lemma	dublikatas
@@ -1272,21 +1272,21 @@
 03022593-a	lit:lemma	biudžetinis
 08253640-n	lit:lemma	puota
 00020259-v	lit:lemma	neiti miegoti
-00063953-s	lit:lemma	kvailas
+00063953-a	lit:lemma	kvailas
 04413631-n	lit:lemma	paskutinė stotis
 00141806-n	lit:lemma	tikrinimas
 00740336-a	lit:lemma	neaiškus
 12708654-n	lit:lemma	karčiavaisis citrinmedis
 09870208-n	lit:lemma	boksininkas
-01442079-s	lit:lemma	metinis
+01442079-a	lit:lemma	metinis
 07008680-n	lit:lemma	fragmentas
 06142118-n	lit:lemma	informatikos mokslas
 07546465-n	lit:lemma	neapkentimas
 01170962-n	lit:lemma	rungtynės
-00547317-s	lit:lemma	trumpas
+00547317-a	lit:lemma	trumpas
 04411264-n	lit:lemma	palapinė
 00593374-a	lit:lemma	sporadinis
-01728614-s	lit:lemma	senovinis
+01728614-a	lit:lemma	senovinis
 00517728-n	lit:lemma	festivalis
 08512736-n	lit:lemma	skiriamoji juosta
 04188643-n	lit:lemma	lakštas
@@ -1301,13 +1301,13 @@
 01094725-n	lit:lemma	verslas
 00216723-n	lit:lemma	atleidimas
 13471206-n	lit:lemma	ekonominis procesas
-01017439-s	lit:lemma	stiprus
+01017439-a	lit:lemma	stiprus
 00874067-n	lit:lemma	nutarimas
-00529657-s	lit:lemma	romus
-01729819-s	lit:lemma	ankstesnis
+00529657-a	lit:lemma	romus
+01729819-a	lit:lemma	ankstesnis
 10522324-n	lit:lemma	nedorėlis
 00163233-n	lit:lemma	intencija
-00335768-s	lit:lemma	aiškus
+00335768-a	lit:lemma	aiškus
 10720453-n	lit:lemma	prekiautojas
 14493716-n	lit:lemma	skurdas
 05584486-n	lit:lemma	kojos piršto nagas
@@ -1321,7 +1321,7 @@
 09351547-n	lit:lemma	kūdra
 12630999-n	lit:lemma	virgininė žemuogė
 00406234-n	lit:lemma	išgaubimas
-00358534-s	lit:lemma	neigiamojo krūvio
+00358534-a	lit:lemma	neigiamojo krūvio
 14802921-n	lit:lemma	plienas
 12630478-n	lit:lemma	braškė
 05138208-n	lit:lemma	vertė
@@ -1341,12 +1341,12 @@
 08796219-n	lit:lemma	Golgota
 02139544-v	lit:lemma	rodytis
 14421585-n	lit:lemma	sąjunga
-00167077-s	lit:lemma	traukiantis
+00167077-a	lit:lemma	traukiantis
 06941644-n	lit:lemma	indoeuropiečių kalba
 00074407-r	lit:lemma	atgalios
 01805523-v	lit:lemma	pasigesti
 01861465-n	lit:lemma	žinduoliai
-01920697-s	lit:lemma	pilnas
+01920697-a	lit:lemma	pilnas
 00410247-n	lit:lemma	nusistovėjusi tvarka
 14490564-n	lit:lemma	įsiskolinimas
 05341920-n	lit:lemma	kaklo arterija
@@ -1359,15 +1359,15 @@
 07456906-n	lit:lemma	susirėmimas
 04935528-n	lit:lemma	lipnumas
 01093085-n	lit:lemma	mainai
-01105042-s	lit:lemma	tipiškas
-01804728-s	lit:lemma	aštrus
+01105042-a	lit:lemma	tipiškas
+01804728-a	lit:lemma	aštrus
 04842993-n	lit:lemma	jautrumas
-01199083-s	lit:lemma	maišytas
+01199083-a	lit:lemma	maišytas
 09354984-n	lit:lemma	Paukščių Takas
-00860127-s	lit:lemma	eksperimentinis
+00860127-a	lit:lemma	eksperimentinis
 08063650-n	lit:lemma	automobilių parduotuvė
 06777164-n	lit:lemma	sarkazmas
-01971671-s	lit:lemma	iš tėvo pusės
+01971671-a	lit:lemma	iš tėvo pusės
 02694933-v	lit:lemma	nustatyti vietą
 15142167-n	lit:lemma	gimimas
 02931227-a	lit:lemma	šventas
@@ -1380,18 +1380,18 @@
 03779370-n	lit:lemma	forma
 09229709-n	lit:lemma	burbulas
 00067265-r	lit:lemma	pirmyn
-02065665-s	lit:lemma	įvairiarūšis
+02065665-a	lit:lemma	įvairiarūšis
 01068773-n	lit:lemma	susilaikymas
 02802215-n	lit:lemma	lankas
 01900349-a	lit:lemma	tikslus
 13954253-n	lit:lemma	būtis
 06757891-n	lit:lemma	padavimas
 00074524-n	lit:lemma	neapsižiūrėjimas
-01019283-s	lit:lemma	su negalia
+01019283-a	lit:lemma	su negalia
 00153961-n	lit:lemma	įrodymas
 01003050-a	lit:lemma	baigtas
-00507292-s	lit:lemma	bejausmis
-01450178-s	lit:lemma	nesantis
+00507292-a	lit:lemma	bejausmis
+01450178-a	lit:lemma	nesantis
 06760722-n	lit:lemma	machinacija
 01817500-a	lit:lemma	teigiamas
 06722453-n	lit:lemma	nutarimas
@@ -1403,7 +1403,7 @@
 01465994-n	lit:lemma	chordiniai
 07229530-n	lit:lemma	gyrimasis
 13602526-n	lit:lemma	elektromagnetinis vienetas
-01368464-s	lit:lemma	laidotuviškas
+01368464-a	lit:lemma	laidotuviškas
 14778436-n	lit:lemma	veiklioji medžiaga
 00433458-n	lit:lemma	kontaktinis sportas
 10480253-n	lit:lemma	specialistas
@@ -1412,25 +1412,25 @@
 03390207-n	lit:lemma	ištrauka
 06665370-n	lit:lemma	rinkmenų persiuntimo protokolas
 05835747-n	lit:lemma	sąvoka
-00522885-s	lit:lemma	visas
+00522885-a	lit:lemma	visas
 00197811-r	lit:lemma	konkrečiai
 00150134-r	lit:lemma	žinoma
 01925372-a	lit:lemma	protingas
-01126291-s	lit:lemma	siaubingas
-01881478-s	lit:lemma	klaidingas
-02295098-s	lit:lemma	autoritetingas
+01126291-a	lit:lemma	siaubingas
+01881478-a	lit:lemma	klaidingas
+02295098-a	lit:lemma	autoritetingas
 00058337-n	lit:lemma	įlaipinimas
-01115920-s	lit:lemma	patvirtintas
+01115920-a	lit:lemma	patvirtintas
 00429949-n	lit:lemma	pramoga
 08547938-n	lit:lemma	sankirta
 00015388-n	lit:lemma	gyvulys
 00400083-n	lit:lemma	virtimas
-01814252-s	lit:lemma	netikslingas
+01814252-a	lit:lemma	netikslingas
 00933420-n	lit:lemma	menas
 08166318-n	lit:lemma	teismų santvarka
 15275598-n	lit:lemma	atsilikimas
 14176895-n	lit:lemma	grybelinė infekcija
-01842468-s	lit:lemma	epizodinis
+01842468-a	lit:lemma	epizodinis
 07237758-n	lit:lemma	kaltinimas
 04623113-n	lit:lemma	būdas
 03621049-n	lit:lemma	virtuvės rykai
@@ -1451,7 +1451,7 @@
 13950812-n	lit:lemma	dvasininko rangas
 03781244-n	lit:lemma	vienuolynas
 00272844-r	lit:lemma	skersai
-00728431-s	lit:lemma	autonominis
+00728431-a	lit:lemma	autonominis
 08928193-n	lit:lemma	Kenijos Respublika
 04712735-n	lit:lemma	suderinamumas
 06077413-n	lit:lemma	histologija
@@ -1460,27 +1460,27 @@
 00059171-r	lit:lemma	labai
 05015117-n	lit:lemma	šaltis
 13767822-n	lit:lemma	ąsotis
-00491320-s	lit:lemma	neįprastas
+00491320-a	lit:lemma	neįprastas
 13688033-n	lit:lemma	markė
 09759501-n	lit:lemma	akademikas
 02714800-a	lit:lemma	dramos
-00850053-s	lit:lemma	ištaigingas
+00850053-a	lit:lemma	ištaigingas
 15293328-n	lit:lemma	karo laikotarpis
 03030035-n	lit:lemma	cigaras
 07600506-n	lit:lemma	cukatos
-00122128-s	lit:lemma	pirmesnis
-01091728-s	lit:lemma	veikiantis
+00122128-a	lit:lemma	pirmesnis
+01091728-a	lit:lemma	veikiantis
 00020133-v	lit:lemma	nemiegoti
 00047903-r	lit:lemma	pagaliau
 09970402-n	lit:lemma	grafienė
 01469677-a	lit:lemma	magnetinis
 01348258-a	lit:lemma	esminis
-02372118-s	lit:lemma	abipusis
+02372118-a	lit:lemma	abipusis
 04663763-n	lit:lemma	dėmesingumas
 00105603-r	lit:lemma	skubiai
-02180277-s	lit:lemma	nuoširdus
+02180277-a	lit:lemma	nuoširdus
 09198574-n	lit:lemma	Pietų vandenynas
-00683531-s	lit:lemma	grubus
+00683531-a	lit:lemma	grubus
 08929922-n	lit:lemma	Prancūzijos Respublika
 09444942-n	lit:lemma	žvaigždutė
 02798370-a	lit:lemma	visuomeninis
@@ -1488,13 +1488,13 @@
 05650329-n	lit:lemma	sugebėjimas
 13480848-n	lit:lemma	ugnis
 00208390-r	lit:lemma	matomai
-01764351-s	lit:lemma	kliudantis
+01764351-a	lit:lemma	kliudantis
 05650820-n	lit:lemma	šneka
 09350524-n	lit:lemma	Mekongas
 00124880-n	lit:lemma	sąlytis
 01831531-v	lit:lemma	perkelti
 00520672-n	lit:lemma	kabareto programa
-02298152-s	lit:lemma	senovinis
+02298152-a	lit:lemma	senovinis
 10661002-n	lit:lemma	nepažįstamasis
 00951781-n	lit:lemma	komercializacija
 01434278-v	lit:lemma	nuvežti
@@ -1505,27 +1505,27 @@
 02726305-n	lit:lemma	butas
 00181676-r	lit:lemma	už vandenyno
 00007846-n	lit:lemma	asmuo
-02013758-s	lit:lemma	atsinaujinęs
+02013758-a	lit:lemma	atsinaujinęs
 10182190-n	lit:lemma	benamis
 00014285-r	lit:lemma	ženkliai
 00953559-n	lit:lemma	kautynės
-00916199-s	lit:lemma	laisvas
+00916199-a	lit:lemma	laisvas
 07283608-n	lit:lemma	atsitikimas
 08960987-n	lit:lemma	Liuksemburgo Didžioji Hercogystė
-01258264-s	lit:lemma	ledinis
+01258264-a	lit:lemma	ledinis
 06755947-n	lit:lemma	išimtinė sąlyga
 15237782-n	lit:lemma	žiema
 00378365-r	lit:lemma	nuoširdžiai
 00297563-r	lit:lemma	bjauriai
 13624026-n	lit:lemma	decilitras
 01985029-v	lit:lemma	atsigulti
-01803583-s	lit:lemma	grubus
+01803583-a	lit:lemma	grubus
 00819235-a	lit:lemma	paskutinis
 03094347-n	lit:lemma	kontaktinis atspaudas
 00610861-a	lit:lemma	įprastinis
 03033362-n	lit:lemma	elektrinė grandinė
 13112664-n	lit:lemma	krūmas
-02298152-s	lit:lemma	klasikinis
+02298152-a	lit:lemma	klasikinis
 02612762-v	lit:lemma	lankyti
 02934641-n	lit:lemma	funikulierius
 05084201-n	lit:lemma	nuotolis
@@ -1543,9 +1543,9 @@
 05524430-n	lit:lemma	gonada
 07331400-n	lit:lemma	atsiskyrimas
 13669342-n	lit:lemma	Irako dinaras
-01735252-s	lit:lemma	motiniškas
+01735252-a	lit:lemma	motiniškas
 04507155-n	lit:lemma	lietsargis
-01007258-s	lit:lemma	ribotas
+01007258-a	lit:lemma	ribotas
 00874806-n	lit:lemma	vertinimas
 04623113-n	lit:lemma	prigimtis
 05517837-n	lit:lemma	pūslelė
@@ -1555,13 +1555,13 @@
 01600333-a	lit:lemma	šiaurės
 02018049-v	lit:lemma	sėsti
 03719053-n	lit:lemma	rūmai
-00282675-s	lit:lemma	glotnus
+00282675-a	lit:lemma	glotnus
 03132438-n	lit:lemma	ąsa
-01041209-s	lit:lemma	atlaidus
+01041209-a	lit:lemma	atlaidus
 08497294-n	lit:lemma	teritorija
 00050817-r	lit:lemma	tvirtai
 13454318-n	lit:lemma	kultivavimas
-02257856-s	lit:lemma	draugiškas
+02257856-a	lit:lemma	draugiškas
 00429964-r	lit:lemma	per anksti
 07001717-n	lit:lemma	stulpelinė diagrama
 11877860-n	lit:lemma	griežtis
@@ -1579,15 +1579,15 @@
 15076180-n	lit:lemma	instrumentinis plienas
 07555863-n	lit:lemma	maisto produktas
 00120010-n	lit:lemma	šuolis
-01523724-s	lit:lemma	perkeliamas
+01523724-a	lit:lemma	perkeliamas
 00741867-a	lit:lemma	išvystytas
 00912473-v	lit:lemma	šaukti
 00358931-n	lit:lemma	patrumpinimas
-00482673-s	lit:lemma	proporcingas
+00482673-a	lit:lemma	proporcingas
 05003423-n	lit:lemma	grakštumas
 14842992-n	lit:lemma	gruntas
 07570720-n	lit:lemma	penas
-01574259-s	lit:lemma	fizinis
+01574259-a	lit:lemma	fizinis
 00046522-n	lit:lemma	palietimas
 06413889-n	lit:lemma	knygelė
 00293171-r	lit:lemma	kryžmai
@@ -1600,9 +1600,9 @@
 03137130-a	lit:lemma	vedybinis
 00044150-n	lit:lemma	įgyvendinimas
 08082602-n	lit:lemma	bažnyčia
-02331857-s	lit:lemma	klestintis
+02331857-a	lit:lemma	klestintis
 00076196-n	lit:lemma	nekultūringumas
-01192035-s	lit:lemma	švelnus
+01192035-a	lit:lemma	švelnus
 01195536-a	lit:lemma	pagalbinis
 15280497-n	lit:lemma	judėjimo greitis
 11682512-n	lit:lemma	endospermas
@@ -1613,9 +1613,9 @@
 05701944-n	lit:lemma	pagrindinis pažinimo procesas
 06820023-n	lit:lemma	viršutinis indeksas
 00300247-r	lit:lemma	galbūt
-01842963-s	lit:lemma	suplanuotas
+01842963-a	lit:lemma	suplanuotas
 07215377-n	lit:lemma	atskleidimas
-01181446-s	lit:lemma	pasaulietiškas
+01181446-a	lit:lemma	pasaulietiškas
 03132879-n	lit:lemma	nėrimas vąšeliu
 14736972-n	lit:lemma	paprastasis baltymas
 08085824-n	lit:lemma	Kardinolų kolegija
@@ -1628,9 +1628,9 @@
 05512835-n	lit:lemma	šlapimtakis
 03044566-a	lit:lemma	Arabijos
 09970963-n	lit:lemma	bendratautis
-01894324-s	lit:lemma	patvirtintas
+01894324-a	lit:lemma	patvirtintas
 00090253-n	lit:lemma	priėmimas
-01523567-s	lit:lemma	judamas
+01523567-a	lit:lemma	judamas
 11451442-n	lit:lemma	elektromagnetinių bangų spektras
 04924103-n	lit:lemma	amžius
 00277376-n	lit:lemma	šlapinimas
@@ -1652,7 +1652,7 @@
 08524262-n	lit:lemma	branduolys
 00641820-n	lit:lemma	mokslinis tyrimas
 04226537-n	lit:lemma	kriauklai
-00521976-s	lit:lemma	visiškas
+00521976-a	lit:lemma	visiškas
 09271415-n	lit:lemma	Ebras
 13369074-n	lit:lemma	degalų atsarga
 13761801-n	lit:lemma	truputėlis
@@ -1664,26 +1664,26 @@
 02367363-v	lit:lemma	vykdyti
 03779370-n	lit:lemma	šablonas
 11878283-n	lit:lemma	garstyčia
-01866812-s	lit:lemma	nevaisingas
+01866812-a	lit:lemma	nevaisingas
 01146012-a	lit:lemma	gramatiškas
-02132735-s	lit:lemma	seksualinis
+02132735-a	lit:lemma	seksualinis
 03143131-n	lit:lemma	krištolo rutulys
 01409581-a	lit:lemma	vienodas
 14839322-n	lit:lemma	duraliuminis
 03094503-n	lit:lemma	konteineris
 00236989-a	lit:lemma	vienašalis
 07511080-n	lit:lemma	lūkestis
-01781076-s	lit:lemma	psichologinis
-02100968-s	lit:lemma	pavaldus
+01781076-a	lit:lemma	psichologinis
+02100968-a	lit:lemma	pavaldus
 00019448-v	lit:lemma	veikti
 14173484-n	lit:lemma	gerklės skausmas
 10079893-n	lit:lemma	fašistas
 02087122-n	lit:lemma	medžioklinis šuo
-01969348-s	lit:lemma	pusmetinis
+01969348-a	lit:lemma	pusmetinis
 00153961-n	lit:lemma	patikrinimas
 00295701-n	lit:lemma	keliavimas
 13724350-n	lit:lemma	dekagramas
-00431004-s	lit:lemma	neaiškus
+00431004-a	lit:lemma	neaiškus
 00166375-r	lit:lemma	tarp kitko
 05519085-n	lit:lemma	gimda
 00901103-v	lit:lemma	supažindinti
@@ -1691,10 +1691,10 @@
 14859838-n	lit:lemma	organinės trąšos
 03434285-n	lit:lemma	generatorius
 00251408-r	lit:lemma	vakare
-02384077-s	lit:lemma	plepus
+02384077-a	lit:lemma	plepus
 06377442-n	lit:lemma	eilėraštis
 03272940-n	lit:lemma	elektrinis plakiklis
-01982957-s	lit:lemma	prestižinis
+01982957-a	lit:lemma	prestižinis
 02727883-v	lit:lemma	būti parduodamam
 09824609-n	lit:lemma	valdžios organai
 03340581-n	lit:lemma	kilis
@@ -1702,22 +1702,22 @@
 01106405-a	lit:lemma	vietinis
 10411551-n	lit:lemma	prekeivis
 03177349-n	lit:lemma	sandėlis
-01535270-s	lit:lemma	ekstremistinis
-02552646-s	lit:lemma	sausutėlis
+01535270-a	lit:lemma	ekstremistinis
+02552646-a	lit:lemma	sausutėlis
 09028841-n	lit:lemma	Gibraltaras
 01518386-a	lit:lemma	karinis
-00138782-s	lit:lemma	ne vietoje esantis
+00138782-a	lit:lemma	ne vietoje esantis
 04162998-n	lit:lemma	sėdimos vietos
 00024814-v	lit:lemma	atvėsti
-01066787-s	lit:lemma	vyraujantis
+01066787-a	lit:lemma	vyraujantis
 00256309-n	lit:lemma	skalavimas
 13934596-n	lit:lemma	aplinka
 04895773-n	lit:lemma	nepasitikėjimas
 00145713-r	lit:lemma	pakankamai
 00334210-r	lit:lemma	pigiai
 09399592-n	lit:lemma	ragas
-02032850-s	lit:lemma	dešiniojo borto
-00818175-s	lit:lemma	neištobulintas
+02032850-a	lit:lemma	dešiniojo borto
+00818175-a	lit:lemma	neištobulintas
 00380696-n	lit:lemma	sumaišymas
 05896059-n	lit:lemma	iliuzija
 09358226-n	lit:lemma	mėnulis
@@ -1729,7 +1729,7 @@
 00851744-a	lit:lemma	pageidaujamas
 00029639-r	lit:lemma	tolyn
 02009122-v	lit:lemma	staiga išeiti
-01809245-s	lit:lemma	nepakenčiamas
+01809245-a	lit:lemma	nepakenčiamas
 00047392-r	lit:lemma	pernelyg
 08166552-n	lit:lemma	tauta
 01433267-a	lit:lemma	nuostolinis
@@ -1754,8 +1754,8 @@
 05924920-n	lit:lemma	norma
 08349916-n	lit:lemma	centrinis bankas
 03179701-n	lit:lemma	stalas
-02023430-s	lit:lemma	neturtingas
-01122595-s	lit:lemma	neįžymus
+02023430-a	lit:lemma	neturtingas
+01122595-a	lit:lemma	neįžymus
 13356985-n	lit:lemma	lėšos
 00301495-r	lit:lemma	pelnytai
 07840395-n	lit:lemma	kario padažas
@@ -1769,18 +1769,18 @@
 04802776-n	lit:lemma	nuokrypis
 01236296-n	lit:lemma	karas
 00426958-v	lit:lemma	pradingti
-01947741-s	lit:lemma	kultūringas
-01940651-s	lit:lemma	pragmatiškas
-02544048-s	lit:lemma	apsvaigęs
+01947741-a	lit:lemma	kultūringas
+01940651-a	lit:lemma	pragmatiškas
+02544048-a	lit:lemma	apsvaigęs
 04074482-n	lit:lemma	gydymo kursas
 04882968-n	lit:lemma	susivaldymas
 04395024-n	lit:lemma	dervuota drobė
 00329227-n	lit:lemma	srovė
 09024467-n	lit:lemma	Madridas
 02940759-a	lit:lemma	šeimos
-00766102-s	lit:lemma	tiesus
+00766102-a	lit:lemma	tiesus
 08887716-n	lit:lemma	Meno sala
-02035086-s	lit:lemma	etiškas
+02035086-a	lit:lemma	etiškas
 14806838-n	lit:lemma	chemikalas
 00080039-r	lit:lemma	po
 07472929-n	lit:lemma	rinkimų kampanija
@@ -1804,22 +1804,22 @@
 02993546-n	lit:lemma	centras
 00031820-v	lit:lemma	nusijuokti
 09543353-n	lit:lemma	kipšas
-00338013-s	lit:lemma	neaiškus
+00338013-a	lit:lemma	neaiškus
 06362953-n	lit:lemma	kūrinys
 00017865-v	lit:lemma	gultis
 07204665-n	lit:lemma	atmetimas
-00414354-s	lit:lemma	šiuolaikinis
+00414354-a	lit:lemma	šiuolaikinis
 03582658-n	lit:lemma	išradimas
 08381165-n	lit:lemma	valdyba
 00177289-r	lit:lemma	stipriai
 08779830-n	lit:lemma	Karelija
-00012689-s	lit:lemma	įsivaizduojamas
+00012689-a	lit:lemma	įsivaizduojamas
 14360320-n	lit:lemma	šleikštumas
-00169056-s	lit:lemma	žavus
+00169056-a	lit:lemma	žavus
 06053280-n	lit:lemma	diagnostika
-01803583-s	lit:lemma	šiurkštus
+01803583-a	lit:lemma	šiurkštus
 09439433-n	lit:lemma	saulės sistema
-02068730-s	lit:lemma	anksčiau paminėtas
+02068730-a	lit:lemma	anksčiau paminėtas
 10125786-n	lit:lemma	generolas
 07303335-n	lit:lemma	signalinė ugnis
 13604718-n	lit:lemma	piniginis vienetas
@@ -1827,7 +1827,7 @@
 05649385-n	lit:lemma	nekūrybiškumas
 11467018-n	lit:lemma	uraganas
 00684838-v	lit:lemma	įtraukti
-02340458-s	lit:lemma	paprastas
+02340458-a	lit:lemma	paprastas
 05714894-n	lit:lemma	smarvė
 00434075-n	lit:lemma	akrobatika
 03120491-n	lit:lemma	sporto aikštynas
@@ -1839,11 +1839,11 @@
 00035491-r	lit:lemma	neįprastai
 02106030-n	lit:lemma	kolis
 04676540-n	lit:lemma	fazė
-01386538-s	lit:lemma	didžiulis
+01386538-a	lit:lemma	didžiulis
 07071942-n	lit:lemma	muzikos rūšis
 13916721-n	lit:lemma	kubas
 00049003-n	lit:lemma	atėjimas
-01689442-s	lit:lemma	stereotipiškas
+01689442-a	lit:lemma	stereotipiškas
 00263272-n	lit:lemma	apipavidalinimas
 05660268-n	lit:lemma	metodas
 04270147-n	lit:lemma	mentelė
@@ -1864,11 +1864,11 @@
 06781383-n	lit:lemma	žaismingas atsitikimas
 00282858-r	lit:lemma	be galo
 05785508-n	lit:lemma	apmąstymas
-01676517-s	lit:lemma	nuostabus
+01676517-a	lit:lemma	nuostabus
 00255214-n	lit:lemma	prausimas
 10636488-n	lit:lemma	senmergė
 04024862-n	lit:lemma	krepšelis
-01710543-s	lit:lemma	neišmokėtas
+01710543-a	lit:lemma	neišmokėtas
 03259505-n	lit:lemma	būstas
 08972521-n	lit:lemma	Naujoji Zelandija
 03863923-n	lit:lemma	rūbas
@@ -1883,11 +1883,11 @@
 04931965-n	lit:lemma	sandara
 00539827-n	lit:lemma	ratelis
 06094587-n	lit:lemma	fizika
-01723648-s	lit:lemma	beaistris
-01868578-s	lit:lemma	nepakartojamas
+01723648-a	lit:lemma	beaistris
+01868578-a	lit:lemma	nepakartojamas
 07753592-n	lit:lemma	bananas
 01380122-v	lit:lemma	sklisti
-00874226-s	lit:lemma	gyvas
+00874226-a	lit:lemma	gyvas
 04164989-n	lit:lemma	dalis
 08570758-n	lit:lemma	žaidimo aikštelė
 05481095-n	lit:lemma	galvos smegenys
@@ -1897,22 +1897,22 @@
 01155090-v	lit:lemma	pavyti
 09753498-n	lit:lemma	ožiaragis
 09984298-n	lit:lemma	prižiūrėtojas
-00215087-s	lit:lemma	plaukuotas
-00830051-s	lit:lemma	nusimanantis
-00813589-s	lit:lemma	pradinis
+00215087-a	lit:lemma	plaukuotas
+00830051-a	lit:lemma	nusimanantis
+00813589-a	lit:lemma	pradinis
 07109847-n	lit:lemma	ištarimas
 00205375-r	lit:lemma	pagrįstai
 06760722-n	lit:lemma	apgaulė
-00904745-s	lit:lemma	apgailėtinas
+00904745-a	lit:lemma	apgailėtinas
 00744616-n	lit:lemma	neteisybė
 06723452-n	lit:lemma	pranešimas
 01057759-n	lit:lemma	maitinimas
-01263013-s	lit:lemma	barbariškas
+01263013-a	lit:lemma	barbariškas
 14768201-n	lit:lemma	arseno trioksidas
-01394075-s	lit:lemma	mažas
+01394075-a	lit:lemma	mažas
 10780632-n	lit:lemma	žmona
 13453428-n	lit:lemma	irimas
-01255022-s	lit:lemma	vasariškas
+01255022-a	lit:lemma	vasariškas
 13091774-n	lit:lemma	sporinė
 03542860-n	lit:lemma	viešbučio kambarys
 01855672-n	lit:lemma	žąsis
@@ -1930,11 +1930,11 @@
 09505418-n	lit:lemma	nemirtinga būtybė
 00151426-r	lit:lemma	po darbo
 01643620-a	lit:lemma	senas
-02114746-s	lit:lemma	užkrečiamas
+02114746-a	lit:lemma	užkrečiamas
 02835654-a	lit:lemma	liekamasis
-00477284-s	lit:lemma	jaukus
-01386234-s	lit:lemma	ekstensyvus
-02110447-s	lit:lemma	atsiskyręs
+00477284-a	lit:lemma	jaukus
+01386234-a	lit:lemma	ekstensyvus
+02110447-a	lit:lemma	atsiskyręs
 15248564-n	lit:lemma	amžius
 00006032-a	lit:lemma	reliatyvus
 08565506-n	lit:lemma	rojus
@@ -1944,30 +1944,30 @@
 00007884-r	lit:lemma	pusiau
 13136781-n	lit:lemma	riešutėlis
 03413428-n	lit:lemma	lošimo namai
-02336109-s	lit:lemma	pakankamas
+02336109-a	lit:lemma	pakankamas
 05454070-n	lit:lemma	eritrocitas
 06834138-n	lit:lemma	alfa
 08953324-n	lit:lemma	Islandijos Respublika
 09224911-n	lit:lemma	kūnas
-01280908-s	lit:lemma	nežymus
+01280908-a	lit:lemma	nežymus
 13282007-n	lit:lemma	atpildas
 10679174-n	lit:lemma	chirurgas
-00783840-s	lit:lemma	bendras
+00783840-a	lit:lemma	bendras
 04941453-n	lit:lemma	tankumas
 00972621-n	lit:lemma	puolimas
 04358874-n	lit:lemma	denio antstatas
 04997988-n	lit:lemma	kūno savybė
-01592857-s	lit:lemma	prastas
+01592857-a	lit:lemma	prastas
 03051152-n	lit:lemma	skalbinių virvė
 04935528-n	lit:lemma	sukibimas
 08050678-n	lit:lemma	valdymo organas
 08642632-n	lit:lemma	buvimas
 09504135-n	lit:lemma	dvasinė būtybė
 10325013-n	lit:lemma	didvyris
-01668567-s	lit:lemma	metodinis
+01668567-a	lit:lemma	metodinis
 13459821-n	lit:lemma	defliacija
 05562595-n	lit:lemma	sterblė
-00818175-s	lit:lemma	nesudėtingas
+00818175-a	lit:lemma	nesudėtingas
 01105259-n	lit:lemma	gabenimas
 07929519-n	lit:lemma	kava
 03025746-a	lit:lemma	alpinis
@@ -1977,7 +1977,7 @@
 02416519-n	lit:lemma	ožys
 07964144-n	lit:lemma	spalvų derinys
 13879947-n	lit:lemma	lygiakraštis trikampis
-00280463-s	lit:lemma	spinduliuojantis
+00280463-a	lit:lemma	spinduliuojantis
 07009640-n	lit:lemma	veiksmas
 01229223-n	lit:lemma	pagerbimas
 02431122-n	lit:lemma	taurusis elnias
@@ -1987,22 +1987,22 @@
 04490091-n	lit:lemma	vilkikas
 10213652-n	lit:lemma	įsibrovėlis
 04418818-n	lit:lemma	scena
-00733743-s	lit:lemma	labiau pageidaujamas
+00733743-a	lit:lemma	labiau pageidaujamas
 05159725-n	lit:lemma	labas
 00999245-n	lit:lemma	standartizavimas
 01922562-a	lit:lemma	neramus
 10484526-n	lit:lemma	iniciatorius
-02119213-s	lit:lemma	blaivus
+02119213-a	lit:lemma	blaivus
 13954253-n	lit:lemma	buvimas
 00803617-n	lit:lemma	patikrinimas
 10305802-n	lit:lemma	daktaras
 02547586-v	lit:lemma	pagelbėti
 00464513-a	lit:lemma	nuoseklus
 10171755-n	lit:lemma	eretikas
-01435060-s	lit:lemma	tolimo veikimo
+01435060-a	lit:lemma	tolimo veikimo
 02923129-n	lit:lemma	degiklis
 08223802-n	lit:lemma	bendrija
-02398378-s	lit:lemma	aštrus
+02398378-a	lit:lemma	aštrus
 07184735-n	lit:lemma	kivirčas
 07009640-n	lit:lemma	aktas
 06725877-n	lit:lemma	deklaracija
@@ -2011,7 +2011,7 @@
 07907943-n	lit:lemma	likeris
 03049326-n	lit:lemma	uždarojo valdymo sistema
 03122748-n	lit:lemma	danga
-01741669-s	lit:lemma	taikingas
+01741669-a	lit:lemma	taikingas
 05338614-n	lit:lemma	petinė arterija
 08242100-n	lit:lemma	kadrai
 10378026-n	lit:lemma	stebėtojas
@@ -2022,8 +2022,8 @@
 04149968-n	lit:lemma	rimbas
 13910384-n	lit:lemma	erdvė
 02520219-a	lit:lemma	savanoriškas
-02071782-s	lit:lemma	artimas
-01327205-s	lit:lemma	izoliuotas
+02071782-a	lit:lemma	artimas
+01327205-a	lit:lemma	izoliuotas
 10752093-n	lit:lemma	auka
 02932019-n	lit:lemma	lėktuvo salonas
 07015510-n	lit:lemma	komedija
@@ -2034,15 +2034,15 @@
 02716739-a	lit:lemma	ekonominis
 00088725-n	lit:lemma	sulaikymas
 07184149-n	lit:lemma	kivirčas
-00972642-s	lit:lemma	modernus
-00421590-s	lit:lemma	nešvarus
+00972642-a	lit:lemma	modernus
+00421590-a	lit:lemma	nešvarus
 15153787-n	lit:lemma	senas amžius
 13247228-n	lit:lemma	bažnyčios žemės
-00035978-s	lit:lemma	įtemptas
+00035978-a	lit:lemma	įtemptas
 06733227-n	lit:lemma	pradinis teiginys
 05712076-n	lit:lemma	pojūtis
 14440488-n	lit:lemma	pažeminimas
-02271052-s	lit:lemma	išmanantis
+02271052-a	lit:lemma	išmanantis
 03614532-n	lit:lemma	klavišinis instrumentas
 13981137-n	lit:lemma	trynimasis
 04742535-n	lit:lemma	vienodumas
@@ -2054,8 +2054,8 @@
 00005815-v	lit:lemma	kosėti
 02541302-a	lit:lemma	sergantis
 00099184-v	lit:lemma	gyti
-00860932-s	lit:lemma	abstraktus
-00978199-s	lit:lemma	greitas
+00860932-a	lit:lemma	abstraktus
+00978199-a	lit:lemma	greitas
 00758795-n	lit:lemma	tingėjimas
 03081021-n	lit:lemma	komponentas
 03404449-n	lit:lemma	krosnis
@@ -2069,10 +2069,10 @@
 01962310-a	lit:lemma	reguliuojamas
 00008055-v	lit:lemma	mirksėti
 09201998-n	lit:lemma	vandeningasis horizontas
-01754873-s	lit:lemma	nuolatinis
-00116245-s	lit:lemma	įtūžęs
+01754873-a	lit:lemma	nuolatinis
+00116245-a	lit:lemma	įtūžęs
 00302394-n	lit:lemma	skridimas
-00345694-s	lit:lemma	kintamas
+00345694-a	lit:lemma	kintamas
 00884466-n	lit:lemma	kursai
 02676496-v	lit:lemma	telkti
 00250570-r	lit:lemma	per metus
@@ -2090,8 +2090,8 @@
 05145118-n	lit:lemma	vertė pinigais
 00226618-a	lit:lemma	malonus
 04393404-n	lit:lemma	gobelenas
-01909421-s	lit:lemma	neišvalytas
-02322512-s	lit:lemma	stiprus
+01909421-a	lit:lemma	neišvalytas
+02322512-a	lit:lemma	stiprus
 13385216-n	lit:lemma	pinigai
 02784218-n	lit:lemma	kaspinas
 00795863-v	lit:lemma	drausti
@@ -2100,18 +2100,18 @@
 02959553-a	lit:lemma	suomių
 05108740-n	lit:lemma	didelis kiekis
 09942431-n	lit:lemma	apžvalgininkas
-00783840-s	lit:lemma	nespecializuotas
-01079052-s	lit:lemma	įšalęs
+00783840-a	lit:lemma	nespecializuotas
+01079052-a	lit:lemma	įšalęs
 06546931-n	lit:lemma	teisių dokumentai
 07713895-n	lit:lemma	kopūstas
 00285092-r	lit:lemma	garbingai
 00502952-n	lit:lemma	šaškės
 00974367-v	lit:lemma	pranešti
 09103943-n	lit:lemma	Misisipė
-00329034-s	lit:lemma	padalintas
+00329034-a	lit:lemma	padalintas
 03214253-n	lit:lemma	tranšėja
 06586672-n	lit:lemma	hiperteksto saitas
-00733743-s	lit:lemma	vertesnis
+00733743-a	lit:lemma	vertesnis
 09992837-n	lit:lemma	dukra
 00529266-a	lit:lemma	ramus
 05710687-n	lit:lemma	aptikimas
@@ -2126,7 +2126,7 @@
 00319939-n	lit:lemma	vijimasis
 00372013-n	lit:lemma	akumuliacija
 10640620-n	lit:lemma	žmona
-01152521-s	lit:lemma	plieninis
+01152521-a	lit:lemma	plieninis
 01740892-a	lit:lemma	taikos
 06776138-n	lit:lemma	humoras
 00043078-v	lit:lemma	išpuošti
@@ -2137,30 +2137,30 @@
 06506191-n	lit:lemma	priminimas
 08182716-n	lit:lemma	pulkas
 00157624-r	lit:lemma	visai
-00751099-s	lit:lemma	patogus vartotojui
+00751099-a	lit:lemma	patogus vartotojui
 07041688-n	lit:lemma	kvartetas
 03790230-n	lit:lemma	motorinė valtis
 05644527-n	lit:lemma	produktyvumas
 00320852-n	lit:lemma	įterpimas
 05622456-n	lit:lemma	talentas
-00053032-s	lit:lemma	lipnus
-00953127-s	lit:lemma	vidinis
+00053032-a	lit:lemma	lipnus
+00953127-a	lit:lemma	vidinis
 04188643-n	lit:lemma	lapas
 06423619-n	lit:lemma	katalogas
 01327925-a	lit:lemma	vientisas
 07397355-n	lit:lemma	griaustinis
-02215087-s	lit:lemma	unikalus
+02215087-a	lit:lemma	unikalus
 00320852-n	lit:lemma	įdėjimas
 00049003-n	lit:lemma	įėjimas
-00799401-s	lit:lemma	apdujęs
-01309657-s	lit:lemma	neinformuotas
+00799401-a	lit:lemma	apdujęs
+01309657-a	lit:lemma	neinformuotas
 11452750-n	lit:lemma	energijos lygmuo
 01871680-v	lit:lemma	stumdyti
 02828884-n	lit:lemma	suoliukas
 08688247-n	lit:lemma	sritis
 13312569-n	lit:lemma	žemės mokestis
 02756346-a	lit:lemma	lokalus
-02469407-s	lit:lemma	tipiškas
+02469407-a	lit:lemma	tipiškas
 00065963-r	lit:lemma	galiausiai, bet ne mažiau svarbu
 07584938-n	lit:lemma	sultinys
 08367880-n	lit:lemma	politinė sistema
@@ -2168,12 +2168,12 @@
 09871229-n	lit:lemma	berniukas
 00174735-r	lit:lemma	smarkiai
 00753685-n	lit:lemma	sukčiavimas
-01066787-s	lit:lemma	dominuojantis
+01066787-a	lit:lemma	dominuojantis
 00521085-n	lit:lemma	demonstravimas
 06487897-n	lit:lemma	katalogas
 00080304-r	lit:lemma	kartu
 08753729-n	lit:lemma	Jamaika
-00182225-s	lit:lemma	savaiminio veikimo
+00182225-a	lit:lemma	savaiminio veikimo
 08907606-n	lit:lemma	Indonezijos Respublika
 02806992-n	lit:lemma	persirengimo kabina
 00575741-n	lit:lemma	darbas
@@ -2181,33 +2181,33 @@
 00054212-r	lit:lemma	paskui
 00034288-v	lit:lemma	vaipytis
 02015238-a	lit:lemma	revoliucingas
-00218305-s	lit:lemma	gražus
+00218305-a	lit:lemma	gražus
 08616311-n	lit:lemma	kursas
 09379111-n	lit:lemma	spraga
 00376063-n	lit:lemma	kintamasis
 14375890-n	lit:lemma	nervinė įtampa
 03113152-n	lit:lemma	kosmetika
 04188179-n	lit:lemma	paklodė
-01062393-s	lit:lemma	suverenus
+01062393-a	lit:lemma	suverenus
 02297166-a	lit:lemma	nestandartinis
 00820976-v	lit:lemma	reikšti
 07051975-n	lit:lemma	žodžiai
-01230616-s	lit:lemma	bejėgiškas
+01230616-a	lit:lemma	bejėgiškas
 04118021-n	lit:lemma	kilimėlis
 15236475-n	lit:lemma	sezonas
 15249799-n	lit:lemma	jubiliejus
 00745005-n	lit:lemma	nusižengimas
-00916199-s	lit:lemma	apytikslis
+00916199-a	lit:lemma	apytikslis
 06623316-n	lit:lemma	registruotas paštas
 00032299-r	lit:lemma	labai
 03032252-n	lit:lemma	kinas
 14380140-n	lit:lemma	psichikos liga
-01728919-s	lit:lemma	buvęs
+01728919-a	lit:lemma	buvęs
 14832193-n	lit:lemma	ribonukleino rūgštis
 01672607-a	lit:lemma	įprastas
 07501545-n	lit:lemma	nemėgimas
 10323634-n	lit:lemma	ponia
-00811536-s	lit:lemma	nekantrus
+00811536-a	lit:lemma	nekantrus
 02754096-a	lit:lemma	juridinis
 14539268-n	lit:lemma	saugumas
 05805475-n	lit:lemma	supratimas
@@ -2218,7 +2218,7 @@
 07501545-n	lit:lemma	antipatija
 09916348-n	lit:lemma	vadovaujantis darbuotojas
 03179318-n	lit:lemma	planas
-02414323-s	lit:lemma	hipersmulkusis
+02414323-a	lit:lemma	hipersmulkusis
 00040325-a	lit:lemma	aktyvus
 09606009-n	lit:lemma	nuotykių ieškotojas
 02872752-n	lit:lemma	aulinis batas
@@ -2230,51 +2230,51 @@
 04910848-n	lit:lemma	dabitiškumas
 14464675-n	lit:lemma	riktas
 02771004-n	lit:lemma	naikinimo klavišas
-00494409-s	lit:lemma	atskiras
+00494409-a	lit:lemma	atskiras
 01028082-n	lit:lemma	religinės apeigos
-02065958-s	lit:lemma	prieštaraujantis
+02065958-a	lit:lemma	prieštaraujantis
 00031921-n	lit:lemma	santykis
 05340599-n	lit:lemma	centrinė tinklainės arterija
 00007488-r	lit:lemma	visiškai
 00014034-v	lit:lemma	purtytis
-02515001-s	lit:lemma	niekšiškas
+02515001-a	lit:lemma	niekšiškas
 06831284-n	lit:lemma	B
-02112701-s	lit:lemma	kolektyvinis
+02112701-a	lit:lemma	kolektyvinis
 01123598-n	lit:lemma	socialinė kontrolė
 00181748-r	lit:lemma	stipriai
-01115635-s	lit:lemma	autentiškas
+01115635-a	lit:lemma	autentiškas
 01149621-n	lit:lemma	ribojimas
-00936297-s	lit:lemma	patyręs
+00936297-a	lit:lemma	patyręs
 06064462-n	lit:lemma	toksikologija
-02144436-s	lit:lemma	tamprus
+02144436-a	lit:lemma	tamprus
 00068368-r	lit:lemma	tolyn
 06722453-n	lit:lemma	sprendimas
 09831962-n	lit:lemma	blogas žmogus
-01792573-s	lit:lemma	grynas
+01792573-a	lit:lemma	grynas
 04810327-n	lit:lemma	nelegalumas
 13659162-n	lit:lemma	metras
-00250739-s	lit:lemma	neatsargus
+00250739-a	lit:lemma	neatsargus
 01014066-n	lit:lemma	sukaupimas
 01195536-a	lit:lemma	naudingas
 00258677-r	lit:lemma	išorėn
 05615028-n	lit:lemma	taisyklingas samprotavimas
 03086580-n	lit:lemma	koncertų salė
 06637824-n	lit:lemma	pamatas
-01395028-s	lit:lemma	mažokas
+01395028-a	lit:lemma	mažokas
 06158346-n	lit:lemma	filosofija
 05786184-n	lit:lemma	meditacija
 01325451-a	lit:lemma	pamokomas
-01860328-s	lit:lemma	užkulisinis
+01860328-a	lit:lemma	užkulisinis
 03690473-n	lit:lemma	sunkvežimis
 09189157-n	lit:lemma	lizdas
 00413239-n	lit:lemma	paprotys
-00521329-s	lit:lemma	įvykdytas
+00521329-a	lit:lemma	įvykdytas
 10622053-n	lit:lemma	kareivis
 13613985-n	lit:lemma	hektaras
 03049457-n	lit:lemma	kabinetas
 00462241-n	lit:lemma	kėgliai
 15159583-n	lit:lemma	kalendorinis laikas
-00726317-s	lit:lemma	bejėgiškas
+00726317-a	lit:lemma	bejėgiškas
 14189204-n	lit:lemma	kraujo liga
 04140631-n	lit:lemma	ožys malkoms pjauti
 07574426-n	lit:lemma	užkandis
@@ -2285,10 +2285,10 @@
 02688974-a	lit:lemma	smegeninis
 00927711-v	lit:lemma	užsiminti
 07217349-n	lit:lemma	pristatymas
-01259391-s	lit:lemma	silpnas
+01259391-a	lit:lemma	silpnas
 00103664-r	lit:lemma	ir taip toliau
 10321882-n	lit:lemma	žmonių nekentėjas
-01690606-s	lit:lemma	įprastas
+01690606-a	lit:lemma	įprastas
 00285557-n	lit:lemma	žengsena
 00254614-r	lit:lemma	pirma
 00123170-v	lit:lemma	mainyti
@@ -2305,9 +2305,9 @@
 08368907-n	lit:lemma	karta
 02872066-a	lit:lemma	vedybinis
 00117082-r	lit:lemma	sudėjus
-01344171-s	lit:lemma	įtraukiantis
+01344171-a	lit:lemma	įtraukiantis
 00185172-r	lit:lemma	sumaniai
-02500590-s	lit:lemma	bevertis
+02500590-a	lit:lemma	bevertis
 01943406-a	lit:lemma	protingas
 13536794-n	lit:lemma	fotografavimas
 01463965-a	lit:lemma	meilus
@@ -2338,83 +2338,83 @@
 08731606-n	lit:lemma	Indokinijos pussiasalis
 06785367-n	lit:lemma	kietas riešutėlis
 05648459-n	lit:lemma	nenuovokumas
-00818008-s	lit:lemma	ankstyvas
+00818008-a	lit:lemma	ankstyvas
 09096664-n	lit:lemma	Kembridžas
 04051825-n	lit:lemma	pylimas
-00758800-s	lit:lemma	švelnus
+00758800-a	lit:lemma	švelnus
 01732172-v	lit:lemma	interpretuoti
 01151110-v	lit:lemma	nutaikyti
 00808182-n	lit:lemma	suvaržymas
 10129825-n	lit:lemma	panelė
 01976957-n	lit:lemma	krabas
-01487943-s	lit:lemma	svarbiausias
+01487943-a	lit:lemma	svarbiausias
 14856893-n	lit:lemma	nuotekos
 00625774-a	lit:lemma	nematerialus
 13817526-n	lit:lemma	procentinis santykis
 13282007-n	lit:lemma	užmokestis
 00207761-n	lit:lemma	ištrėmimas
-01322323-s	lit:lemma	nusikaltęs
+01322323-a	lit:lemma	nusikaltęs
 00363260-n	lit:lemma	padidinimas
 13262913-n	lit:lemma	paveldas
-00780352-s	lit:lemma	aiškus
+00780352-a	lit:lemma	aiškus
 02688974-a	lit:lemma	cerebrinis
 14816745-n	lit:lemma	degalai
 08163273-n	lit:lemma	įstatymų leidybos organas
 03132076-n	lit:lemma	kriketo lazda
 03230785-n	lit:lemma	eskizas
-00297598-s	lit:lemma	buržuazinis
-01439496-s	lit:lemma	pastovus
+00297598-a	lit:lemma	buržuazinis
+01439496-a	lit:lemma	pastovus
 03546766-n	lit:lemma	korpusas
 01811909-n	lit:lemma	balandis
 02695079-n	lit:lemma	albumas
 15262921-n	lit:lemma	dabartis
 08913434-n	lit:lemma	Irakas
-00951003-s	lit:lemma	paviršinis
+00951003-a	lit:lemma	paviršinis
 08415272-n	lit:lemma	prisiekusiųjų teismas
 02607078-a	lit:lemma	aeromechaninis
 00340133-r	lit:lemma	pažodžiui
-00440579-s	lit:lemma	žioplas
+00440579-a	lit:lemma	žioplas
 04540547-n	lit:lemma	galvaninė baterija
 00607421-a	lit:lemma	konvencionalus
 10020890-n	lit:lemma	daktaras
 08559508-n	lit:lemma	gyvenamoji vieta
 00505114-r	lit:lemma	jei tik
 03636248-n	lit:lemma	lempa
-02323358-s	lit:lemma	sustiprintas
-01564315-s	lit:lemma	ramus
+02323358-a	lit:lemma	sustiprintas
+01564315-a	lit:lemma	ramus
 00409200-r	lit:lemma	neramiai
 09311259-n	lit:lemma	Indijos vandenynas
 09929298-n	lit:lemma	alpinistas
 10324851-n	lit:lemma	(sektinas) pavyzdys
 09213565-n	lit:lemma	pakrantė
-00766102-s	lit:lemma	sąžiningas
-00422168-s	lit:lemma	tepaluotas
+00766102-a	lit:lemma	sąžiningas
+00422168-a	lit:lemma	tepaluotas
 07142566-n	lit:lemma	suvažiavimas
-01246388-s	lit:lemma	nedraugiškas
+01246388-a	lit:lemma	nedraugiškas
 09622302-n	lit:lemma	mylimasis
 01215902-n	lit:lemma	parama
 02363358-a	lit:lemma	neimlus
 06604066-n	lit:lemma	esmė
 04407686-n	lit:lemma	šventovė
-01127147-s	lit:lemma	baisus
+01127147-a	lit:lemma	baisus
 04656996-n	lit:lemma	nepritapimas
-01991586-s	lit:lemma	tvirtas
-00432453-s	lit:lemma	skaidrus
+01991586-a	lit:lemma	tvirtas
+00432453-a	lit:lemma	skaidrus
 03519578-n	lit:lemma	kelias
 02733213-n	lit:lemma	arkada
 01235137-n	lit:lemma	atpildas
-00818175-s	lit:lemma	primityvus
-02119213-s	lit:lemma	rimtas
+00818175-a	lit:lemma	primityvus
+02119213-a	lit:lemma	rimtas
 05329735-n	lit:lemma	belatakė liauka
 03137130-a	lit:lemma	vestuvinis
 12901724-n	lit:lemma	uoginė paprika
 03160309-n	lit:lemma	užtvanka
 00059854-r	lit:lemma	vis daugiau
-00966357-s	lit:lemma	senas
+00966357-a	lit:lemma	senas
 08056601-n	lit:lemma	kolektyvas
 00089408-r	lit:lemma	didžiai
 15271008-n	lit:lemma	pauzė
-01270486-s	lit:lemma	greitas
+01270486-a	lit:lemma	greitas
 06598915-n	lit:lemma	turinys
 10618342-n	lit:lemma	futbolininkas
 04417809-n	lit:lemma	teatras
@@ -2434,10 +2434,10 @@
 09089139-n	lit:lemma	Kentukis
 00236483-a	lit:lemma	beveidis
 00407535-n	lit:lemma	veiksmas
-02372520-s	lit:lemma	taisyklingas
+02372520-a	lit:lemma	taisyklingas
 00007347-n	lit:lemma	sukėlėjas
 10546633-n	lit:lemma	jūrininkas
-00813589-s	lit:lemma	pirminis
+00813589-a	lit:lemma	pirminis
 00903559-n	lit:lemma	fotografavimas
 00332069-r	lit:lemma	vienodai
 13279262-n	lit:lemma	atlyginimas
@@ -2451,10 +2451,10 @@
 06000400-n	lit:lemma	gamtos mokslas
 06355894-n	lit:lemma	programos kodas
 00027384-r	lit:lemma	tačiau
-02436025-s	lit:lemma	nepakenčiamas
+02436025-a	lit:lemma	nepakenčiamas
 03196598-n	lit:lemma	skaitmeninis rodytuvas
 06634376-n	lit:lemma	pranešimas
-01664015-s	lit:lemma	džiugus
+01664015-a	lit:lemma	džiugus
 05660937-n	lit:lemma	pedagogika
 03374570-n	lit:lemma	musgaudis
 05035353-n	lit:lemma	jėga
@@ -2467,27 +2467,27 @@
 06159473-n	lit:lemma	etika
 00794825-a	lit:lemma	dramatiškas
 09886220-n	lit:lemma	chamas
-01754873-s	lit:lemma	patvarus
+01754873-a	lit:lemma	patvarus
 00394803-n	lit:lemma	nulupimas
-01940472-s	lit:lemma	praktiškas
+01940472-a	lit:lemma	praktiškas
 09827683-n	lit:lemma	kūdikis
-00878086-s	lit:lemma	parengtinis
+00878086-a	lit:lemma	parengtinis
 03959936-n	lit:lemma	lėkštė
-00974697-s	lit:lemma	senoviškas
-01627315-s	lit:lemma	parazitinis
+00974697-a	lit:lemma	senoviškas
+01627315-a	lit:lemma	parazitinis
 08293982-n	lit:lemma	sąjunga
 10640620-n	lit:lemma	sutuoktinis
-01313649-s	lit:lemma	apleistas
+01313649-a	lit:lemma	apleistas
 00118965-r	lit:lemma	kadaise
 03191029-n	lit:lemma	kauliukas
 02684875-a	lit:lemma	šventinis
 01245618-n	lit:lemma	metimas
 03907654-n	lit:lemma	įkalinimo įstaiga
 02821071-a	lit:lemma	miesto
-00491320-s	lit:lemma	keistas
+00491320-a	lit:lemma	keistas
 00032803-r	lit:lemma	labai
 00510189-n	lit:lemma	puotavimas
-02302187-s	lit:lemma	tolydus
+02302187-a	lit:lemma	tolydus
 08999482-n	lit:lemma	Pietų Afrikos Respublika
 06473837-n	lit:lemma	paraiškos forma
 01225027-n	lit:lemma	įžeidimas
@@ -2507,7 +2507,7 @@
 01028655-n	lit:lemma	garbinimas
 01651896-a	lit:lemma	atšauktas
 05650329-n	lit:lemma	gebėjimas
-00438909-s	lit:lemma	nuovokus
+00438909-a	lit:lemma	nuovokus
 00390581-n	lit:lemma	skiemenavimas
 01508368-v	lit:lemma	sviesti
 02857477-n	lit:lemma	pensionas
@@ -2531,7 +2531,7 @@
 01033189-v	lit:lemma	komentuoti
 06667317-n	lit:lemma	kodeksas
 08240169-n	lit:lemma	grupė
-00566342-s	lit:lemma	kaimyninis
+00566342-a	lit:lemma	kaimyninis
 14543552-n	lit:lemma	rizikingumas
 07995453-n	lit:lemma	guotas
 07200527-n	lit:lemma	atsakymas
@@ -2540,43 +2540,43 @@
 01992503-v	lit:lemma	judėti į priekį
 07456906-n	lit:lemma	susitikimas
 05074774-n	lit:lemma	padėtis
-01826979-s	lit:lemma	stiprus
-01243102-s	lit:lemma	siaubingas
+01826979-a	lit:lemma	stiprus
+01243102-a	lit:lemma	siaubingas
 05130875-n	lit:lemma	atstumas jardais
 00023646-v	lit:lemma	nualpti
 06200617-n	lit:lemma	pritarimas
 01518386-a	lit:lemma	kareiviškas
 09815790-n	lit:lemma	asistentas
 08163273-n	lit:lemma	įstatymų leidžiamoji valdžia
-00789494-s	lit:lemma	nuolankus
+00789494-a	lit:lemma	nuolankus
 04518764-n	lit:lemma	lagaminėlis
 04967801-n	lit:lemma	pilkšvai žalia spalva
 01277974-v	lit:lemma	užlenkti
 14445379-n	lit:lemma	komfortas
 00061528-r	lit:lemma	netikėtai
-01916979-s	lit:lemma	įtartinas
-01712753-s	lit:lemma	jautrus
+01916979-a	lit:lemma	įtartinas
+01712753-a	lit:lemma	jautrus
 00269258-n	lit:lemma	atkūrimas
 00919542-a	lit:lemma	sujaudintas
 09048880-n	lit:lemma	Naujoji Anglija
 03679712-n	lit:lemma	svečių kambarys
 00176150-a	lit:lemma	palankus
-01916784-s	lit:lemma	problematiškas
+01916784-a	lit:lemma	problematiškas
 03440512-n	lit:lemma	gaublys
 13910384-n	lit:lemma	vieta
 01825237-v	lit:lemma	trokšti
 10334567-n	lit:lemma	alpinistas
 00034634-v	lit:lemma	suraukti
 08482113-n	lit:lemma	sparnas
-02336109-s	lit:lemma	užtenkamas
+02336109-a	lit:lemma	užtenkamas
 06518068-n	lit:lemma	kuponas
 02603699-v	lit:lemma	egzistuoti
 00802238-n	lit:lemma	rizikinga situacija
-00014490-s	lit:lemma	apstus
+00014490-a	lit:lemma	apstus
 05850624-n	lit:lemma	aspektas
 08688247-n	lit:lemma	zona
 01216670-v	lit:lemma	palaikyti
-01564881-s	lit:lemma	suakmenėjęs
+01564881-a	lit:lemma	suakmenėjęs
 09254614-n	lit:lemma	žemynas
 09020440-n	lit:lemma	Kirgizijos Respublika
 00374135-v	lit:lemma	sušalti
@@ -2586,9 +2586,9 @@
 01845477-n	lit:lemma	žąsiniai paukščiai
 00032613-n	lit:lemma	nuosavybė
 02136271-v	lit:lemma	atspindėti
-01124768-s	lit:lemma	priimtinas
+01124768-a	lit:lemma	priimtinas
 14520518-n	lit:lemma	oro masė
-00624576-s	lit:lemma	gerokas
+00624576-a	lit:lemma	gerokas
 13901585-n	lit:lemma	lašelis
 09820263-n	lit:lemma	atletas
 10709435-n	lit:lemma	baudžiauninkas
@@ -2603,12 +2603,12 @@
 02435671-a	lit:lemma	nepakeliamas
 08191532-n	lit:lemma	karinio jūrų laivyno dalinys
 01528069-v	lit:lemma	įdėti
-00176387-s	lit:lemma	perspektyvus, daug žadantis
+00176387-a	lit:lemma	perspektyvus, daug žadantis
 00270275-n	lit:lemma	atkūrimas
 09972661-n	lit:lemma	galvijų prižiūrėtojas
 05499379-n	lit:lemma	pagumburis
 02427103-v	lit:lemma	steigti
-00049879-s	lit:lemma	pridėtinis
+00049879-a	lit:lemma	pridėtinis
 04782116-n	lit:lemma	siaubingumas
 01091905-n	lit:lemma	prekiavimas
 14744698-n	lit:lemma	amilo alkoholis
@@ -2619,13 +2619,13 @@
 06376154-n	lit:lemma	drama
 09075842-n	lit:lemma	Džordžija
 00033955-v	lit:lemma	gūžtelėti pečiais
-01086915-s	lit:lemma	nuogas
-01230616-s	lit:lemma	pasimetęs
+01086915-a	lit:lemma	nuogas
+01230616-a	lit:lemma	pasimetęs
 15180528-n	lit:lemma	metas
 08672738-n	lit:lemma	gyvenvietė
 00151087-n	lit:lemma	susekimas
 08119397-n	lit:lemma	tiekimo skyrius
-00792202-s	lit:lemma	pagrindinis
+00792202-a	lit:lemma	pagrindinis
 09225146-n	lit:lemma	vandens telkinys
 10164747-n	lit:lemma	valstybės galva
 00803617-n	lit:lemma	kontrolė
@@ -2633,7 +2633,7 @@
 02395406-n	lit:lemma	paršas
 00100592-r	lit:lemma	anksti
 03871083-n	lit:lemma	paketas
-00866987-s	lit:lemma	skatinantis
+00866987-a	lit:lemma	skatinantis
 10066624-n	lit:lemma	evakuotasis
 04520170-n	lit:lemma	furgonas
 00068215-r	lit:lemma	visą laiką
@@ -2652,18 +2652,18 @@
 07526338-n	lit:lemma	saugumo pojūtis
 00402128-n	lit:lemma	pasikeitimas
 00098385-n	lit:lemma	mechanizmas
-02077904-s	lit:lemma	pakvaišęs
-01951197-s	lit:lemma	netašytas
+02077904-a	lit:lemma	pakvaišęs
+01951197-a	lit:lemma	netašytas
 00011516-r	lit:lemma	blogai
 13366693-n	lit:lemma	kapitalo kaupimas
 02122164-v	lit:lemma	sopėti
 00258175-r	lit:lemma	nemokamai
-00668208-s	lit:lemma	dabartinis
+00668208-a	lit:lemma	dabartinis
 00804502-a	lit:lemma	vienodas
 03141609-a	lit:lemma	rasinis
 10189776-n	lit:lemma	namų šeimininkė
 00160440-r	lit:lemma	glaudžiai
-02397119-s	lit:lemma	vaisinis
+02397119-a	lit:lemma	vaisinis
 06074507-n	lit:lemma	algologija
 14616181-n	lit:lemma	subero rūgštis
 00485431-a	lit:lemma	paaukštintas
@@ -2672,10 +2672,10 @@
 00608808-v	lit:lemma	samprotauti
 01137597-n	lit:lemma	nesiekianti pelno organizacija
 10748309-n	lit:lemma	bažnyčios prižiūrėtojas
-01640261-s	lit:lemma	ilgametis
+01640261-a	lit:lemma	ilgametis
 06802571-n	lit:lemma	pranašas
 04645599-n	lit:lemma	nenoras
-02341864-s	lit:lemma	pirmarūšis
+02341864-a	lit:lemma	pirmarūšis
 01910965-v	lit:lemma	praeiti
 01232635-a	lit:lemma	horizontalus
 00693780-v	lit:lemma	laikyti
@@ -2689,7 +2689,7 @@
 14930476-n	lit:lemma	lauro rūgštis
 09119277-n	lit:lemma	Niujorkas
 02899666-a	lit:lemma	kunigų
-00798491-s	lit:lemma	pasigėręs
+00798491-a	lit:lemma	pasigėręs
 00119578-r	lit:lemma	antra vertus
 02968473-n	lit:lemma	karieta
 14527171-n	lit:lemma	imunitetas
@@ -2698,7 +2698,7 @@
 11446067-n	lit:lemma	rūdgyslė
 00121286-r	lit:lemma	akademiškai
 00284101-n	lit:lemma	pasivaikščiojimas
-00848983-s	lit:lemma	privalomas
+00848983-a	lit:lemma	privalomas
 07286278-n	lit:lemma	karo nuotaika
 15105268-n	lit:lemma	rašomasis popierius
 00831651-v	lit:lemma	pranešti
@@ -2706,24 +2706,24 @@
 04564698-n	lit:lemma	kelias
 01482228-a	lit:lemma	netekėjusi
 06174404-n	lit:lemma	gramatika
-00967646-s	lit:lemma	absurdiškas
+00967646-a	lit:lemma	absurdiškas
 05836468-n	lit:lemma	suvokimas
 00529266-a	lit:lemma	santūrus
 13679855-n	lit:lemma	guldenas
 00605516-a	lit:lemma	tradicinis
 01471848-a	lit:lemma	pilnametis
 05131283-n	lit:lemma	pakyla
-01443097-s	lit:lemma	momentalus
+01443097-a	lit:lemma	momentalus
 00027167-n	lit:lemma	vieta
 02963821-n	lit:lemma	mašinos durelės
-02574481-s	lit:lemma	miškinis
+02574481-a	lit:lemma	miškinis
 05837850-n	lit:lemma	idėja
 12709901-n	lit:lemma	mandarininis citrinmedis
 01047937-n	lit:lemma	regeneravimas
 10071332-n	lit:lemma	išeivis
 02914213-a	lit:lemma	gydomasis
 05941423-n	lit:lemma	tikėjimas
-00015720-s	lit:lemma	apstus
+00015720-a	lit:lemma	apstus
 05999266-n	lit:lemma	sritis
 14599168-n	lit:lemma	acto rūgštis
 03613592-n	lit:lemma	klavišas
@@ -2733,15 +2733,15 @@
 10157744-n	lit:lemma	neišmanėlis
 09906538-n	lit:lemma	didvyris
 00112828-n	lit:lemma	pelės spustelėjimas
-01451768-s	lit:lemma	palaimingas
+01451768-a	lit:lemma	palaimingas
 07204911-n	lit:lemma	neigiamas atsakymas
 15072857-n	lit:lemma	timinas
-00421875-s	lit:lemma	purvinas
+00421875-a	lit:lemma	purvinas
 10027476-n	lit:lemma	dvigubas agentas
 10278128-n	lit:lemma	mama
 13649268-n	lit:lemma	ilgio matavimo vienetas
 01754421-a	lit:lemma	ilgalaikis
-02186338-s	lit:lemma	vienetas
+02186338-a	lit:lemma	vienetas
 10077593-n	lit:lemma	sirgalius
 02959406-a	lit:lemma	sovietinis
 04399382-n	lit:lemma	pliušinis meškiukas
@@ -2752,7 +2752,7 @@
 01186397-n	lit:lemma	sužlugimas
 04664413-n	lit:lemma	atsargumas
 09078231-n	lit:lemma	Havajai
-00021110-s	lit:lemma	malonus
+00021110-a	lit:lemma	malonus
 00163590-r	lit:lemma	bet kaip
 00426958-v	lit:lemma	išnykti
 00372660-r	lit:lemma	apdairiai
@@ -2760,7 +2760,7 @@
 15245990-n	lit:lemma	valgis
 13356112-n	lit:lemma	pinigų ištekliai
 11416988-n	lit:lemma	padarinys
-01935935-s	lit:lemma	pramanytas
+01935935-a	lit:lemma	pramanytas
 14857897-n	lit:lemma	griuvėsiai
 04264914-n	lit:lemma	kosminis aparatas
 06598915-n	lit:lemma	tema
@@ -2777,12 +2777,12 @@
 10009484-n	lit:lemma	detektyvas
 10084295-n	lit:lemma	mergaitė
 13959818-n	lit:lemma	nebuvimas
-01007258-s	lit:lemma	limitinis
+01007258-a	lit:lemma	limitinis
 05200169-n	lit:lemma	sugebėjimas
-01285136-s	lit:lemma	didingas
+01285136-a	lit:lemma	didingas
 02547586-v	lit:lemma	padėti
 00065575-r	lit:lemma	ilgokai
-00179190-s	lit:lemma	šventasis
+00179190-a	lit:lemma	šventasis
 07035870-n	lit:lemma	giesmė
 13774404-n	lit:lemma	aibė
 01083077-n	lit:lemma	išdalijimas
@@ -2790,24 +2790,24 @@
 04663319-n	lit:lemma	nedėmesingumas
 00140652-n	lit:lemma	naudojimas
 10470460-n	lit:lemma	taikinys
-01074582-s	lit:lemma	sūrokas
+01074582-a	lit:lemma	sūrokas
 11469691-n	lit:lemma	infraraudonasis spektras
-02384077-s	lit:lemma	šnekus
+02384077-a	lit:lemma	šnekus
 02771564-v	lit:lemma	permerkti
 02660442-v	lit:lemma	įvykti kartu
 00293650-r	lit:lemma	irzliai
 14504726-n	lit:lemma	iškrypimas
-01126291-s	lit:lemma	klaikus
+01126291-a	lit:lemma	klaikus
 05646926-n	lit:lemma	sunkiausia silpnaprotystė
 14504726-n	lit:lemma	nukrypimas
 09429387-n	lit:lemma	segmentas
-00808011-s	lit:lemma	blankus
+00808011-a	lit:lemma	blankus
 01379705-a	lit:lemma	paženklintas
 00283235-r	lit:lemma	be galo
 10403162-n	lit:lemma	partijos pirmininkas
 01052372-n	lit:lemma	orientacija
 05002822-n	lit:lemma	laikysena
-00792075-s	lit:lemma	valdantysis
+00792075-a	lit:lemma	valdantysis
 10660333-n	lit:lemma	melagis
 00260622-n	lit:lemma	pertvarkymas
 02267060-v	lit:lemma	išleisti
@@ -2817,25 +2817,25 @@
 02691156-n	lit:lemma	lėktuvas
 02151625-n	lit:lemma	sparnas
 00465341-r	lit:lemma	visiškai
-00066146-s	lit:lemma	rizikingas
+00066146-a	lit:lemma	rizikingas
 00066191-v	lit:lemma	ašaroti
 06734322-n	lit:lemma	daiktinis įrodymas
-01385255-s	lit:lemma	milžiniškas
+01385255-a	lit:lemma	milžiniškas
 00882802-v	lit:lemma	atminti
 00074624-n	lit:lemma	aplaidumas
-00803432-s	lit:lemma	rėžiantis
+00803432-a	lit:lemma	rėžiantis
 05264247-n	lit:lemma	šašas
 03416329-n	lit:lemma	tarpas
 05106928-n	lit:lemma	smulkumas
 14461231-n	lit:lemma	visybė
-01501821-s	lit:lemma	melodingas
+01501821-a	lit:lemma	melodingas
 00187028-r	lit:lemma	puikiai
 09535622-n	lit:lemma	deivė
-01265308-s	lit:lemma	juokingas
+01265308-a	lit:lemma	juokingas
 09079505-n	lit:lemma	Havajai
 07531255-n	lit:lemma	pasitenkinimas
 07837362-n	lit:lemma	baltasis padažas
-02576489-s	lit:lemma	medinis
+02576489-a	lit:lemma	medinis
 05855125-n	lit:lemma	kiekis
 07502669-n	lit:lemma	bjaurėjimasis
 01023820-n	lit:lemma	procedūra
@@ -2844,12 +2844,12 @@
 05279688-n	lit:lemma	mentikaulis
 00161294-r	lit:lemma	ženkliai
 03029573-a	lit:lemma	cezario
-01818077-s	lit:lemma	konstruktyvus
+01818077-a	lit:lemma	konstruktyvus
 03051249-n	lit:lemma	skalbinių spaustukas
 06369829-n	lit:lemma	apsakymas
 08397255-n	lit:lemma	armija
-00764484-s	lit:lemma	atviras
-00357556-s	lit:lemma	originalus
+00764484-a	lit:lemma	atviras
+00357556-a	lit:lemma	originalus
 02736808-a	lit:lemma	grafiškas
 07544647-n	lit:lemma	mėgimas
 04845475-n	lit:lemma	žiaurumas
@@ -2863,11 +2863,11 @@
 04164529-n	lit:lemma	antra pavara
 07235335-n	lit:lemma	kaltinamasis aktas
 03015441-a	lit:lemma	keraminis
-00491511-s	lit:lemma	unikalus
+00491511-a	lit:lemma	unikalus
 05151372-n	lit:lemma	funkcionalumas
 03141609-a	lit:lemma	rasių
 09018030-n	lit:lemma	Jerevanas
-01230616-s	lit:lemma	bejėgis
+01230616-a	lit:lemma	bejėgis
 05491461-n	lit:lemma	didžioji jungtis
 03179701-n	lit:lemma	rašomasis stalas
 15267536-n	lit:lemma	galas
@@ -2875,8 +2875,8 @@
 04748836-n	lit:lemma	skirtingumas
 01552885-a	lit:lemma	nedaug
 03102859-n	lit:lemma	aušinimas
-02522938-s	lit:lemma	vegetacinis
-01871473-s	lit:lemma	pajamingas
+02522938-a	lit:lemma	vegetacinis
+01871473-a	lit:lemma	pajamingas
 00411009-a	lit:lemma	krikščioniškas
 05100156-n	lit:lemma	slenkstinis lygis
 00831191-n	lit:lemma	kvėpavimas
@@ -2893,35 +2893,35 @@
 05948264-n	lit:lemma	religinis kultas
 14865800-n	lit:lemma	geležies oksidas
 08426461-n	lit:lemma	junginys
-00279092-s	lit:lemma	spindintis
+00279092-a	lit:lemma	spindintis
 10047030-n	lit:lemma	inteligentas
 06777164-n	lit:lemma	ironija
 00281132-n	lit:lemma	įėjimas
 03945167-n	lit:lemma	pypkė
 07196682-n	lit:lemma	klausimas
 00204439-n	lit:lemma	atsisakymas
-01500247-s	lit:lemma	mašinalus
+01500247-a	lit:lemma	mašinalus
 04650201-n	lit:lemma	humoro jausmas
 04976952-n	lit:lemma	odos spalva
 04407435-n	lit:lemma	šventykla
 04332243-n	lit:lemma	sietas
 03277771-n	lit:lemma	elektroninis įtaisas
-01474942-s	lit:lemma	pavaldus
-02302187-s	lit:lemma	reguliarus
+01474942-a	lit:lemma	pavaldus
+02302187-a	lit:lemma	reguliarus
 01811682-n	lit:lemma	karveliniai
 02109190-v	lit:lemma	patirti
-02481012-s	lit:lemma	padalintas
+02481012-a	lit:lemma	padalintas
 06724559-n	lit:lemma	paradoksas
 13464820-n	lit:lemma	vystymasis
 01182709-v	lit:lemma	tiekti
-01046226-s	lit:lemma	įprastas
+01046226-a	lit:lemma	įprastas
 04205759-n	lit:lemma	kulka
 14573713-n	lit:lemma	veninis mazgas
 02961505-a	lit:lemma	Vengrijos
 13308147-n	lit:lemma	mokestis už važiavimą
-00974159-s	lit:lemma	nemadingas
-01822563-s	lit:lemma	įvykdomas
-00972642-s	lit:lemma	šiuolaikinis
+00974159-a	lit:lemma	nemadingas
+01822563-a	lit:lemma	įvykdomas
+00972642-a	lit:lemma	šiuolaikinis
 09114696-n	lit:lemma	Naujoji Meksika
 09867956-n	lit:lemma	darbdavys
 03075191-a	lit:lemma	iranietiškas
@@ -2941,17 +2941,17 @@
 08739047-n	lit:lemma	Managva
 03739518-n	lit:lemma	gydymo įstaiga
 00075708-v	lit:lemma	nualinti
-01265308-s	lit:lemma	komiškas
-02312450-s	lit:lemma	kreivas
+01265308-a	lit:lemma	komiškas
+02312450-a	lit:lemma	kreivas
 03231912-n	lit:lemma	kanalizacijos vamzdis
 02914991-n	lit:lemma	kompleksas
 04891333-n	lit:lemma	neapdairumas
 05269901-n	lit:lemma	kaulas
-01931926-s	lit:lemma	laukiantis
+01931926-a	lit:lemma	laukiantis
 15295778-n	lit:lemma	trukmė
 00035758-v	lit:lemma	prausti
-01154030-s	lit:lemma	švelnus
-01784217-s	lit:lemma	netikintis
+01154030-a	lit:lemma	švelnus
+01784217-a	lit:lemma	netikintis
 02927303-a	lit:lemma	Amerikos
 00290579-n	lit:lemma	maršas
 01826723-v	lit:lemma	viltis
@@ -2964,7 +2964,7 @@
 06208751-n	lit:lemma	perspektyva
 07738353-n	lit:lemma	žievė
 07212190-n	lit:lemma	pranešimas
-01627315-s	lit:lemma	parazitiškas
+01627315-a	lit:lemma	parazitiškas
 00309906-n	lit:lemma	safaris
 04079933-n	lit:lemma	rezistorius
 02131418-n	lit:lemma	lokiniai
@@ -2974,12 +2974,12 @@
 14422035-n	lit:lemma	nepertraukiamumas
 14442530-n	lit:lemma	viešpatavimas
 14625458-n	lit:lemma	metalas
-01134486-s	lit:lemma	ramus
+01134486-a	lit:lemma	ramus
 04565233-n	lit:lemma	pakelė
 13745086-n	lit:lemma	aštuonetas
 02784218-n	lit:lemma	juosta
 14985383-n	lit:lemma	dažai
-00486990-s	lit:lemma	dažnas
+00486990-a	lit:lemma	dažnas
 02069355-a	lit:lemma	kitas
 07827750-n	lit:lemma	aguona
 01025913-a	lit:lemma	bekompromisis
@@ -2990,17 +2990,17 @@
 05031726-n	lit:lemma	tvirtumas
 02847894-a	lit:lemma	finansinis
 00294459-r	lit:lemma	taigi
-00796715-s	lit:lemma	teatriškas
+00796715-a	lit:lemma	teatriškas
 00075998-v	lit:lemma	pervarginti
 04223580-n	lit:lemma	kriauklė
 03127531-n	lit:lemma	apsauginis atitvaras
-02571277-s	lit:lemma	beprasmiškas
+02571277-a	lit:lemma	beprasmiškas
 01247413-n	lit:lemma	emancipacija
-01119661-s	lit:lemma	glazūruotas
+01119661-a	lit:lemma	glazūruotas
 03429914-n	lit:lemma	gazas (audinys)
 00392848-n	lit:lemma	atskyrimas
 00406234-n	lit:lemma	išlenkimas
-02477211-s	lit:lemma	sujungtas
+02477211-a	lit:lemma	sujungtas
 00459498-v	lit:lemma	paskubėti
 09957523-n	lit:lemma	konservatorius
 04344246-n	lit:lemma	ateljė
@@ -3009,7 +3009,7 @@
 02940392-a	lit:lemma	eksperimentinis
 02959007-a	lit:lemma	Portugalijos
 01034312-v	lit:lemma	diskutuoti
-02503305-s	lit:lemma	nereikalingas
+02503305-a	lit:lemma	nereikalingas
 00105820-n	lit:lemma	perdavimas
 03270695-n	lit:lemma	elektrinis skambutis
 02763740-v	lit:lemma	šviesti
@@ -3021,7 +3021,7 @@
 03129123-n	lit:lemma	dirbinys
 01563945-n	lit:lemma	paprastasis nykštukas
 06770275-n	lit:lemma	prekyba
-00202095-s	lit:lemma	atvirkščias
+00202095-a	lit:lemma	atvirkščias
 07514520-n	lit:lemma	neramumai
 00828990-n	lit:lemma	imunizavimas
 00229260-n	lit:lemma	sustabdymas
@@ -3030,7 +3030,7 @@
 02879718-n	lit:lemma	lankas
 01778212-a	lit:lemma	fizinis
 08182379-n	lit:lemma	būrys
-01574259-s	lit:lemma	materialus
+01574259-a	lit:lemma	materialus
 09813632-n	lit:lemma	kvailys
 06613686-n	lit:lemma	kino filmas
 11410625-n	lit:lemma	poveikis
@@ -3040,7 +3040,7 @@
 13857486-n	lit:lemma	prieštaringumas
 04766275-n	lit:lemma	sudėtingumas
 01760944-a	lit:lemma	leistinas
-01723648-s	lit:lemma	bejausmis
+01723648-a	lit:lemma	bejausmis
 00267349-n	lit:lemma	lopymas
 02139544-v	lit:lemma	reikštis
 10180178-n	lit:lemma	savininkas
@@ -3058,13 +3058,13 @@
 08964810-n	lit:lemma	Malajos pusiasalis
 07374633-n	lit:lemma	kietėjimas
 09903153-n	lit:lemma	įžymybė
-02433975-s	lit:lemma	išsekęs
+02433975-a	lit:lemma	išsekęs
 06598915-n	lit:lemma	dalykas
 00804802-v	lit:lemma	nesutikti
 13405166-n	lit:lemma	žurnalas
 09767197-n	lit:lemma	darbuotojas
 08504594-n	lit:lemma	dykvietė
-00595299-s	lit:lemma	nepaliaujamas
+00595299-a	lit:lemma	nepaliaujamas
 00023271-n	lit:lemma	mokėjimas
 10388924-n	lit:lemma	valdytojas
 00040547-r	lit:lemma	nelauktai
@@ -3076,41 +3076,41 @@
 02951843-n	lit:lemma	tentas
 02621244-v	lit:lemma	sudaryti
 02335828-a	lit:lemma	pakankamas
-01439784-s	lit:lemma	nesibaigiantis
-01783522-s	lit:lemma	bažnytinis
-02059381-s	lit:lemma	rizikingas
+01439784-a	lit:lemma	nesibaigiantis
+01783522-a	lit:lemma	bažnytinis
+02059381-a	lit:lemma	rizikingas
 05019339-n	lit:lemma	nepastebimumas
 00052500-n	lit:lemma	nutūpimas
 07291794-n	lit:lemma	galas
-02291336-s	lit:lemma	tvirtas
+02291336-a	lit:lemma	tvirtas
 04437953-n	lit:lemma	laikrodis
 13623856-n	lit:lemma	centilitras
-01968165-s	lit:lemma	kasdienis
+01968165-a	lit:lemma	kasdienis
 13996719-n	lit:lemma	engimas
 08250501-n	lit:lemma	roko grupė
-00669853-s	lit:lemma	prakeiktas
+00669853-a	lit:lemma	prakeiktas
 00030142-v	lit:lemma	kikenti
 00364787-n	lit:lemma	staigus padidėjimas
 05281189-n	lit:lemma	krūtinkaulis
-01982957-s	lit:lemma	gerbiamas
+01982957-a	lit:lemma	gerbiamas
 01925372-a	lit:lemma	racionalus
-02179968-s	lit:lemma	atviras
+02179968-a	lit:lemma	atviras
 04154152-n	lit:lemma	sraigtas
 02526085-v	lit:lemma	įvykdyti
-00213610-s	lit:lemma	plaukuotas
+00213610-a	lit:lemma	plaukuotas
 02790222-a	lit:lemma	agrikultūrinis
 08223802-n	lit:lemma	gyvenvietė
 00803617-n	lit:lemma	reguliavimas
 10162991-n	lit:lemma	galva
 00094396-r	lit:lemma	žemutiniame aukšte
 15055442-n	lit:lemma	vandens garai
-00599005-s	lit:lemma	sulaikytas
+00599005-a	lit:lemma	sulaikytas
 04118021-n	lit:lemma	kilimas
 04453910-n	lit:lemma	dangtis
 07450842-n	lit:lemma	ceremonija
-01276482-s	lit:lemma	svarbiausias
+01276482-a	lit:lemma	svarbiausias
 03581125-n	lit:lemma	kryžkelė
-00447472-s	lit:lemma	artimiausias
+00447472-a	lit:lemma	artimiausias
 07959016-n	lit:lemma	susumavimas
 07066659-n	lit:lemma	stilius
 00034189-r	lit:lemma	trumpai
@@ -3118,17 +3118,17 @@
 08892766-n	lit:lemma	Lodianas
 10435988-n	lit:lemma	metėjas
 02997740-a	lit:lemma	įsipareigojantis
-02065958-s	lit:lemma	priešingas
+02065958-a	lit:lemma	priešingas
 13968547-n	lit:lemma	tvarka
-01167540-s	lit:lemma	jėgų atgavimo
+01167540-a	lit:lemma	jėgų atgavimo
 00008997-r	lit:lemma	visai
 07635155-n	lit:lemma	sausainis
-01199083-s	lit:lemma	nevienodas
+01199083-a	lit:lemma	nevienodas
 07496463-n	lit:lemma	sielvartas
 00358985-r	lit:lemma	kas valandą
 08008017-n	lit:lemma	pėdas
 03673027-n	lit:lemma	laineris
-00969556-s	lit:lemma	keistas
+00969556-a	lit:lemma	keistas
 05949726-n	lit:lemma	tautos balsas
 00250259-n	lit:lemma	vystymas
 02724630-a	lit:lemma	egzistencializmo
@@ -3142,45 +3142,45 @@
 10085736-n	lit:lemma	feodalas
 04037625-n	lit:lemma	lenktynių trasa
 13903079-n	lit:lemma	riba
-01492907-s	lit:lemma	vaikiškas
+01492907-a	lit:lemma	vaikiškas
 00349520-n	lit:lemma	klavišo paspaudimas
-00326608-s	lit:lemma	karštagalviškas
-00202095-s	lit:lemma	atbulas
+00326608-a	lit:lemma	karštagalviškas
+00202095-a	lit:lemma	atbulas
 11448153-n	lit:lemma	smėlio audra
 00120474-r	lit:lemma	sistemingai
 02015598-v	lit:lemma	išvažiuoti
 00177483-r	lit:lemma	švelniai
 00084223-r	lit:lemma	labai
-01475160-s	lit:lemma	valdomas
+01475160-a	lit:lemma	valdomas
 02271137-v	lit:lemma	investuoti
 07965937-n	lit:lemma	pasaulis
 11682349-n	lit:lemma	sėklos luobelė
 02761897-v	lit:lemma	užpūsti
 12352287-n	lit:lemma	bananas
 07859284-n	lit:lemma	rafinuotas cukrus
-01577327-s	lit:lemma	magiškas
+01577327-a	lit:lemma	magiškas
 05027529-n	lit:lemma	svoris
-01977488-s	lit:lemma	rūpestingas
+01977488-a	lit:lemma	rūpestingas
 00023271-n	lit:lemma	supratimas
-00901969-s	lit:lemma	reikšmingas
+00901969-a	lit:lemma	reikšmingas
 13305673-n	lit:lemma	įvertinimas
-00179035-s	lit:lemma	patvirtintas
+00179035-a	lit:lemma	patvirtintas
 00077168-r	lit:lemma	skaisčiai
 00626800-a	lit:lemma	medžiaginis
 15164957-n	lit:lemma	dienos metas
 09906986-n	lit:lemma	kancleris
 04648207-n	lit:lemma	frivoliškumas
-01419784-s	lit:lemma	metaforinis
+01419784-a	lit:lemma	metaforinis
 00624738-n	lit:lemma	treniruotė
 08737376-n	lit:lemma	Gvatemala
 07007945-n	lit:lemma	drama
 00456199-n	lit:lemma	varžybos
 10197525-n	lit:lemma	debilas
-02000968-s	lit:lemma	perdėtas
-02342899-s	lit:lemma	kokybiškas
+02000968-a	lit:lemma	perdėtas
+02342899-a	lit:lemma	kokybiškas
 06473940-n	lit:lemma	paraiškos forma
 03849814-n	lit:lemma	operos teatras
-01878870-s	lit:lemma	moralus
+01878870-a	lit:lemma	moralus
 00077458-v	lit:lemma	žiaukčioti
 08242675-n	lit:lemma	profesinė sąjunga
 00397760-n	lit:lemma	ištrynimas
@@ -3197,14 +3197,14 @@
 09696585-n	lit:lemma	kanadietė
 10043643-n	lit:lemma	ekonomistas
 14460565-n	lit:lemma	vieningumas
-00847715-s	lit:lemma	veltui duodamas
+00847715-a	lit:lemma	veltui duodamas
 10319796-n	lit:lemma	kalnakasys
 02122725-n	lit:lemma	katinas
 13272545-n	lit:lemma	nemokamas priedas
 00948103-a	lit:lemma	išorinis
-00438909-s	lit:lemma	įžvalgus
-00018850-s	lit:lemma	prieštarautinas
-01662119-s	lit:lemma	nesavalaikis
+00438909-a	lit:lemma	įžvalgus
+00018850-a	lit:lemma	prieštarautinas
+01662119-a	lit:lemma	nesavalaikis
 08407619-n	lit:lemma	ekspozicija
 14464675-n	lit:lemma	klaida programoje
 00294868-n	lit:lemma	šliaužimas
@@ -3217,9 +3217,9 @@
 01619929-v	lit:lemma	ardyti
 10694258-n	lit:lemma	mokytojas
 01871680-v	lit:lemma	spausti
-00995647-s	lit:lemma	atvirkščias
-01563494-s	lit:lemma	paslankus
-02024928-s	lit:lemma	prabangus
+00995647-a	lit:lemma	atvirkščias
+01563494-a	lit:lemma	paslankus
+02024928-a	lit:lemma	prabangus
 00513761-n	lit:lemma	stumdymasis
 01567862-a	lit:lemma	nacionalinis
 14580897-n	lit:lemma	medžiaga
@@ -3228,12 +3228,12 @@
 00550771-n	lit:lemma	spektaklis
 06355894-n	lit:lemma	kodas
 10804406-n	lit:lemma	jaunuolis
-01199083-s	lit:lemma	mišrus
+01199083-a	lit:lemma	mišrus
 06943771-n	lit:lemma	slavų kalba
 00724081-a	lit:lemma	patikimas
 04081281-n	lit:lemma	valgomasis
 05217168-n	lit:lemma	žmogaus kūnas
-00195684-s	lit:lemma	šiurpus
+00195684-a	lit:lemma	šiurpus
 01481612-a	lit:lemma	susituokęs
 10194969-n	lit:lemma	higienistas
 15254028-n	lit:lemma	istorinis laikotarpis
@@ -3249,7 +3249,7 @@
 08948155-n	lit:lemma	Gviana
 01247240-a	lit:lemma	karštas
 11665781-n	lit:lemma	dviskilčiai
-00016647-s	lit:lemma	žaliuojantis
+00016647-a	lit:lemma	žaliuojantis
 02765464-v	lit:lemma	susiurbti
 06037666-n	lit:lemma	biologija
 15279957-n	lit:lemma	megahercas
@@ -3260,8 +3260,8 @@
 00147876-r	lit:lemma	lengvai
 00112601-r	lit:lemma	neseniai
 01718867-a	lit:lemma	įžambus
-01252151-s	lit:lemma	labai šaltas
-00507292-s	lit:lemma	beširdis
+01252151-a	lit:lemma	labai šaltas
+00507292-a	lit:lemma	beširdis
 03025357-n	lit:lemma	pjaustymo lentelė
 06634376-n	lit:lemma	žinia
 04746430-n	lit:lemma	analogija
@@ -3269,18 +3269,18 @@
 02967791-a	lit:lemma	korėjiečių
 06478582-n	lit:lemma	diplomas
 00485264-r	lit:lemma	neįprastai
-01051814-s	lit:lemma	nelaimingas
+01051814-a	lit:lemma	nelaimingas
 08951777-n	lit:lemma	Fryzija
-01274945-s	lit:lemma	nusilpęs
-01384730-s	lit:lemma	kolosalus
+01274945-a	lit:lemma	nusilpęs
+01384730-a	lit:lemma	kolosalus
 00733044-v	lit:lemma	spręsti
 05417975-n	lit:lemma	kraujagyslė
-00545746-s	lit:lemma	nerūpestingas
-02347086-s	lit:lemma	apverktinas
+00545746-a	lit:lemma	nerūpestingas
+02347086-a	lit:lemma	apverktinas
 01560320-a	lit:lemma	nesujaudintas
 03426134-n	lit:lemma	degalų rezervuaras
 05650329-n	lit:lemma	įgūdis
-00168694-s	lit:lemma	žavus
+00168694-a	lit:lemma	žavus
 02790322-n	lit:lemma	užkarpa
 15243590-n	lit:lemma	amžinybė
 00293171-r	lit:lemma	susikryžiuojančiai
@@ -3292,16 +3292,16 @@
 15229144-n	lit:lemma	pikas
 01239868-n	lit:lemma	įsipareigojimas
 07121157-n	lit:lemma	šauksmas
-00927832-s	lit:lemma	nesantis
+00927832-a	lit:lemma	nesantis
 02202384-v	lit:lemma	palikti
 01069980-n	lit:lemma	pasninkas
-00349894-s	lit:lemma	paskutinis
+00349894-a	lit:lemma	paskutinis
 15284999-n	lit:lemma	lankomumas
 04633197-n	lit:lemma	gajumas
-00839225-s	lit:lemma	efektyvus
+00839225-a	lit:lemma	efektyvus
 12874783-n	lit:lemma	sezamas
 03208938-n	lit:lemma	diskiniai stabdžiai
-00421513-s	lit:lemma	drumzlinas
+00421513-a	lit:lemma	drumzlinas
 13412321-n	lit:lemma	žurnalas
 10173410-n	lit:lemma	didvyrė
 00976531-n	lit:lemma	įsiveržimas
@@ -3314,19 +3314,19 @@
 02991302-n	lit:lemma	kalėjimo kamera
 15262120-n	lit:lemma	procesas
 00263000-n	lit:lemma	dailinimas
-00743183-s	lit:lemma	dešinysis
+00743183-a	lit:lemma	dešinysis
 01418288-a	lit:lemma	išvardytas
 03322570-n	lit:lemma	pastatas
-02057226-s	lit:lemma	pasaulietinis
+02057226-a	lit:lemma	pasaulietinis
 02037272-a	lit:lemma	nedoras
 01810447-v	lit:lemma	šokiruoti
-01046553-s	lit:lemma	epistolinis
-00392093-s	lit:lemma	baltytėlaitis
+01046553-a	lit:lemma	epistolinis
+00392093-a	lit:lemma	baltytėlaitis
 00031899-r	lit:lemma	tikrai
 07621618-n	lit:lemma	papuošimas
 01655505-v	lit:lemma	kurti
 00003380-r	lit:lemma	erzinančiai
-00345494-s	lit:lemma	kintamas
+00345494-a	lit:lemma	kintamas
 15269513-n	lit:lemma	laiko tarpas
 00327824-n	lit:lemma	siūbavimas
 09955015-n	lit:lemma	apgavikas
@@ -3334,7 +3334,7 @@
 01654628-v	lit:lemma	pastatyti
 08547938-n	lit:lemma	susikryžiavimas
 02727825-n	lit:lemma	aparatas
-00168910-s	lit:lemma	žavingas
+00168910-a	lit:lemma	žavingas
 13972797-n	lit:lemma	suirutė
 00455599-n	lit:lemma	varžybos
 04894037-n	lit:lemma	neatsargumas
@@ -3342,32 +3342,32 @@
 10522035-n	lit:lemma	įgaliotinis
 06831926-n	lit:lemma	H
 02898121-a	lit:lemma	architektūrinis
-00059782-s	lit:lemma	nusagstytas
+00059782-a	lit:lemma	nusagstytas
 07037465-n	lit:lemma	muzikos kūrinys
 02890874-a	lit:lemma	kalnų
-02367319-s	lit:lemma	specialus
+02367319-a	lit:lemma	specialus
 08409617-n	lit:lemma	vidurinė mokykla
 06762711-n	lit:lemma	komentaras
 05582191-n	lit:lemma	guolis
 07516997-n	lit:lemma	pyktis
 08793914-n	lit:lemma	Galilėja
-01388062-s	lit:lemma	didžiulis
+01388062-a	lit:lemma	didžiulis
 04891333-n	lit:lemma	kvailumas
 15279104-n	lit:lemma	hercas
 01967240-a	lit:lemma	periodinis
-01610484-s	lit:lemma	nustatytas
+01610484-a	lit:lemma	nustatytas
 05395690-n	lit:lemma	skrandis
 02488705-a	lit:lemma	tranzityvinis
 14323683-n	lit:lemma	skausmas
 14740587-n	lit:lemma	sočioji riebalų rūgštis
 04827957-n	lit:lemma	nedorumas
-01722846-s	lit:lemma	dukteriškas
+01722846-a	lit:lemma	dukteriškas
 00942871-a	lit:lemma	nenaudojamas
 00459498-v	lit:lemma	skubėti
 00157528-r	lit:lemma	visiškai
 14495080-n	lit:lemma	higiena
 14382238-n	lit:lemma	specifinė fobija
-01251958-s	lit:lemma	šaltas
+01251958-a	lit:lemma	šaltas
 03030663-n	lit:lemma	cigaretė
 10261388-n	lit:lemma	baržos valtininkas
 15143012-n	lit:lemma	pradinė stadija
@@ -3381,29 +3381,29 @@
 07184545-n	lit:lemma	kivirčas
 04683814-n	lit:lemma	grožybė
 01044240-a	lit:lemma	neoficialus
-01619475-s	lit:lemma	aiškus
+01619475-a	lit:lemma	aiškus
 03598151-n	lit:lemma	štagburė
 15291498-n	lit:lemma	tarnybos laikotarpis
 08715390-n	lit:lemma	Mianmaras
-01763159-s	lit:lemma	nuolaidus
+01763159-a	lit:lemma	nuolaidus
 00533805-n	lit:lemma	tarantela
-00969264-s	lit:lemma	keistokas
+00969264-a	lit:lemma	keistokas
 00015953-r	lit:lemma	sunkiai
 05456945-n	lit:lemma	gameta
 08794574-n	lit:lemma	Golano aukštumos
 06651577-n	lit:lemma	aliuzija
-01620286-s	lit:lemma	neaiškus
+01620286-a	lit:lemma	neaiškus
 13725457-n	lit:lemma	centneris
 14642417-n	lit:lemma	geležis
 00059413-r	lit:lemma	daug
 06252954-n	lit:lemma	informacijos perdavimas
-01335903-s	lit:lemma	guvus
+01335903-a	lit:lemma	guvus
 00004394-r	lit:lemma	maloniai
 03051307-a	lit:lemma	bulgariškas
 14585519-n	lit:lemma	kruopelė
 00427829-r	lit:lemma	su apmokėtomis pašto išlaidomis
-01649651-s	lit:lemma	jaunyvas
-01882292-s	lit:lemma	apokaliptinis
+01649651-a	lit:lemma	jaunyvas
+01882292-a	lit:lemma	apokaliptinis
 09873899-n	lit:lemma	gyvulių augintojas
 00081486-r	lit:lemma	kiekvieną dieną
 08403631-n	lit:lemma	profesija
@@ -3416,12 +3416,12 @@
 09375223-n	lit:lemma	kometos branduolys
 07469772-n	lit:lemma	šuolis į aukštį
 05980875-n	lit:lemma	tikslas
-00970610-s	lit:lemma	įprastas
+00970610-a	lit:lemma	įprastas
 05970311-n	lit:lemma	empirizmas
 10021892-n	lit:lemma	mokslų daktaras
 00150671-r	lit:lemma	svarbiausia
 03118661-a	lit:lemma	slaviškas
-00392093-s	lit:lemma	sniego baltumo
+00392093-a	lit:lemma	sniego baltumo
 00123229-r	lit:lemma	ekonomikos požiūriu
 02439929-n	lit:lemma	letena
 02374451-n	lit:lemma	arklys
@@ -3430,7 +3430,7 @@
 01099109-n	lit:lemma	finansavimas
 00193406-n	lit:lemma	prisitaikymas
 04356056-n	lit:lemma	akiniai nuo saulės
-02406370-s	lit:lemma	neramus
+02406370-a	lit:lemma	neramus
 02961505-a	lit:lemma	vengriškas
 02724483-a	lit:lemma	egzistencijos
 00031974-a	lit:lemma	energingas
@@ -3444,15 +3444,15 @@
 04983122-n	lit:lemma	garso savybė
 03345487-n	lit:lemma	gaisrinis automobilis
 14526764-n	lit:lemma	atsparumas
-00487198-s	lit:lemma	bendras
+00487198-a	lit:lemma	bendras
 00424767-n	lit:lemma	nežmoniškumas
-01698231-s	lit:lemma	snieguotas
+01698231-a	lit:lemma	snieguotas
 13284283-n	lit:lemma	atpildas
 10197525-n	lit:lemma	silpnaprotis
 00956687-v	lit:lemma	apibūdinti
 01814385-a	lit:lemma	politinis
-01080900-s	lit:lemma	našus
-00768397-s	lit:lemma	nukrypstantis
+01080900-a	lit:lemma	našus
+00768397-a	lit:lemma	nukrypstantis
 06407372-n	lit:lemma	rankraščių rinkinys
 02530167-v	lit:lemma	bandyti
 12268918-n	lit:lemma	ąžuolas
@@ -3467,44 +3467,44 @@
 01216670-v	lit:lemma	turėti
 01525776-a	lit:lemma	kelioninis
 00268557-n	lit:lemma	restauravimas
-00746047-s	lit:lemma	nepatogus
-00511739-s	lit:lemma	neefektyvus
+00746047-a	lit:lemma	nepatogus
+00511739-a	lit:lemma	neefektyvus
 04633197-n	lit:lemma	energingumas
 13686526-n	lit:lemma	Didžiosios Britanijos piniginis vienetas
 03103904-n	lit:lemma	arnotas
-01764895-s	lit:lemma	atsargumo
+01764895-a	lit:lemma	atsargumo
 01236947-n	lit:lemma	vendeta
 14724645-n	lit:lemma	antioksidantas
 04623113-n	lit:lemma	natūra
 13953467-n	lit:lemma	pilietybė
-00228294-s	lit:lemma	geriausias
+00228294-a	lit:lemma	geriausias
 00348247-r	lit:lemma	džiaugsmingai
 08956760-n	lit:lemma	Laosas
 10564098-n	lit:lemma	kino aktorius
-02161982-s	lit:lemma	svarbus
-00312234-s	lit:lemma	nerūpestingas
+02161982-a	lit:lemma	svarbus
+00312234-a	lit:lemma	nerūpestingas
 02897957-a	lit:lemma	architektūrinis
-00068180-s	lit:lemma	apgalvotas
+00068180-a	lit:lemma	apgalvotas
 00110533-r	lit:lemma	namie
 15032376-n	lit:lemma	toksinai
-02119213-s	lit:lemma	ramus
+02119213-a	lit:lemma	ramus
 14842019-n	lit:lemma	blogas kvapas iš burnos
 02698145-a	lit:lemma	klasikinis
 02665617-v	lit:lemma	būti panašiam
-01936528-s	lit:lemma	tariamas
+01936528-a	lit:lemma	tariamas
 05697363-n	lit:lemma	pasikliovimas
 00764222-v	lit:lemma	sutikti
 04850589-n	lit:lemma	amoralumas
 00486067-r	lit:lemma	žemiau
 05142180-n	lit:lemma	gėris
-00975487-s	lit:lemma	skoningas
+00975487-a	lit:lemma	skoningas
 10602985-n	lit:lemma	seseris
 09351547-n	lit:lemma	tvenkinys
 02742482-v	lit:lemma	reikšti
-02336904-s	lit:lemma	skurdus
+02336904-a	lit:lemma	skurdus
 15213115-n	lit:lemma	spalis
 07214994-n	lit:lemma	skundimas
-01155968-s	lit:lemma	kietas
+01155968-a	lit:lemma	kietas
 10741590-n	lit:lemma	naudotojas
 06253690-n	lit:lemma	žinutė
 02607455-a	lit:lemma	gydomasis
@@ -3516,7 +3516,7 @@
 15152261-n	lit:lemma	nepilnametystė
 00820976-v	lit:lemma	patvirtinti
 01045073-v	lit:lemma	purkštauti
-01076145-s	lit:lemma	jaukus
+01076145-a	lit:lemma	jaukus
 07941170-n	lit:lemma	biologinė grupė
 07199922-n	lit:lemma	atkirtis
 08293982-n	lit:lemma	koalicija
@@ -3527,36 +3527,36 @@
 08198398-n	lit:lemma	kariuomenė
 01406640-a	lit:lemma	santuokinis
 15230482-n	lit:lemma	žmogaus darbo valanda
-01028163-s	lit:lemma	lankstus
+01028163-a	lit:lemma	lankstus
 04463983-n	lit:lemma	bėgiai
 05090255-n	lit:lemma	žingsnis
-00660809-s	lit:lemma	trimatis
+00660809-a	lit:lemma	trimatis
 06353445-n	lit:lemma	rašyba
-01044730-s	lit:lemma	nerūpestingas
+01044730-a	lit:lemma	nerūpestingas
 13661820-n	lit:lemma	euras
 03825080-n	lit:lemma	naktiniai drabužiai
-00168694-s	lit:lemma	simpatiškas
-00339742-s	lit:lemma	kupinas pasitikėjimo
+00168694-a	lit:lemma	simpatiškas
+00339742-a	lit:lemma	kupinas pasitikėjimo
 05602835-n	lit:lemma	žandas
 02803349-n	lit:lemma	bosas
-00371945-s	lit:lemma	kaip
-01372948-s	lit:lemma	dosnus
+00371945-a	lit:lemma	kaip
+01372948-a	lit:lemma	dosnus
 07494363-n	lit:lemma	skausmas
 00044673-n	lit:lemma	suvienodinimas
 06575681-n	lit:lemma	grafinė sąsaja
-00122128-s	lit:lemma	ankstesnis
+00122128-a	lit:lemma	ankstesnis
 08395465-n	lit:lemma	Jungtinių Valstijų karo akademija
 13812607-n	lit:lemma	giminystė
 06722186-n	lit:lemma	pastabų įterpimas
-00995647-s	lit:lemma	priešingas
+00995647-a	lit:lemma	priešingas
 00717358-v	lit:lemma	reaguoti
-00421513-s	lit:lemma	nešvarus
+00421513-a	lit:lemma	nešvarus
 15204983-n	lit:lemma	dešimtmetis
 14529524-n	lit:lemma	pirmiau
 02721547-a	lit:lemma	arkliškas
-02372434-s	lit:lemma	kryžiškas
+02372434-a	lit:lemma	kryžiškas
 13975752-n	lit:lemma	sumaištis
-02570046-s	lit:lemma	išmintingas
+02570046-a	lit:lemma	išmintingas
 08641113-n	lit:lemma	kaimynystė
 02952275-a	lit:lemma	krikščioniškas
 05033906-n	lit:lemma	atsparumas
@@ -3565,11 +3565,11 @@
 00693743-a	lit:lemma	faktiškai
 10024937-n	lit:lemma	Dominikos Respublikos gyventojas
 04412901-n	lit:lemma	stotis
-01601297-s	lit:lemma	šiaurinis
+01601297-a	lit:lemma	šiaurinis
 10200365-n	lit:lemma	pamėgdžiotojas
 01984317-v	lit:lemma	virsti
-02112108-s	lit:lemma	jungtinis
-01649720-s	lit:lemma	jaunatviškas
+02112108-a	lit:lemma	jungtinis
+01649720-a	lit:lemma	jaunatviškas
 02928347-a	lit:lemma	Indijos
 10083823-n	lit:lemma	aristokratė
 14326880-n	lit:lemma	liežuvio skausmas
@@ -3593,11 +3593,11 @@
 11879505-n	lit:lemma	juodasis bastutis
 02950256-n	lit:lemma	patranka
 03452594-n	lit:lemma	senoviškas aukštas laikrodis
-01435060-s	lit:lemma	toliašaudis
+01435060-a	lit:lemma	toliašaudis
 00427944-r	lit:lemma	stipriai
 14129784-n	lit:lemma	dengė karštligė
 09977326-n	lit:lemma	kriketo žaidėjas
-01486854-s	lit:lemma	identiškas
+01486854-a	lit:lemma	identiškas
 00071178-v	lit:lemma	kankinti
 00407535-n	lit:lemma	veikla
 08647354-n	lit:lemma	šventorius
@@ -3610,17 +3610,17 @@
 00414179-n	lit:lemma	įprotis
 10247358-n	lit:lemma	mergaitė
 05685363-n	lit:lemma	suglumimas
-02342899-s	lit:lemma	rinktinis
+02342899-a	lit:lemma	rinktinis
 08080025-n	lit:lemma	futbolo komanda
 04626280-n	lit:lemma	emocingumas
 01522376-a	lit:lemma	judamas
 10044879-n	lit:lemma	redaktorius
-00685113-s	lit:lemma	lemtingas
+00685113-a	lit:lemma	lemtingas
 04081281-n	lit:lemma	valgykla
-02396098-s	lit:lemma	kartus
+02396098-a	lit:lemma	kartus
 11876803-n	lit:lemma	brokolis
 07360647-n	lit:lemma	užkrėtimas
-01515692-s	lit:lemma	suinteresuotas
+01515692-a	lit:lemma	suinteresuotas
 10085869-n	lit:lemma	sužadėtinis
 04752221-n	lit:lemma	nevienodumas
 05221895-n	lit:lemma	sritis
@@ -3635,32 +3635,32 @@
 10448983-n	lit:lemma	pareigūnas
 02157557-n	lit:lemma	uodega
 10478293-n	lit:lemma	prokonsulas
-00567161-s	lit:lemma	sujungtas
+00567161-a	lit:lemma	sujungtas
 04268799-n	lit:lemma	kibirkštinis iškroviklis
-00853473-s	lit:lemma	nepageidaujamas
+00853473-a	lit:lemma	nepageidaujamas
 04582625-n	lit:lemma	langelis
 04436185-n	lit:lemma	sija
 00686447-v	lit:lemma	sutikti
-01580775-s	lit:lemma	būtinas
-00168910-s	lit:lemma	žavus
+01580775-a	lit:lemma	būtinas
+00168910-a	lit:lemma	žavus
 01237167-n	lit:lemma	agresija
 05138488-n	lit:lemma	vertė
 01740892-a	lit:lemma	taikus
-00440489-s	lit:lemma	bukas
+00440489-a	lit:lemma	bukas
 07082198-n	lit:lemma	kalbėsena
 00879271-n	lit:lemma	patikrinimas
 02374914-a	lit:lemma	palankus
-01036754-s	lit:lemma	vidaus
+01036754-a	lit:lemma	vidaus
 05331171-n	lit:lemma	antinkstis
-01660444-s	lit:lemma	pasiruošęs kovai
+01660444-a	lit:lemma	pasiruošęs kovai
 01548193-a	lit:lemma	moralinis
 05596004-n	lit:lemma	klubo sąnarys
 07332956-n	lit:lemma	žūtis
 00279835-n	lit:lemma	judėjimas
 05036715-n	lit:lemma	blogumas
 00358089-n	lit:lemma	traiškymas
-02059811-s	lit:lemma	rizikingas
-01136248-s	lit:lemma	piktas
+02059811-a	lit:lemma	rizikingas
+01136248-a	lit:lemma	piktas
 06643763-n	lit:lemma	užuomina
 15211806-n	lit:lemma	birželis
 05434927-n	lit:lemma	branduolys
@@ -3669,12 +3669,12 @@
 00898963-a	lit:lemma	ezoterinis
 04799133-n	lit:lemma	etniškumas
 00962447-v	lit:lemma	kalbėti
-01951197-s	lit:lemma	grubus
+01951197-a	lit:lemma	grubus
 01883898-a	lit:lemma	numatomas
-02526124-s	lit:lemma	neįveikiamas
+02526124-a	lit:lemma	neįveikiamas
 03016202-a	lit:lemma	graikų
 15164957-n	lit:lemma	diena
-02081114-s	lit:lemma	neblogas
+02081114-a	lit:lemma	neblogas
 03943544-n	lit:lemma	smeigtuko smaigalys
 09630641-n	lit:lemma	vargšas
 02367363-v	lit:lemma	daryti
@@ -3687,18 +3687,18 @@
 05699172-n	lit:lemma	neapsisprendimas
 05823054-n	lit:lemma	pateisinimas
 00831651-v	lit:lemma	sužinoti
-01516346-s	lit:lemma	įsivėlęs
-00444984-s	lit:lemma	gretimas
-02413851-s	lit:lemma	siūlinis
+01516346-a	lit:lemma	įsivėlęs
+00444984-a	lit:lemma	gretimas
+02413851-a	lit:lemma	siūlinis
 10677713-n	lit:lemma	palaikytojas
 02555126-a	lit:lemma	drėgnas
 05035353-n	lit:lemma	galia
 01672607-a	lit:lemma	eilinis
 06413889-n	lit:lemma	lankstinukas
-02558767-s	lit:lemma	ekologiškas
+02558767-a	lit:lemma	ekologiškas
 02412440-n	lit:lemma	ėriukas
-02218314-s	lit:lemma	įvairus
-01308736-s	lit:lemma	neišmanantis
+02218314-a	lit:lemma	įvairus
+01308736-a	lit:lemma	neišmanantis
 09867956-n	lit:lemma	samdytojas
 07417405-n	lit:lemma	kritiška padėtis
 14788332-n	lit:lemma	sviesto rūgštis
@@ -3708,21 +3708,21 @@
 00223395-r	lit:lemma	ištikimai
 02106006-v	lit:lemma	justi
 00380568-n	lit:lemma	lydymas
-00417204-s	lit:lemma	neapdirbtas
+00417204-a	lit:lemma	neapdirbtas
 13899404-n	lit:lemma	rutulys
-02251212-s	lit:lemma	vienišas
-00157268-s	lit:lemma	drovus
+02251212-a	lit:lemma	vienišas
+00157268-a	lit:lemma	drovus
 01016778-v	lit:lemma	tvirtinti
 04632157-n	lit:lemma	energingumas
 04538403-n	lit:lemma	dirbtinis šilkas
 13556893-n	lit:lemma	dūmai
-00482673-s	lit:lemma	atitinkamas
-00505410-s	lit:lemma	vienintelis
+00482673-a	lit:lemma	atitinkamas
+00505410-a	lit:lemma	vienintelis
 01140658-n	lit:lemma	mandatas
 00239230-n	lit:lemma	pirmasis žingsnis
-00522463-s	lit:lemma	visapusis
+00522463-a	lit:lemma	visapusis
 00056912-n	lit:lemma	atsitraukimas
-02363614-s	lit:lemma	imunus
+02363614-a	lit:lemma	imunus
 07513508-n	lit:lemma	susijaudinimas
 14841770-n	lit:lemma	kvėpavimas
 00284544-n	lit:lemma	pasivaikščiojimas
@@ -3734,54 +3734,54 @@
 09067277-n	lit:lemma	Kolorado valstija
 14435670-n	lit:lemma	valdovas
 05090255-n	lit:lemma	nuotolis
-01779193-s	lit:lemma	materialinis
+01779193-a	lit:lemma	materialinis
 08953324-n	lit:lemma	Islandija
-00545746-s	lit:lemma	atsainus
+00545746-a	lit:lemma	atsainus
 02248349-a	lit:lemma	visuomeninis
-00978754-s	lit:lemma	neatidėliojamas
+00978754-a	lit:lemma	neatidėliojamas
 01604330-n	lit:lemma	plėšrusis paukštis
 05833022-n	lit:lemma	reikalas
 00053004-r	lit:lemma	labai gerai
 02726681-n	lit:lemma	daugiabutis namas
-00383291-s	lit:lemma	safyrinis
+00383291-a	lit:lemma	safyrinis
 14404160-n	lit:lemma	depresija
-00803275-s	lit:lemma	smarkus
+00803275-a	lit:lemma	smarkus
 00591115-v	lit:lemma	suvokti
 02854926-n	lit:lemma	palaidinė
 10553402-n	lit:lemma	laukinis
 00060833-v	lit:lemma	kastruoti
-01074335-s	lit:lemma	druskingas
+01074335-a	lit:lemma	druskingas
 04633197-n	lit:lemma	gyvybingumas
 09370773-n	lit:lemma	Niagaros krioklys
 09906986-n	lit:lemma	ministras pirmininkas
 00871781-v	lit:lemma	gąsdinti
 03668279-n	lit:lemma	šviesinis rašiklis
 03671473-n	lit:lemma	transporto įmonė
-02007067-s	lit:lemma	tinklinis
+02007067-a	lit:lemma	tinklinis
 00015498-v	lit:lemma	snausti
 05027135-n	lit:lemma	kūno svoris
 00391599-n	lit:lemma	panaikinimas
-00032733-s	lit:lemma	guvus
+00032733-a	lit:lemma	guvus
 11878520-n	lit:lemma	garstyčių aliejus
 03718458-n	lit:lemma	dvaro rūmai
 05047059-n	lit:lemma	vėlavimas
 06533484-n	lit:lemma	ieškinio senaties įstatymas
 07616748-n	lit:lemma	bananas su ledais ir kremu
-02405805-s	lit:lemma	gausus nuotykių
+02405805-a	lit:lemma	gausus nuotykių
 02859500-a	lit:lemma	apaštalų
 09894909-n	lit:lemma	kortuotojas sukčiautojas
 09326662-n	lit:lemma	kalvelė
 14006945-n	lit:lemma	veikla
 05849789-n	lit:lemma	buožas
-02081114-s	lit:lemma	puikus
+02081114-a	lit:lemma	puikus
 13724582-n	lit:lemma	kilogramas
 07048928-n	lit:lemma	himnas
 01116968-n	lit:lemma	prekyba
 01454810-v	lit:lemma	traukti
 11441416-n	lit:lemma	kosminės dulkės
-01462324-s	lit:lemma	mylimas
+01462324-a	lit:lemma	mylimas
 02018049-v	lit:lemma	laipinti
-01386234-s	lit:lemma	išplėstas
+01386234-a	lit:lemma	išplėstas
 00074524-n	lit:lemma	klaida
 00732746-n	lit:lemma	netinkamas elgesys
 09366317-n	lit:lemma	kalva
@@ -3796,15 +3796,15 @@
 06694796-n	lit:lemma	charakteristika
 12582231-n	lit:lemma	palmė
 06669513-n	lit:lemma	dvejopas vertinimo matas
-01742119-s	lit:lemma	taikus
+01742119-a	lit:lemma	taikus
 09403086-n	lit:lemma	triušio urvas
 02659763-v	lit:lemma	derėti
 02716866-n	lit:lemma	antibiotikas
-02068946-s	lit:lemma	identiškas
-00310433-s	lit:lemma	detalus
+02068946-a	lit:lemma	identiškas
+00310433-a	lit:lemma	detalus
 05015678-n	lit:lemma	vėsa
 06490451-n	lit:lemma	katalogas
-02067491-s	lit:lemma	įvairus
+02067491-a	lit:lemma	įvairus
 00614829-v	lit:lemma	užmiršti
 06135806-n	lit:lemma	metrologija
 01325777-a	lit:lemma	pamokomas
@@ -3812,28 +3812,28 @@
 13359690-n	lit:lemma	banko sąskaita
 03895585-n	lit:lemma	pasažas
 06730780-n	lit:lemma	kaltinimas
-00853473-s	lit:lemma	netinkamas
+00853473-a	lit:lemma	netinkamas
 00359862-a	lit:lemma	šykštus
 00043765-a	lit:lemma	realus
 07532440-n	lit:lemma	liūdesys
 00374135-v	lit:lemma	suledėti
 01717117-a	lit:lemma	juntamas
-01254165-s	lit:lemma	labai šaltas
-01744515-s	lit:lemma	skvarbus
+01254165-a	lit:lemma	labai šaltas
+01744515-a	lit:lemma	skvarbus
 03496749-n	lit:lemma	Harvardas
 00797878-n	lit:lemma	avantiūra
 05760202-n	lit:lemma	atmintis
 03598151-n	lit:lemma	stakselis
 07944050-n	lit:lemma	jaunimas
 07823591-n	lit:lemma	mėtinis padažas
-02571277-s	lit:lemma	kvailas
+02571277-a	lit:lemma	kvailas
 01482228-a	lit:lemma	nevedęs
 08253815-n	lit:lemma	pietūs
 04656996-n	lit:lemma	nedraugingumas
 00361065-r	lit:lemma	identiškai
-01440889-s	lit:lemma	ilgalaikis
+01440889-a	lit:lemma	ilgalaikis
 07517737-n	lit:lemma	pyktis
-00567860-s	lit:lemma	atokus
+00567860-a	lit:lemma	atokus
 00806075-n	lit:lemma	vidinė kontrolė
 06208021-n	lit:lemma	pasaulėžiūra
 03671272-n	lit:lemma	geležinkelio linija
@@ -3850,15 +3850,15 @@
 13508333-n	lit:lemma	lingvistinis procesas
 02416519-n	lit:lemma	ožka
 02898584-a	lit:lemma	pažinimo
-01513050-s	lit:lemma	smarkus
+01513050-a	lit:lemma	smarkus
 00024720-n	lit:lemma	padėtis
-01248958-s	lit:lemma	ugningas
+01248958-a	lit:lemma	ugningas
 02492198-v	lit:lemma	linksmintis
 01615180-a	lit:lemma	objektyvus
 02871858-a	lit:lemma	regioninis
 00002452-n	lit:lemma	daiktas
 04326084-n	lit:lemma	akmuo
-00387392-s	lit:lemma	sidabriškas
+00387392-a	lit:lemma	sidabriškas
 00216174-n	lit:lemma	pašalinti
 00877345-a	lit:lemma	bandomasis
 08401554-n	lit:lemma	klientūra
@@ -3869,7 +3869,7 @@
 05418717-n	lit:lemma	vena
 00255214-n	lit:lemma	maudymasis
 07615289-n	lit:lemma	šerbetas
-02408977-s	lit:lemma	rajoninis
+02408977-a	lit:lemma	rajoninis
 14857897-n	lit:lemma	nuolaužos
 04210390-n	lit:lemma	šventykla
 14627081-n	lit:lemma	taurusis metalas
@@ -3886,24 +3886,24 @@
 00081737-r	lit:lemma	kasmet
 10164747-n	lit:lemma	valstybės vadovas
 13577171-n	lit:lemma	matavimo sistema
-00013662-s	lit:lemma	realus
+00013662-a	lit:lemma	realus
 04220717-n	lit:lemma	sidabro kasykla
-00929815-s	lit:lemma	norėtas
-00968010-s	lit:lemma	savotiškas
+00929815-a	lit:lemma	norėtas
+00968010-a	lit:lemma	savotiškas
 14441610-n	lit:lemma	gėda
 06392935-n	lit:lemma	straipsnis
 02395406-n	lit:lemma	meitėlis
 04233405-n	lit:lemma	plokštė
 01182709-v	lit:lemma	aprūpinti
-02569558-s	lit:lemma	pilnas
+02569558-a	lit:lemma	pilnas
 14616073-n	lit:lemma	selenato rūgštis
 04643662-n	lit:lemma	agresyvumas
 00511555-n	lit:lemma	festivalis
 10522759-n	lit:lemma	gelbėtojas
 02405302-n	lit:lemma	jakas
-01668567-s	lit:lemma	metodiškas
+01668567-a	lit:lemma	metodiškas
 13412321-n	lit:lemma	registras
-00012689-s	lit:lemma	idealus
+00012689-a	lit:lemma	idealus
 09385911-n	lit:lemma	gabalas
 06832140-n	lit:lemma	J
 03772077-n	lit:lemma	vienuolyno bažnyčia
@@ -3914,7 +3914,7 @@
 02225492-v	lit:lemma	saugoti
 10480583-n	lit:lemma	sportininkas profesionalas
 03231912-n	lit:lemma	nuotakas
-00228294-s	lit:lemma	pirmas
+00228294-a	lit:lemma	pirmas
 03487533-n	lit:lemma	rankinis bagažas
 08660339-n	lit:lemma	paviršius
 09053019-n	lit:lemma	Dakota
@@ -3922,42 +3922,42 @@
 07954731-n	lit:lemma	viskas
 08236438-n	lit:lemma	sindikatas
 01776974-a	lit:lemma	psichotropinis
-01933731-s	lit:lemma	tikras
+01933731-a	lit:lemma	tikras
 00962447-v	lit:lemma	pasikalbėti
-01413763-s	lit:lemma	galimas
+01413763-a	lit:lemma	galimas
 00079398-n	lit:lemma	prekyba
 03092314-n	lit:lemma	konservatorija
-01842963-s	lit:lemma	sumanytas
+01842963-a	lit:lemma	sumanytas
 00166608-r	lit:lemma	paslapčiomis
 03845550-n	lit:lemma	tepalas
 13504739-n	lit:lemma	kariokinezė
 06876309-n	lit:lemma	mostas
 01967240-a	lit:lemma	periodiškas
 03316406-n	lit:lemma	įmonė
-01139832-s	lit:lemma	sklandus
+01139832-a	lit:lemma	sklandus
 00348110-r	lit:lemma	mielai
 09336052-n	lit:lemma	Laptevų jūra
-01840880-s	lit:lemma	silpno proto
+01840880-a	lit:lemma	silpno proto
 02991847-n	lit:lemma	vyno rūsys
-00977699-s	lit:lemma	greitasis
+00977699-a	lit:lemma	greitasis
 06252954-n	lit:lemma	pranešimas
 00151755-r	lit:lemma	bendrais bruožais
 00027705-v	lit:lemma	ištiesti
 06209101-n	lit:lemma	panorama
-01248958-s	lit:lemma	ugninis
+01248958-a	lit:lemma	ugninis
 09873899-n	lit:lemma	veislininkas
 03322099-n	lit:lemma	ūkis
 13396276-n	lit:lemma	stoka
 15091846-n	lit:lemma	vitaminas B₉
 03113657-n	lit:lemma	kostiumas
 10277132-n	lit:lemma	pietautojas
-00354934-s	lit:lemma	pakeistas
-01731786-s	lit:lemma	esantis
+00354934-a	lit:lemma	pakeistas
+01731786-a	lit:lemma	esantis
 14364802-n	lit:lemma	pūslė
 00165018-r	lit:lemma	rimtai
 00005567-r	lit:lemma	nesąmoningai
 06392001-n	lit:lemma	sekcija
-01253592-s	lit:lemma	ledinis
+01253592-a	lit:lemma	ledinis
 01186397-n	lit:lemma	bankrotas
 08453108-n	lit:lemma	administracinė teisė
 14773865-n	lit:lemma	elektrolitas
@@ -3971,7 +3971,7 @@
 15250178-n	lit:lemma	gimimo diena
 00259019-r	lit:lemma	tiesiogiai
 11669921-n	lit:lemma	gėlė
-01386538-s	lit:lemma	gigantiškas
+01386538-a	lit:lemma	gigantiškas
 00047317-v	lit:lemma	pasimatuoti
 06598915-n	lit:lemma	objektas
 00278403-n	lit:lemma	drėkinimas
@@ -3992,24 +3992,24 @@
 08756735-n	lit:lemma	Kipras
 01517081-a	lit:lemma	kariškas
 01023820-n	lit:lemma	procesas
-02104890-s	lit:lemma	jautrus švitinimui
+02104890-a	lit:lemma	jautrus švitinimui
 05207130-n	lit:lemma	nesugebėjimas
 08900535-n	lit:lemma	Indija
 15202131-n	lit:lemma	nekeliamieji metai
-01660444-s	lit:lemma	pasirengęs
-00167077-s	lit:lemma	charizmatinis
+01660444-a	lit:lemma	pasirengęs
+00167077-a	lit:lemma	charizmatinis
 01037819-n	lit:lemma	krikštas
 08401248-n	lit:lemma	padalinys
 00110057-n	lit:lemma	metimas
 05955186-n	lit:lemma	pagrindinė kryptis
-00726317-s	lit:lemma	bejėgis
+00726317-a	lit:lemma	bejėgis
 00336065-r	lit:lemma	klaidingai
-02126430-s	lit:lemma	pastatytas
-01710946-s	lit:lemma	neapmokamas
+02126430-a	lit:lemma	pastatytas
+01710946-a	lit:lemma	neapmokamas
 00123170-v	lit:lemma	pertvarkyti
 02988402-a	lit:lemma	tautinis
-01419784-s	lit:lemma	metaforiškas
-02090567-s	lit:lemma	akivaizdus
+01419784-a	lit:lemma	metaforiškas
+02090567-a	lit:lemma	akivaizdus
 01762582-a	lit:lemma	neleistinas
 12897493-n	lit:lemma	bulvė
 03604156-n	lit:lemma	muzikos automatas
@@ -4031,13 +4031,13 @@
 07304852-n	lit:lemma	nepasisekimas
 09178999-n	lit:lemma	motyvas
 01470496-a	lit:lemma	geografinis
-01969150-s	lit:lemma	metinis
-00698586-s	lit:lemma	išvestinis
+01969150-a	lit:lemma	metinis
+00698586-a	lit:lemma	išvestinis
 01604226-a	lit:lemma	šiaurės
 03636248-n	lit:lemma	žibintas
 00004980-a	lit:lemma	nesutrumpintas
 00018526-v	lit:lemma	pabusti
-02344070-s	lit:lemma	kokybiškas
+02344070-a	lit:lemma	kokybiškas
 10200365-n	lit:lemma	apsimetėlis
 15262921-n	lit:lemma	nūdiena
 09480077-n	lit:lemma	spraga
@@ -4047,15 +4047,15 @@
 00053004-r	lit:lemma	puikiai
 00314384-r	lit:lemma	dorai
 03141823-n	lit:lemma	ramentas
-01441866-s	lit:lemma	atimantis laiko
+01441866-a	lit:lemma	atimantis laiko
 02857407-a	lit:lemma	politinis
-01975671-s	lit:lemma	atitinkamas
+01975671-a	lit:lemma	atitinkamas
 06407372-n	lit:lemma	senovinis rankraštis
 08439694-n	lit:lemma	krūmynas
 05125377-n	lit:lemma	veikimo sritis
 02939185-n	lit:lemma	virintuvas
 05584265-n	lit:lemma	rankos piršto nagas
-01042491-s	lit:lemma	ceremoningas
+01042491-a	lit:lemma	ceremoningas
 05723210-n	lit:lemma	lytėjimo pojūtis
 03056368-n	lit:lemma	anglių kasykla
 14186541-n	lit:lemma	artritas
@@ -4069,26 +4069,26 @@
 00057486-n	lit:lemma	pasitraukimas
 03302487-n	lit:lemma	birža
 08702402-n	lit:lemma	Pietų Amerikos šalis
-02514380-s	lit:lemma	niekšiškas
+02514380-a	lit:lemma	niekšiškas
 00219012-n	lit:lemma	nužudymas
 00378069-n	lit:lemma	deginimas
 13814336-n	lit:lemma	brolija
 00308370-n	lit:lemma	išvyka
 00338821-n	lit:lemma	perstatymas
-00615191-s	lit:lemma	patikimas
+00615191-a	lit:lemma	patikimas
 02950711-a	lit:lemma	strateginis
 01237415-n	lit:lemma	konsolidacija
 04074963-n	lit:lemma	nuotolinio valdymo prietaisas
 01878466-a	lit:lemma	deramas
 00033020-n	lit:lemma	bendravimas
-01439496-s	lit:lemma	ilgalaikis
+01439496-a	lit:lemma	ilgalaikis
 00335182-r	lit:lemma	nepasirengus
-01214430-s	lit:lemma	spiegiamas
+01214430-a	lit:lemma	spiegiamas
 03863923-n	lit:lemma	viršutinis
 00586183-a	lit:lemma	griaunamasis
 13624705-n	lit:lemma	hektolitras
 00892315-v	lit:lemma	dėkoti
-02285407-s	lit:lemma	ranka rašytas
+02285407-a	lit:lemma	ranka rašytas
 10148305-n	lit:lemma	bambeklis
 10480253-n	lit:lemma	profesionalas
 00089351-n	lit:lemma	atidavimas
@@ -4123,9 +4123,9 @@
 08303275-n	lit:lemma	federacija
 00219856-n	lit:lemma	eutanazija
 00514128-n	lit:lemma	išdaiga
-01935744-s	lit:lemma	legendinis
-01732131-s	lit:lemma	dabartinis
-01017439-s	lit:lemma	tvirtas
+01935744-a	lit:lemma	legendinis
+01732131-a	lit:lemma	dabartinis
+01017439-a	lit:lemma	tvirtas
 04625284-n	lit:lemma	neramumas
 07928696-n	lit:lemma	kokakola
 00647270-n	lit:lemma	kiekybinė cheminė analizė
@@ -4133,7 +4133,7 @@
 14973133-n	lit:lemma	bloknotas
 07151380-n	lit:lemma	pasakymas
 10599354-n	lit:lemma	neišmanėlis
-01602966-s	lit:lemma	pietinis
+01602966-a	lit:lemma	pietinis
 01996377-a	lit:lemma	atsakingas
 02771756-v	lit:lemma	išsekti
 03038281-n	lit:lemma	sąsaga
@@ -4153,7 +4153,7 @@
 00105603-r	lit:lemma	greitai
 00785684-a	lit:lemma	nedalijamas
 00075421-v	lit:lemma	išsekinti
-02369027-s	lit:lemma	aitrus
+02369027-a	lit:lemma	aitrus
 00910203-n	lit:lemma	įrašymas
 03044566-a	lit:lemma	arabų
 06023969-n	lit:lemma	vidurkis
@@ -4164,15 +4164,15 @@
 00624738-n	lit:lemma	mankšta
 02488705-a	lit:lemma	galininkinis
 00179112-r	lit:lemma	vien tik
-01439784-s	lit:lemma	begalinis
+01439784-a	lit:lemma	begalinis
 10101634-n	lit:lemma	futbolo žaidėjas
 01065441-n	lit:lemma	dykinėjimas
 14288871-n	lit:lemma	sumušimas
 05930136-n	lit:lemma	suvokinys
 01985923-v	lit:lemma	smukti
-02587556-s	lit:lemma	brangus
+02587556-a	lit:lemma	brangus
 00090253-n	lit:lemma	gavimas
-01687167-s	lit:lemma	naujas
+01687167-a	lit:lemma	naujas
 00591115-v	lit:lemma	suprasti
 05513020-n	lit:lemma	šlaplė
 14686585-n	lit:lemma	mazutas
@@ -4184,7 +4184,7 @@
 04894037-n	lit:lemma	neprotingumas
 00066862-v	lit:lemma	šaukti
 05849040-n	lit:lemma	savybė
-01459755-s	lit:lemma	žavus
+01459755-a	lit:lemma	žavus
 07511380-n	lit:lemma	jaudulys
 03234306-n	lit:lemma	brėžinys
 00355420-n	lit:lemma	detantas
@@ -4194,8 +4194,8 @@
 05322103-n	lit:lemma	endolimfa
 13619764-n	lit:lemma	galonas
 02875707-a	lit:lemma	odos
-00550574-s	lit:lemma	galutinis
-01711465-s	lit:lemma	geliantis
+00550574-a	lit:lemma	galutinis
+01711465-a	lit:lemma	geliantis
 07496463-n	lit:lemma	kančia
 13723712-n	lit:lemma	gramas
 00480508-n	lit:lemma	badmintonas
@@ -4218,14 +4218,14 @@
 05200169-n	lit:lemma	kompetencija
 00008997-r	lit:lemma	absoliučiai
 07450651-n	lit:lemma	šventė
-02048247-s	lit:lemma	kampinis
+02048247-a	lit:lemma	kampinis
 14445226-n	lit:lemma	nelaimė
 07523180-n	lit:lemma	drovumas
 01327925-a	lit:lemma	integralus
-01515692-s	lit:lemma	susijęs
+01515692-a	lit:lemma	susijęs
 05267345-n	lit:lemma	audinys
 06958836-n	lit:lemma	vengrų kalba
-00692255-s	lit:lemma	seklus
+00692255-a	lit:lemma	seklus
 08877382-n	lit:lemma	Liverpulis
 00121166-n	lit:lemma	išsiuntimas
 08318691-n	lit:lemma	parlamentas
@@ -4233,13 +4233,13 @@
 00262249-n	lit:lemma	dekoravimas
 08630985-n	lit:lemma	kraštas
 00427580-n	lit:lemma	išdaiga
-02343110-s	lit:lemma	puikus
+02343110-a	lit:lemma	puikus
 00125436-n	lit:lemma	patapšnojimas
-00488998-s	lit:lemma	neįprastas
-02569558-s	lit:lemma	protingas
-02503305-s	lit:lemma	beprasmis
+00488998-a	lit:lemma	neįprastas
+02569558-a	lit:lemma	protingas
+02503305-a	lit:lemma	beprasmis
 01091905-n	lit:lemma	prekyba
-01998730-s	lit:lemma	neatsakingas
+01998730-a	lit:lemma	neatsakingas
 08717730-n	lit:lemma	Žaliasis Kyšulys
 03272940-n	lit:lemma	elektrinis maišytuvas
 03540476-n	lit:lemma	užeigos namai
@@ -4264,47 +4264,47 @@
 04683814-n	lit:lemma	grožis
 07507560-n	lit:lemma	susigėdimas
 00276987-n	lit:lemma	užteršimas
-00877816-s	lit:lemma	alfa versija
+00877816-a	lit:lemma	alfa versija
 09855630-n	lit:lemma	biologas
 09492123-n	lit:lemma	šaka (mokslo)
 00076884-n	lit:lemma	apvirtimas
 01347138-a	lit:lemma	neakivaizdinis (mokslas)
-00515380-s	lit:lemma	ištisas
+00515380-a	lit:lemma	ištisas
 00906735-v	lit:lemma	nuteisti
 08561583-n	lit:lemma	pietinė dalis
 03247620-n	lit:lemma	narkotikas
 00336831-a	lit:lemma	įsitikinęs
 03485309-n	lit:lemma	rankinė granata
 10022645-n	lit:lemma	iškaršėlis
-01466775-s	lit:lemma	šaltas
+01466775-a	lit:lemma	šaltas
 02372584-n	lit:lemma	damanas
 14039534-n	lit:lemma	alkis
 01047803-n	lit:lemma	Renesansas
-00807399-s	lit:lemma	nykus
+00807399-a	lit:lemma	nykus
 06746005-n	lit:lemma	atsakymas
 00162765-r	lit:lemma	viešai
 07939382-n	lit:lemma	išdėstymas
-02406370-s	lit:lemma	nervingas
+02406370-a	lit:lemma	nervingas
 04931267-n	lit:lemma	sutvarkymas
-00989647-s	lit:lemma	lieknas ir aukštas
+00989647-a	lit:lemma	lieknas ir aukštas
 10421470-n	lit:lemma	vaistininkas
 01689880-a	lit:lemma	tradicinis
-01036754-s	lit:lemma	krašto
+01036754-a	lit:lemma	krašto
 14009481-n	lit:lemma	veikimas
 13282550-n	lit:lemma	kompensacija
-00015247-s	lit:lemma	gausus
-01264913-s	lit:lemma	juokingas
+00015247-a	lit:lemma	gausus
+01264913-a	lit:lemma	juokingas
 00045250-n	lit:lemma	varymas
 02917694-a	lit:lemma	akušerinis
 06799897-n	lit:lemma	brūkšnys
 05093890-n	lit:lemma	kokybė
 13097338-n	lit:lemma	brazdas
-00971506-s	lit:lemma	madingas
+00971506-a	lit:lemma	madingas
 03262717-n	lit:lemma	įtvirtinimai
 13664521-n	lit:lemma	centas
 14464203-n	lit:lemma	yda
 10388732-n	lit:lemma	viršininkas
-01401105-s	lit:lemma	juridinis
+01401105-a	lit:lemma	juridinis
 00042614-r	lit:lemma	liūdnai
 04134632-n	lit:lemma	smėlio laikrodis
 00104249-n	lit:lemma	impulsas
@@ -4314,7 +4314,7 @@
 00070765-r	lit:lemma	nesirenkant
 00120223-r	lit:lemma	vienu metu
 03597469-n	lit:lemma	juvelyriniai dirbiniai
-01143006-s	lit:lemma	pamažu
+01143006-a	lit:lemma	pamažu
 04649261-n	lit:lemma	linksmumas
 02874876-a	lit:lemma	komunistinis
 05802185-n	lit:lemma	suskaičiavimas
@@ -4324,14 +4324,14 @@
 00651176-n	lit:lemma	analogija
 10157744-n	lit:lemma	žioplys
 09433442-n	lit:lemma	pakrantė
-00143854-s	lit:lemma	šarvuotas
+00143854-a	lit:lemma	šarvuotas
 08558963-n	lit:lemma	buveinė
 05455375-n	lit:lemma	centrinė duobutė
 00654885-n	lit:lemma	rūpinimasis
 00894552-n	lit:lemma	treniravimasis
 00448748-n	lit:lemma	dailusis čiuožimas
-01744515-s	lit:lemma	veriantis
-00195684-s	lit:lemma	baisus
+01744515-a	lit:lemma	veriantis
+00195684-a	lit:lemma	baisus
 00005779-r	lit:lemma	labai
 03308297-n	lit:lemma	kilputė
 05750163-n	lit:lemma	mada
@@ -4346,21 +4346,21 @@
 04105893-n	lit:lemma	patalpa
 00406243-v	lit:lemma	parengti
 14859344-n	lit:lemma	trąša
-02333976-s	lit:lemma	žlugęs
+02333976-a	lit:lemma	žlugęs
 13480541-n	lit:lemma	pildymas
 08301155-n	lit:lemma	Tarptautinė plėtros asociacija
 08278324-n	lit:lemma	koledžas
 00087423-n	lit:lemma	subsidijavimas
 01479940-a	lit:lemma	automatiškai valdomas
-01635018-s	lit:lemma	neoficialus
+01635018-a	lit:lemma	neoficialus
 08892971-n	lit:lemma	Glasgas
 01170962-n	lit:lemma	kivirčas
-01780740-s	lit:lemma	psichinis
+01780740-a	lit:lemma	psichinis
 05647156-n	lit:lemma	kvailybė
 09102016-n	lit:lemma	Minesota
 13152742-n	lit:lemma	lapas
-02436025-s	lit:lemma	sunkus
-00901969-s	lit:lemma	tvirtas
+02436025-a	lit:lemma	sunkus
+00901969-a	lit:lemma	tvirtas
 04876053-n	lit:lemma	neteisingumas
 13367070-n	lit:lemma	fondas
 00251304-r	lit:lemma	priešpiet
@@ -4381,14 +4381,14 @@
 03046257-n	lit:lemma	laikrodis
 02601456-v	lit:lemma	kreiptis
 09535809-n	lit:lemma	Žemyna
-00959244-s	lit:lemma	ištikimas
+00959244-a	lit:lemma	ištikimas
 09143786-n	lit:lemma	Dalasas
 13385913-n	lit:lemma	valiuta
 01812950-v	lit:lemma	apsidžiaugti
-01861776-s	lit:lemma	nacionalinis
-01177899-s	lit:lemma	psichinis
-00071427-s	lit:lemma	susižavėjęs teatru
-02355248-s	lit:lemma	bendrininkavimo
+01861776-a	lit:lemma	nacionalinis
+01177899-a	lit:lemma	psichinis
+00071427-a	lit:lemma	susižavėjęs teatru
+02355248-a	lit:lemma	bendrininkavimo
 04933544-n	lit:lemma	sandara
 03966976-n	lit:lemma	replės
 05139094-n	lit:lemma	defektas
@@ -4409,7 +4409,7 @@
 00144405-r	lit:lemma	neilgai
 02129463-n	lit:lemma	liūtė
 01170962-n	lit:lemma	varžybos
-00766102-s	lit:lemma	nuoširdus
+00766102-a	lit:lemma	nuoširdus
 07486229-n	lit:lemma	norėjimas
 09816771-n	lit:lemma	bendradarbis
 00064095-v	lit:lemma	apmalšinti
@@ -4421,25 +4421,25 @@
 01166351-v	lit:lemma	valgyti
 03446528-n	lit:lemma	golfo aikštelė
 01857392-v	lit:lemma	pasilikti
-00978754-s	lit:lemma	akimirksnio, momentinis
-00418364-s	lit:lemma	tvarkingas
+00978754-a	lit:lemma	akimirksnio, momentinis
+00418364-a	lit:lemma	tvarkingas
 09619168-n	lit:lemma	moteris
-01181446-s	lit:lemma	žemiškas
+01181446-a	lit:lemma	žemiškas
 00486067-r	lit:lemma	apačioje
 08552138-n	lit:lemma	šaka (mokslo)
 03055374-a	lit:lemma	klimato
-01810189-s	lit:lemma	smailus
+01810189-a	lit:lemma	smailus
 08208560-n	lit:lemma	grupė
-01140054-s	lit:lemma	malonus
+01140054-a	lit:lemma	malonus
 15262120-n	lit:lemma	vyksmas
-00345494-s	lit:lemma	nepatvarus
+00345494-a	lit:lemma	nepatvarus
 00383390-n	lit:lemma	atidarymas
 02873811-a	lit:lemma	gyslinis
 05923696-n	lit:lemma	idealas
 00166146-a	lit:lemma	patrauklus
 01871680-v	lit:lemma	spaustis
 08075388-n	lit:lemma	bendrija
-01723091-s	lit:lemma	neobjektyvus
+01723091-a	lit:lemma	neobjektyvus
 07548567-n	lit:lemma	agresyvumas
 10251779-n	lit:lemma	mokinys
 07628870-n	lit:lemma	kepinys
@@ -4448,7 +4448,7 @@
 06831605-n	lit:lemma	E
 00378479-n	lit:lemma	padegimas
 08927186-n	lit:lemma	Jordanija
-02074929-s	lit:lemma	pamišęs
+02074929-a	lit:lemma	pamišęs
 00047056-r	lit:lemma	neabejotinai
 07621618-n	lit:lemma	priedas
 05279688-n	lit:lemma	mentė
@@ -4461,40 +4461,40 @@
 02212825-v	lit:lemma	atsisakyti
 09350045-n	lit:lemma	Viduržemio jūra
 02788689-n	lit:lemma	pagalys
-00864884-s	lit:lemma	atleistas
+00864884-a	lit:lemma	atleistas
 01880113-v	lit:lemma	pulsuoti
 05805475-n	lit:lemma	suvokimas
 13134059-n	lit:lemma	svogūnas
 05999266-n	lit:lemma	pamatas
 03738472-n	lit:lemma	mechanizmas
 14330046-n	lit:lemma	krūtinės skausmas
-01993693-s	lit:lemma	doras
-01580775-s	lit:lemma	reikalingas
+01993693-a	lit:lemma	doras
+01580775-a	lit:lemma	reikalingas
 00206130-n	lit:lemma	boikotas
-01199083-s	lit:lemma	įvairus
+01199083-a	lit:lemma	įvairus
 00664788-v	lit:lemma	demonstruoti
 10344443-n	lit:lemma	žinomas asmuo
 00120095-r	lit:lemma	tuo pat metu
-02565425-s	lit:lemma	pasiruošęs
-00959244-s	lit:lemma	pastovus
+02565425-a	lit:lemma	pasiruošęs
+00959244-a	lit:lemma	pastovus
 03537866-n	lit:lemma	baisybė
 02653381-v	lit:lemma	glūdėti
 00134701-a	lit:lemma	tinkamas
 08381820-n	lit:lemma	vyriausybė
 01832604-a	lit:lemma	nepasodintas
-01692512-s	lit:lemma	lauko
+01692512-a	lit:lemma	lauko
 00060939-r	lit:lemma	pirmiau
 02386310-n	lit:lemma	darbinis arklys
 02541302-a	lit:lemma	nesveikas
 00424599-n	lit:lemma	žiaurus poelgis
 14526182-n	lit:lemma	nuotaika
 02894605-n	lit:lemma	bangolaužis
-00164308-s	lit:lemma	atidus
-01916979-s	lit:lemma	neaiškus
-01263445-s	lit:lemma	žvėriškas
+00164308-a	lit:lemma	atidus
+01916979-a	lit:lemma	neaiškus
+01263445-a	lit:lemma	žvėriškas
 07503430-n	lit:lemma	bjaurėjimasis
-02152473-s	lit:lemma	tarpusavis
-01383394-s	lit:lemma	nemažas
+02152473-a	lit:lemma	tarpusavis
+01383394-a	lit:lemma	nemažas
 01716227-a	lit:lemma	skanus
 14417551-n	lit:lemma	netolydumas
 01780202-v	lit:lemma	baimintis
@@ -4516,29 +4516,29 @@
 00050817-r	lit:lemma	atkakliai
 09785992-n	lit:lemma	labai artimas žmogus
 10150940-n	lit:lemma	svečias
-02477557-s	lit:lemma	vientisas
+02477557-a	lit:lemma	vientisas
 02937469-n	lit:lemma	gabalas
 05414147-n	lit:lemma	antidiurezinis hormonas
 15266911-n	lit:lemma	pabaiga
-01611973-s	lit:lemma	nežalingas
+01611973-a	lit:lemma	nežalingas
 09416076-n	lit:lemma	akmuo
 00411570-r	lit:lemma	jokiu būdu
 00061917-n	lit:lemma	realizavimas
 02018372-v	lit:lemma	suspėti
 09816771-n	lit:lemma	kolega
 03080101-a	lit:lemma	lotyniškas
-02394793-s	lit:lemma	netinkamas
+02394793-a	lit:lemma	netinkamas
 02682567-v	lit:lemma	išlaikyti
-00604978-s	lit:lemma	palankus
+00604978-a	lit:lemma	palankus
 05282247-n	lit:lemma	pieniniai dantys
 00374135-v	lit:lemma	užšalti
-00792202-s	lit:lemma	vyriausias
+00792202-a	lit:lemma	vyriausias
 01194483-a	lit:lemma	dėmesingas
-00807399-s	lit:lemma	nuobodus
+00807399-a	lit:lemma	nuobodus
 05588174-n	lit:lemma	nugarkaulis
-01676026-s	lit:lemma	išskirtinis
+01676026-a	lit:lemma	išskirtinis
 00023271-n	lit:lemma	žinojimas
-01199083-s	lit:lemma	margas
+01199083-a	lit:lemma	margas
 01955318-n	lit:lemma	moliuskų šilkas
 10077593-n	lit:lemma	mėgėjas
 07995453-n	lit:lemma	būrys
@@ -4546,7 +4546,7 @@
 00007846-n	lit:lemma	dvasia
 07523180-n	lit:lemma	baikštumas
 05019661-n	lit:lemma	jautris
-01038332-s	lit:lemma	vidaus
+01038332-a	lit:lemma	vidaus
 14709265-n	lit:lemma	etanolis
 03043274-n	lit:lemma	poliklinika
 10126424-n	lit:lemma	genetikos specialistas
@@ -4556,9 +4556,9 @@
 00394135-a	lit:lemma	spalvotas
 05790758-n	lit:lemma	numylėtinis
 00260430-a	lit:lemma	viduriniosios klasės
-02521036-s	lit:lemma	savanoriškas
+02521036-a	lit:lemma	savanoriškas
 14435670-n	lit:lemma	viešpats
-00414919-s	lit:lemma	sugrupuotas
+00414919-a	lit:lemma	sugrupuotas
 06390962-n	lit:lemma	juodraštis
 02956371-a	lit:lemma	komunikacinis
 08750986-n	lit:lemma	Gvantanamas
@@ -4569,9 +4569,9 @@
 00759944-v	lit:lemma	melstis
 08172695-n	lit:lemma	Europa
 08947319-n	lit:lemma	Gvinėjos Respublika
-01854129-s	lit:lemma	pagalbinis
+01854129-a	lit:lemma	pagalbinis
 01049475-n	lit:lemma	slėpimas
-01145151-s	lit:lemma	skardus
+01145151-a	lit:lemma	skardus
 08893223-n	lit:lemma	Hebridų salos
 05470189-n	lit:lemma	išauga
 07859284-n	lit:lemma	cukrus
@@ -4579,7 +4579,7 @@
 01613807-n	lit:lemma	ereliukas
 06756407-n	lit:lemma	melagystė
 00007846-n	lit:lemma	siela
-00122844-s	lit:lemma	sekantis
+00122844-a	lit:lemma	sekantis
 03465605-n	lit:lemma	pensionas
 01215421-a	lit:lemma	žemas
 00812274-n	lit:lemma	sugriebimas
@@ -4592,12 +4592,12 @@
 04548280-n	lit:lemma	sieninis laikrodis
 03113835-n	lit:lemma	apranga
 13292613-n	lit:lemma	atlyginimas
-02365900-s	lit:lemma	apsaugotas
+02365900-a	lit:lemma	apsaugotas
 01986483-a	lit:lemma	suderinamas
 10285313-n	lit:lemma	berniukas
 04633453-n	lit:lemma	veržlumas
 02504562-v	lit:lemma	versti
-01134486-s	lit:lemma	santūrus
+01134486-a	lit:lemma	santūrus
 01016778-v	lit:lemma	teigti
 08834408-n	lit:lemma	Pietų Australija
 14849880-n	lit:lemma	švitrinis popierius
@@ -4607,35 +4607,35 @@
 05301072-n	lit:lemma	liežuvis
 04882968-n	lit:lemma	savitvarda
 04664778-n	lit:lemma	akylumas
-00294579-s	lit:lemma	vangus
+00294579-a	lit:lemma	vangus
 00773814-n	lit:lemma	užpuolimas
-02418412-s	lit:lemma	galimas
+02418412-a	lit:lemma	galimas
 05982915-n	lit:lemma	mintis
 09428293-n	lit:lemma	paplūdimys
 02641012-a	lit:lemma	vienvalenčio sidabro
 09967063-n	lit:lemma	kosmetologas
-01856419-s	lit:lemma	pamatinis
+01856419-a	lit:lemma	pamatinis
 15174218-n	lit:lemma	Grigaliaus kalendorius
-01741669-s	lit:lemma	taikus
+01741669-a	lit:lemma	taikus
 07431852-n	lit:lemma	baltasis triukšmas
 09945905-n	lit:lemma	bendras
 11460488-n	lit:lemma	frontas
 02704949-n	lit:lemma	amfiteatras
-01372948-s	lit:lemma	nuoširdus
-01155603-s	lit:lemma	gudrus
+01372948-a	lit:lemma	nuoširdus
+01155603-a	lit:lemma	gudrus
 04603081-n	lit:lemma	dirbtuvė
 10748620-n	lit:lemma	svarbus asmuo
 10626540-n	lit:lemma	kerėtoja
 01199365-n	lit:lemma	pakartotinis bylos nagrinėjimas
 02411705-n	lit:lemma	avis
 08521267-n	lit:lemma	dangus
-01439155-s	lit:lemma	ilgai trunkantis
+01439155-a	lit:lemma	ilgai trunkantis
 03208556-n	lit:lemma	plokštelė
 10763383-n	lit:lemma	padavėjas
 15112932-n	lit:lemma	etoksiditiometano rūgštis
 02942577-n	lit:lemma	kamėja
 07457834-n	lit:lemma	čempionatas
-01300661-s	lit:lemma	korekcinis
+01300661-a	lit:lemma	korekcinis
 01878466-a	lit:lemma	tinkamas
 02931013-n	lit:lemma	kabrioletas
 08738820-n	lit:lemma	Nikaragva
@@ -4651,8 +4651,8 @@
 09227839-n	lit:lemma	uolos nuolauža
 03473465-n	lit:lemma	giroskopinis stabilizatorius
 00958896-n	lit:lemma	ginčas
-00440292-s	lit:lemma	bukas
-01802774-s	lit:lemma	siaubingas
+00440292-a	lit:lemma	bukas
+01802774-a	lit:lemma	siaubingas
 01771535-v	lit:lemma	jaustis
 00342028-n	lit:lemma	apsisukimas
 05474346-n	lit:lemma	nervas
@@ -4660,22 +4660,22 @@
 00362831-r	lit:lemma	teisėtai
 00115859-r	lit:lemma	politiškai
 00059552-n	lit:lemma	manevras
-01014953-s	lit:lemma	tarpinis
+01014953-a	lit:lemma	tarpinis
 01984902-v	lit:lemma	atsisėsti
 15153787-n	lit:lemma	senatvė
-02471984-s	lit:lemma	požeminis
+02471984-a	lit:lemma	požeminis
 08198398-n	lit:lemma	armija
 14543552-n	lit:lemma	pavojingumas
 10312077-n	lit:lemma	metalurgijos inžinierius
-01677200-s	lit:lemma	baisus
+01677200-a	lit:lemma	baisus
 01098698-n	lit:lemma	finansavimas
 02997740-a	lit:lemma	žadantis
 14381416-n	lit:lemma	fobija
-01757608-s	lit:lemma	laikinas
+01757608-a	lit:lemma	laikinas
 02563327-v	lit:lemma	paleisti
-01515280-s	lit:lemma	aktyvus
+01515280-a	lit:lemma	aktyvus
 00480993-n	lit:lemma	krepšinis
-02101942-s	lit:lemma	bulvarinis
+02101942-a	lit:lemma	bulvarinis
 00102736-r	lit:lemma	iš pradžių
 00626800-a	lit:lemma	materialus
 04861486-n	lit:lemma	pasiryžimas
@@ -4687,42 +4687,42 @@
 09622049-n	lit:lemma	nepilnametis
 07739125-n	lit:lemma	obuolys
 00105479-n	lit:lemma	sviedimas
-01036874-s	lit:lemma	vietinis
+01036874-a	lit:lemma	vietinis
 00112279-r	lit:lemma	tarptautiškai
 00806484-n	lit:lemma	kokybės kontrolė
 04277980-n	lit:lemma	knygos nugarėlė
-00279092-s	lit:lemma	blizgantis
+00279092-a	lit:lemma	blizgantis
 00202284-n	lit:lemma	opozicija
 00160532-n	lit:lemma	suviliojimas
 00575365-n	lit:lemma	lengvas uždavinys
-00197773-s	lit:lemma	tolimiausias
+00197773-a	lit:lemma	tolimiausias
 04634833-n	lit:lemma	smarkumas
 15293590-n	lit:lemma	tarnavimo laikas
 00230331-r	lit:lemma	išoriškai
-01564315-s	lit:lemma	inertiškas
+01564315-a	lit:lemma	inertiškas
 15284704-n	lit:lemma	galinis greitis
 03822951-n	lit:lemma	Niujorko birža
 00697188-a	lit:lemma	aiškus
 05770926-n	lit:lemma	mąstymas
-01642657-s	lit:lemma	esminis
+01642657-a	lit:lemma	esminis
 00120223-r	lit:lemma	drauge
 07504111-n	lit:lemma	pykinimas
 08253815-n	lit:lemma	pokylis
-01178458-s	lit:lemma	mazguotas
-01177435-s	lit:lemma	įaugantis
-01640261-s	lit:lemma	ilgalaikis
+01178458-a	lit:lemma	mazguotas
+01177435-a	lit:lemma	įaugantis
+01640261-a	lit:lemma	ilgalaikis
 10421470-n	lit:lemma	farmacininkas
 00254166-n	lit:lemma	pasterizacija
 04690196-n	lit:lemma	negražumas
 10753546-n	lit:lemma	nenaudėlis
 01491775-a	lit:lemma	brandus
 09402370-n	lit:lemma	kvazaras
-02050841-s	lit:lemma	agrikultūrinis
+02050841-a	lit:lemma	agrikultūrinis
 01038808-a	lit:lemma	naminis
 02205272-v	lit:lemma	paimti
 09636339-n	lit:lemma	negras
-02552415-s	lit:lemma	bevandenis
-00063953-s	lit:lemma	netinkamas
+02552415-a	lit:lemma	bevandenis
+00063953-a	lit:lemma	netinkamas
 09241247-n	lit:lemma	kanalas
 08436562-n	lit:lemma	amatas
 07291312-n	lit:lemma	pabaiga
@@ -4740,14 +4740,14 @@
 03413428-n	lit:lemma	kazino
 14954822-n	lit:lemma	mėnulio akmuo
 03241335-n	lit:lemma	geriamojo vandens fontanėlis
-00067379-s	lit:lemma	geriausias
+00067379-a	lit:lemma	geriausias
 00260051-n	lit:lemma	optimizacija
 09963320-n	lit:lemma	virėjas
 08507255-n	lit:lemma	minų laukas
 06964901-n	lit:lemma	prancūzų kalba
 09983572-n	lit:lemma	pastorius
 10752480-n	lit:lemma	apgaulės auka
-01723091-s	lit:lemma	šališkas
+01723091-a	lit:lemma	šališkas
 07340094-n	lit:lemma	nuostolis
 02132580-n	lit:lemma	grizlis
 01177703-n	lit:lemma	demonstracija
@@ -4756,7 +4756,7 @@
 00033421-r	lit:lemma	tučtuojau
 02136271-v	lit:lemma	atsispindėti
 00069531-a	lit:lemma	estetinis
-01742715-s	lit:lemma	militaristinis
+01742715-a	lit:lemma	militaristinis
 01792042-n	lit:lemma	viščiukas
 00250153-r	lit:lemma	tolygiai
 07250034-n	lit:lemma	reklama
@@ -4768,13 +4768,13 @@
 02963942-a	lit:lemma	Serbijos
 03023449-a	lit:lemma	paryžietiškas
 08305568-n	lit:lemma	muitų sąjunga
-00659259-s	lit:lemma	plokščias
+00659259-a	lit:lemma	plokščias
 13263779-n	lit:lemma	palikimas
 00714884-v	lit:lemma	diskutuoti
 03790230-n	lit:lemma	motorlaivis
 07233634-n	lit:lemma	prakeikimas
 05139094-n	lit:lemma	yda
-02569558-s	lit:lemma	išmintingas
+02569558-a	lit:lemma	išmintingas
 08110373-n	lit:lemma	rūšis
 01236164-v	lit:lemma	trenktis
 09503877-n	lit:lemma	antgamtiniai reiškiniai
@@ -4784,7 +4784,7 @@
 08407330-n	lit:lemma	institucija
 00908492-n	lit:lemma	kūrimas
 03398467-n	lit:lemma	priešakys
-01581305-s	lit:lemma	perteklinis
+01581305-a	lit:lemma	perteklinis
 09298410-n	lit:lemma	Gvinėjos įlanka
 09194357-n	lit:lemma	Alpės
 00102457-n	lit:lemma	mechanizacija
@@ -4795,8 +4795,8 @@
 06637824-n	lit:lemma	duomenų bazė
 04072193-n	lit:lemma	reguliatorius
 04820258-n	lit:lemma	suprantamumas
-01805801-s	lit:lemma	pasitenkinęs
-01719779-s	lit:lemma	įžambus
+01805801-a	lit:lemma	pasitenkinęs
+01719779-a	lit:lemma	įžambus
 03839993-n	lit:lemma	stabdys
 05529729-n	lit:lemma	gerklos
 14477667-n	lit:lemma	kančia
@@ -4810,24 +4810,24 @@
 14514805-n	lit:lemma	karalystė
 07738353-n	lit:lemma	lukštas
 06712325-n	lit:lemma	pamokslavimas
-00463399-s	lit:lemma	pajūrinis
-01649720-s	lit:lemma	jaunas
+00463399-a	lit:lemma	pajūrinis
+01649720-a	lit:lemma	jaunas
 01433267-a	lit:lemma	nuostolingas
 06999802-n	lit:lemma	lentelė
 11465688-n	lit:lemma	kruša
 05838765-n	lit:lemma	skyrius
 07307477-n	lit:lemma	įvykis
 07135080-n	lit:lemma	plepėjimas
-00592880-s	lit:lemma	daugkartinis
+00592880-a	lit:lemma	daugkartinis
 14778436-n	lit:lemma	veiksnys
 10499355-n	lit:lemma	valdovė
 04743370-n	lit:lemma	vienybė
 07506149-n	lit:lemma	kietaširdiškumas
 02395115-a	lit:lemma	gardus
 00154213-r	lit:lemma	saugiai
-02557719-s	lit:lemma	maitinamasis
+02557719-a	lit:lemma	maitinamasis
 06600684-n	lit:lemma	nukrypimas
-02163602-s	lit:lemma	vertas dėmesio
+02163602-a	lit:lemma	vertas dėmesio
 13474290-n	lit:lemma	spinduliavimas
 06410904-n	lit:lemma	knygelė
 00532739-n	lit:lemma	fandangas
@@ -4839,17 +4839,17 @@
 08588294-n	lit:lemma	vidus
 00704690-v	lit:lemma	planuoti
 01155090-v	lit:lemma	pasivyti
-00169692-s	lit:lemma	tamsokas
+00169692-a	lit:lemma	tamsokas
 03125792-a	lit:lemma	kirpėjų
 05790758-n	lit:lemma	favoritas
 10569744-n	lit:lemma	sekretorius
 08189659-n	lit:lemma	vienetas
 00583089-n	lit:lemma	verslas
 09081213-n	lit:lemma	Aidahas
-02121123-s	lit:lemma	lengvabūdis
+02121123-a	lit:lemma	lengvabūdis
 11900569-n	lit:lemma	aguona
-00068180-s	lit:lemma	apsvarstytas
-01871473-s	lit:lemma	pelningas
+00068180-a	lit:lemma	apsvarstytas
+01871473-a	lit:lemma	pelningas
 08049401-n	lit:lemma	susivienijimas
 10016103-n	lit:lemma	pasekėjas
 00236483-a	lit:lemma	bevardis
@@ -4867,15 +4867,15 @@
 00863049-a	lit:lemma	taikomasis
 13434120-n	lit:lemma	agamogonija
 10245863-n	lit:lemma	kraštovaizdžio specialistas
-00661640-s	lit:lemma	supjaustytas
-02587738-s	lit:lemma	naudingas
+00661640-a	lit:lemma	supjaustytas
+02587738-a	lit:lemma	naudingas
 10051975-n	lit:lemma	pabėgėlis
-00840212-s	lit:lemma	ekonomiškas
-00405879-s	lit:lemma	pabalęs
+00840212-a	lit:lemma	ekonomiškas
+00405879-a	lit:lemma	pabalęs
 01229223-n	lit:lemma	pagarba
 00505114-r	lit:lemma	jeigu tiktai
 03047553-n	lit:lemma	barjeras
-01413763-s	lit:lemma	tikroviškas
+01413763-a	lit:lemma	tikroviškas
 01831473-a	lit:lemma	pasodintas
 09386422-n	lit:lemma	dalelytė
 08267640-n	lit:lemma	matrica
@@ -4884,47 +4884,47 @@
 02099774-a	lit:lemma	viršesnis
 00174735-r	lit:lemma	stipriai
 03177059-n	lit:lemma	išvykimo salė
-00152629-s	lit:lemma	nebylus
-01062393-s	lit:lemma	nepriklausomas
-01313649-s	lit:lemma	atokus
+00152629-a	lit:lemma	nebylus
+01062393-a	lit:lemma	nepriklausomas
+01313649-a	lit:lemma	atokus
 09379111-n	lit:lemma	anga
-01287486-s	lit:lemma	matomas
+01287486-a	lit:lemma	matomas
 15180528-n	lit:lemma	laikas
-00343226-s	lit:lemma	lemtingas
+00343226-a	lit:lemma	lemtingas
 01932973-a	lit:lemma	esamas
-01022785-s	lit:lemma	lankstus
-00541614-s	lit:lemma	paplitęs
+01022785-a	lit:lemma	lankstus
+00541614-a	lit:lemma	paplitęs
 13381734-n	lit:lemma	čekis
-01142196-s	lit:lemma	maloningas
+01142196-a	lit:lemma	maloningas
 02769358-a	lit:lemma	nominalus
 00959827-v	lit:lemma	išversti
-00097768-s	lit:lemma	negyvas
+00097768-a	lit:lemma	negyvas
 10006511-n	lit:lemma	palikuonis
 09308572-n	lit:lemma	ledkalnis
 00038262-n	lit:lemma	kelias
 14811706-n	lit:lemma	chromo rūgštis
 00543114-n	lit:lemma	karo šokis
-01372948-s	lit:lemma	geraširdis
+01372948-a	lit:lemma	geraširdis
 08061042-n	lit:lemma	firma
 00456199-n	lit:lemma	rungtynės
-00979366-s	lit:lemma	spartus
+00979366-a	lit:lemma	spartus
 09945603-n	lit:lemma	komunistų partijos narys
 14801921-n	lit:lemma	ketus
 02863724-a	lit:lemma	anglies
-01461292-s	lit:lemma	simpatiškas
+01461292-a	lit:lemma	simpatiškas
 00658942-a	lit:lemma	dvimatis
 08792548-n	lit:lemma	Izraelio Valstybė
 07397355-n	lit:lemma	perkūnas
 09403734-n	lit:lemma	kalnų virtinė
-00286837-s	lit:lemma	liberalus
+00286837-a	lit:lemma	liberalus
 09626031-n	lit:lemma	nedirbantysis
 11447851-n	lit:lemma	akstinas
 13104059-n	lit:lemma	medis
 02957276-a	lit:lemma	Rusijos
-00844719-s	lit:lemma	lankstus
+00844719-a	lit:lemma	lankstus
 03712337-n	lit:lemma	didburė
 09374306-n	lit:lemma	Norvegijos jūra
-02516148-s	lit:lemma	vizualus
+02516148-a	lit:lemma	vizualus
 00378365-r	lit:lemma	tikrai
 03174079-n	lit:lemma	skraidyklė
 06536389-n	lit:lemma	vertimas
@@ -4933,7 +4933,7 @@
 00019182-v	lit:lemma	vėl pabudinti
 01245471-n	lit:lemma	holokaustas
 00507927-r	lit:lemma	kartu
-02413390-s	lit:lemma	peršviečiamas
+02413390-a	lit:lemma	peršviečiamas
 04216963-n	lit:lemma	taikiklis
 00273048-r	lit:lemma	iš visų jėgų
 00106170-r	lit:lemma	vogčiomis
@@ -4946,9 +4946,9 @@
 08183290-n	lit:lemma	minia
 00575365-n	lit:lemma	vieni juokai
 13824929-n	lit:lemma	lūžio rodiklis
-01073435-s	lit:lemma	rūkytas
+01073435-a	lit:lemma	rūkytas
 00611802-v	lit:lemma	atsiminti
-01496311-s	lit:lemma	ribinis
+01496311-a	lit:lemma	ribinis
 01237901-v	lit:lemma	nepataikyti
 00027268-v	lit:lemma	ištiesti
 07184735-n	lit:lemma	barnis
@@ -4956,9 +4956,9 @@
 02156140-n	lit:lemma	nagas
 10100761-n	lit:lemma	neišmanėlis
 07342049-n	lit:lemma	pakartojimas
-01804422-s	lit:lemma	bjaurus
+01804422-a	lit:lemma	bjaurus
 02984781-a	lit:lemma	korporacinis
-00440579-s	lit:lemma	kvailas
+00440579-a	lit:lemma	kvailas
 02386612-a	lit:lemma	mažas
 03876519-n	lit:lemma	paveikslas
 07289014-n	lit:lemma	sunkumas
@@ -4969,11 +4969,11 @@
 08058098-n	lit:lemma	kompanija
 01764800-v	lit:lemma	maldyti
 05835747-n	lit:lemma	idėja
-01894196-s	lit:lemma	išmėgintas
+01894196-a	lit:lemma	išmėgintas
 04179126-n	lit:lemma	nutekamasis vamzdis
 10621847-n	lit:lemma	laikinas gyventojas
 00106503-r	lit:lemma	atsakingai
-00412171-s	lit:lemma	modernus
+00412171-a	lit:lemma	modernus
 03899328-n	lit:lemma	kelias
 08320052-n	lit:lemma	dūma
 00348801-n	lit:lemma	drebulys
@@ -4981,27 +4981,27 @@
 00136329-n	lit:lemma	smūgis koja
 01934554-a	lit:lemma	netikras
 00356790-n	lit:lemma	spaudimas
-01579128-s	lit:lemma	paskutinis
-02087178-s	lit:lemma	atidarytas
+01579128-a	lit:lemma	paskutinis
+02087178-a	lit:lemma	atidarytas
 05085991-n	lit:lemma	gretimumas
 00823532-n	lit:lemma	gynyba (teisme)
-02070342-s	lit:lemma	skirtingas
-02250430-s	lit:lemma	atsiskyręs
+02070342-a	lit:lemma	skirtingas
+02250430-a	lit:lemma	atsiskyręs
 00066191-v	lit:lemma	verkti
-01611973-s	lit:lemma	nekenksmingas
+01611973-a	lit:lemma	nekenksmingas
 06161223-n	lit:lemma	estetika
-01266397-s	lit:lemma	absurdiškas
+01266397-a	lit:lemma	absurdiškas
 13504497-n	lit:lemma	citokinezė
 05297523-n	lit:lemma	organas
 08544813-n	lit:lemma	šalis
 02724417-v	lit:lemma	sietis
 06248863-n	lit:lemma	teogonija
-01941604-s	lit:lemma	tikras
+01941604-a	lit:lemma	tikras
 11877646-n	lit:lemma	ropė
 06735533-n	lit:lemma	netiesioginis įrodymas
 05098099-n	lit:lemma	kraštutinybė
 07529096-n	lit:lemma	euforija
-01816376-s	lit:lemma	mėgstamas
+01816376-a	lit:lemma	mėgstamas
 00368663-r	lit:lemma	tiksliai
 07985628-n	lit:lemma	dvejetas
 10216106-n	lit:lemma	investuotojas
@@ -5010,7 +5010,7 @@
 08408267-n	lit:lemma	mugė
 10180923-n	lit:lemma	banditas
 14285662-n	lit:lemma	sužeidimas
-00018850-s	lit:lemma	ginčijamas
+00018850-a	lit:lemma	ginčijamas
 08585657-n	lit:lemma	akiratis
 06470073-n	lit:lemma	raštas
 01078783-v	lit:lemma	susitikti
@@ -5023,7 +5023,7 @@
 05784242-n	lit:lemma	apsvarstymas
 08737041-n	lit:lemma	Gvatemalos Respublika
 10311021-n	lit:lemma	pasiuntinys
-00510644-s	lit:lemma	produktyvus
+00510644-a	lit:lemma	produktyvus
 01953467-a	lit:lemma	neišgrynintas
 01628449-v	lit:lemma	pradėti
 10104064-n	lit:lemma	bosas
@@ -5031,27 +5031,27 @@
 01382086-a	lit:lemma	didelis
 04063373-n	lit:lemma	įrašymo įtaisas
 11409689-n	lit:lemma	fotolaidumas
-00219389-s	lit:lemma	puikus
+00219389-a	lit:lemma	puikus
 02068735-n	lit:lemma	delfininiai
 14414715-n	lit:lemma	izoliacija
 02637938-v	lit:lemma	palaukti
 02293321-v	lit:lemma	perduoti
-00590669-s	lit:lemma	ginčytinas
+00590669-a	lit:lemma	ginčytinas
 00060477-v	lit:lemma	iškastruoti
-01916784-s	lit:lemma	ginčijamas
-01159907-s	lit:lemma	nekenksmingas
+01916784-a	lit:lemma	ginčijamas
+01159907-a	lit:lemma	nekenksmingas
 01525776-a	lit:lemma	portatyvus
-01405523-s	lit:lemma	neįskaitomas
-00850648-s	lit:lemma	tvarkingas
-01196775-s	lit:lemma	pagalbinis
-00915321-s	lit:lemma	tikslus
+01405523-a	lit:lemma	neįskaitomas
+00850648-a	lit:lemma	tvarkingas
+01196775-a	lit:lemma	pagalbinis
+00915321-a	lit:lemma	tikslus
 12270741-n	lit:lemma	burgundinis ąžuolas
-00900071-s	lit:lemma	mistinis
+00900071-a	lit:lemma	mistinis
 06492939-n	lit:lemma	meniu
 06124532-n	lit:lemma	kraštovaizdžio architektūra
 01003050-a	lit:lemma	užbaigtas
 13816649-n	lit:lemma	procentas
-00168694-s	lit:lemma	malonus
+00168694-a	lit:lemma	malonus
 02891236-a	lit:lemma	mechaninis
 02825355-a	lit:lemma	balsinis
 00293307-n	lit:lemma	bridimas
@@ -5059,8 +5059,8 @@
 01926376-a	lit:lemma	iracionalus
 00297657-n	lit:lemma	bridimas
 03907227-n	lit:lemma	aptvaras
-01415219-s	lit:lemma	mažas
-01537448-s	lit:lemma	viduramžiškas
+01415219-a	lit:lemma	mažas
+01537448-a	lit:lemma	viduramžiškas
 00679147-a	lit:lemma	pažeistas
 13738327-n	lit:lemma	dešimtadalis
 03709206-n	lit:lemma	lupa
@@ -5068,7 +5068,7 @@
 00157081-n	lit:lemma	įtaka
 02160878-a	lit:lemma	pasirašytas
 04675314-n	lit:lemma	įspūdis
-01165943-s	lit:lemma	terapinis
+01165943-a	lit:lemma	terapinis
 00205375-r	lit:lemma	pelnytai
 05770926-n	lit:lemma	galvojimas
 07506569-n	lit:lemma	sarmata
@@ -5077,11 +5077,11 @@
 05336377-n	lit:lemma	aortos lankas
 04504141-n	lit:lemma	kostiumas
 13903387-n	lit:lemma	siena
-01854129-s	lit:lemma	papildomas
+01854129-a	lit:lemma	papildomas
 09337048-n	lit:lemma	plyšys
 04726724-n	lit:lemma	esmė
 15254028-n	lit:lemma	amžius
-01166413-s	lit:lemma	palankus
+01166413-a	lit:lemma	palankus
 07303335-n	lit:lemma	laužas
 03860404-n	lit:lemma	išvietė
 07335716-n	lit:lemma	prapuolimas
@@ -5090,9 +5090,9 @@
 05896059-n	lit:lemma	pramanas
 08319061-n	lit:lemma	prekybos rūmai
 09630641-n	lit:lemma	nelaimėlis
-02064127-s	lit:lemma	vienodas
+02064127-a	lit:lemma	vienodas
 00744305-n	lit:lemma	pakenkimas
-01263971-s	lit:lemma	žiaurus
+01263971-a	lit:lemma	žiaurus
 02686568-n	lit:lemma	skraidymo aparatas
 02026442-a	lit:lemma	nemokus
 07071942-n	lit:lemma	muzikos stilius
@@ -5105,12 +5105,12 @@
 00355080-r	lit:lemma	labai
 00665079-n	lit:lemma	slaugymas
 13446390-n	lit:lemma	cheminis procesas
-01729819-s	lit:lemma	pastaras
+01729819-a	lit:lemma	pastaras
 01412415-a	lit:lemma	neįtikėtinas
 14803074-n	lit:lemma	anglinis plienas
 08511970-n	lit:lemma	dugnas
 10488309-n	lit:lemma	aiškiaregys
-01573238-s	lit:lemma	suklastotas
+01573238-a	lit:lemma	suklastotas
 01080366-n	lit:lemma	grupinė veikla
 15137676-n	lit:lemma	laisvalaikis
 01151110-v	lit:lemma	taikyti
@@ -5118,13 +5118,13 @@
 09164561-n	lit:lemma	Jemenas
 06832033-n	lit:lemma	I
 04898437-n	lit:lemma	padorumas
-00709215-s	lit:lemma	dužus
+00709215-a	lit:lemma	dužus
 14417551-n	lit:lemma	vientisumo stoka
 09178999-n	lit:lemma	pagrindas
 00281237-r	lit:lemma	apdairiai
-00224515-s	lit:lemma	piktas
-01715287-s	lit:lemma	aprašytas
-00799401-s	lit:lemma	apsvaigęs nuo narkotikų
+00224515-a	lit:lemma	piktas
+01715287-a	lit:lemma	aprašytas
+00799401-a	lit:lemma	apsvaigęs nuo narkotikų
 00654885-n	lit:lemma	priežiūra
 08464601-n	lit:lemma	judėjimas
 00156222-r	lit:lemma	tarp kita ko
@@ -5135,9 +5135,9 @@
 03717131-n	lit:lemma	ėdžios
 03213014-n	lit:lemma	skirstytuvas
 15279596-n	lit:lemma	kilohercas
-00167829-s	lit:lemma	žavus
+00167829-a	lit:lemma	žavus
 00689062-n	lit:lemma	nosies plastinė operacija
-00750296-s	lit:lemma	paprastas
+00750296-a	lit:lemma	paprastas
 00210768-r	lit:lemma	iš papratimo
 03147509-n	lit:lemma	puodukas
 01090446-n	lit:lemma	prekyba
@@ -5151,22 +5151,22 @@
 13945919-n	lit:lemma	statusas
 08296720-n	lit:lemma	ECOSOC
 15141213-n	lit:lemma	tūkstantmetis
-00012362-s	lit:lemma	konceptualus
+00012362-a	lit:lemma	konceptualus
 01823092-a	lit:lemma	neįmanomas
-01459755-s	lit:lemma	mielas
-00646117-s	lit:lemma	neįtikėtinas
+01459755-a	lit:lemma	mielas
+00646117-a	lit:lemma	neįtikėtinas
 14912387-n	lit:lemma	druskos rūgštis
 02829565-a	lit:lemma	įstatymų leidžiamasis
 00426958-v	lit:lemma	prapulti
 02939272-a	lit:lemma	pakrančių
-00090219-s	lit:lemma	grubus
+00090219-a	lit:lemma	grubus
 04078747-n	lit:lemma	tvenkinys
 14333645-n	lit:lemma	skausmas šlapinantis
 02781764-n	lit:lemma	kardiografas
-00370267-s	lit:lemma	žydras
+00370267-a	lit:lemma	žydras
 01792429-n	lit:lemma	gaidžiukas
 01021629-v	lit:lemma	suorganizuoti
-02512641-s	lit:lemma	banditiškas
+02512641-a	lit:lemma	banditiškas
 13721804-n	lit:lemma	megatona
 09698788-n	lit:lemma	Kosta Rikos gyventojas
 10180178-n	lit:lemma	turėtojas
@@ -5187,10 +5187,10 @@
 05518094-n	lit:lemma	folikulas
 07943870-n	lit:lemma	pagyvenę žmonės
 00240938-n	lit:lemma	įdiegimas
-01893510-s	lit:lemma	nuolaidus
+01893510-a	lit:lemma	nuolaidus
 14580752-n	lit:lemma	cheminė sudėtis
-02499148-s	lit:lemma	teisėtas
-00051571-s	lit:lemma	kompetentingas
+02499148-a	lit:lemma	teisėtas
+00051571-a	lit:lemma	kompetentingas
 02172870-n	lit:lemma	grambuolys
 00163047-n	lit:lemma	valia
 01237415-n	lit:lemma	integracija
@@ -5210,7 +5210,7 @@
 04550426-n	lit:lemma	drabužiai
 00177483-r	lit:lemma	silpnai
 03249569-n	lit:lemma	būgnas
-00930765-s	lit:lemma	nenumatytas
+00930765-a	lit:lemma	nenumatytas
 01636859-v	lit:lemma	svajoti
 10647359-n	lit:lemma	prekiautojas pašto ženklais
 00366675-n	lit:lemma	įtempimas
@@ -5218,9 +5218,9 @@
 00306900-n	lit:lemma	etapas
 04713118-n	lit:lemma	sutarimas
 00048268-r	lit:lemma	dabar
-02361848-s	lit:lemma	įkalbamas
+02361848-a	lit:lemma	įkalbamas
 02145814-v	lit:lemma	pasislėpti
-01781076-s	lit:lemma	psichinis
+01781076-a	lit:lemma	psichinis
 03895866-n	lit:lemma	vagonas
 00035058-r	lit:lemma	dažnai
 01981699-a	lit:lemma	atstovaujantis
@@ -5236,7 +5236,7 @@
 01027859-n	lit:lemma	ritualas
 00031820-v	lit:lemma	juoktis
 03398467-n	lit:lemma	violončelė
-02379157-s	lit:lemma	lygiagretus
+02379157-a	lit:lemma	lygiagretus
 03464467-n	lit:lemma	saugos įrenginys
 05816287-n	lit:lemma	informacija
 01064148-n	lit:lemma	atsipalaidavimas
@@ -5248,7 +5248,7 @@
 00133160-n	lit:lemma	smūgis atgalia ranka
 01105737-n	lit:lemma	laivyba
 09882716-n	lit:lemma	verslininkas
-00922840-s	lit:lemma	kasdieninis
+00922840-a	lit:lemma	kasdieninis
 00510189-n	lit:lemma	ūžavimas
 07628870-n	lit:lemma	pyragas
 00040365-r	lit:lemma	dar kartą
@@ -5257,7 +5257,7 @@
 05795044-n	lit:lemma	susitarimas
 00030142-v	lit:lemma	krizenti
 03839993-n	lit:lemma	kliūtis
-02421364-s	lit:lemma	taupus
+02421364-a	lit:lemma	taupus
 06818970-n	lit:lemma	rašmuo
 06434165-n	lit:lemma	Teisėjų knyga
 00883139-n	lit:lemma	uostymas
@@ -5265,7 +5265,7 @@
 00819235-a	lit:lemma	vėlesnis
 01205564-n	lit:lemma	kompromisas
 05798043-n	lit:lemma	eksperimentas
-01916784-s	lit:lemma	problemiškas
+01916784-a	lit:lemma	problemiškas
 04033901-n	lit:lemma	plunksna
 15273522-n	lit:lemma	tarpuvaldis
 00406243-v	lit:lemma	rengti
@@ -5273,8 +5273,8 @@
 00277209-r	lit:lemma	atvirai
 00062330-r	lit:lemma	sąmoningai
 13774404-n	lit:lemma	daugybė
-00357556-s	lit:lemma	išskirtinis
-01689223-s	lit:lemma	trivialus
+00357556-a	lit:lemma	išskirtinis
+01689223-a	lit:lemma	trivialus
 00141806-n	lit:lemma	patikrinimas
 08796219-n	lit:lemma	Kalvarijos kalva
 03306207-n	lit:lemma	eksportas
@@ -5282,7 +5282,7 @@
 06514093-n	lit:lemma	pasakojimas
 04487996-n	lit:lemma	trofėjus
 05047059-n	lit:lemma	pavėlavimas
-01163941-s	lit:lemma	simfoninis
+01163941-a	lit:lemma	simfoninis
 08952190-n	lit:lemma	Vengrija
 03315805-n	lit:lemma	apsiuvai
 04007894-n	lit:lemma	dirbinys
@@ -5301,7 +5301,7 @@
 13400334-n	lit:lemma	hipoteka
 05849040-n	lit:lemma	požymis
 07207273-n	lit:lemma	atsisakymas
-02097480-s	lit:lemma	gundantis
+02097480-a	lit:lemma	gundantis
 00007846-n	lit:lemma	žmogus
 07734017-n	lit:lemma	pomidoras
 02131942-n	lit:lemma	tikrieji lokiai
@@ -5310,13 +5310,13 @@
 00502847-r	lit:lemma	švelniai
 02349980-n	lit:lemma	kengūriniai šokliai
 01170962-n	lit:lemma	barnis
-01126291-s	lit:lemma	baisus
+01126291-a	lit:lemma	baisus
 02009433-v	lit:lemma	išeiti
-02065665-s	lit:lemma	įvairus
+02065665-a	lit:lemma	įvairus
 02144835-v	lit:lemma	slėpti
-00338013-s	lit:lemma	abejotinas
+00338013-a	lit:lemma	abejotinas
 14491271-n	lit:lemma	turtingumas
-01259123-s	lit:lemma	antropomorfinis
+01259123-a	lit:lemma	antropomorfinis
 02790222-a	lit:lemma	žemės ūkio
 00347180-n	lit:lemma	purtymas
 09761310-n	lit:lemma	akordeonistas
@@ -5326,43 +5326,43 @@
 03130689-a	lit:lemma	vilnonis
 00305283-r	lit:lemma	noriai
 13903387-n	lit:lemma	riba
-00413861-s	lit:lemma	senovinis
+00413861-a	lit:lemma	senovinis
 10599354-n	lit:lemma	mulkis
-00383291-s	lit:lemma	ryškiai mėlynas
+00383291-a	lit:lemma	ryškiai mėlynas
 11476231-n	lit:lemma	atmosferos elektra
 00296585-n	lit:lemma	eitynės
 00721889-v	lit:lemma	įvertinti
 09092497-n	lit:lemma	Meinas
 00219855-r	lit:lemma	šiltai
-01958259-s	lit:lemma	kvalifikuotas
+01958259-a	lit:lemma	kvalifikuotas
 06696483-n	lit:lemma	apdovanojimas
 04210390-n	lit:lemma	šventojo kapas
 13526110-n	lit:lemma	biologinis procesas
-01536094-s	lit:lemma	šiuolaikinis
+01536094-a	lit:lemma	šiuolaikinis
 00165906-r	lit:lemma	labai greitai
-01167269-s	lit:lemma	prevencinis
+01167269-a	lit:lemma	prevencinis
 00006105-r	lit:lemma	didžia dalimi
 14009481-n	lit:lemma	eiga
 01323958-v	lit:lemma	nužudyti
-01246148-s	lit:lemma	priešiškas
+01246148-a	lit:lemma	priešiškas
 02472987-n	lit:lemma	žmonija
 04827957-n	lit:lemma	nuodėmė
 03696065-n	lit:lemma	bagažinė
-01384730-s	lit:lemma	didžiulis
-01565608-s	lit:lemma	animacinis
+01384730-a	lit:lemma	didžiulis
+01565608-a	lit:lemma	animacinis
 13386614-n	lit:lemma	grynieji pinigai
 05933246-n	lit:lemma	vaizdas
-00010726-s	lit:lemma	rajus
+00010726-a	lit:lemma	rajus
 03581125-n	lit:lemma	sankryža
 10595647-n	lit:lemma	ligonis
 00173498-r	lit:lemma	nekantriai
 02538626-a	lit:lemma	infliacinis
-01644225-s	lit:lemma	pagyvenęs
+01644225-a	lit:lemma	pagyvenęs
 07199565-n	lit:lemma	atsakymas
 03871628-n	lit:lemma	pakelis
 08292756-n	lit:lemma	laivynas
 04742766-n	lit:lemma	kitoniškumas
-02547862-s	lit:lemma	rasotas
+02547862-a	lit:lemma	rasotas
 01726692-n	lit:lemma	gyvatė
 10388732-n	lit:lemma	prižiūrėtojas
 10009276-n	lit:lemma	detektyvas
@@ -5395,7 +5395,7 @@
 00443231-n	lit:lemma	plūduriavimas
 04328329-n	lit:lemma	akumuliatorius
 00173353-r	lit:lemma	giliai
-01765237-s	lit:lemma	pirmumo teisės
+01765237-a	lit:lemma	pirmumo teisės
 14910748-n	lit:lemma	hidridas
 02329401-n	lit:lemma	graužikas
 07874995-n	lit:lemma	avižų košė
@@ -5412,13 +5412,13 @@
 00193406-n	lit:lemma	adaptacija
 03705379-n	lit:lemma	magnetas
 09837088-n	lit:lemma	banditas
-00820975-s	lit:lemma	šiuolaikinis
+00820975-a	lit:lemma	šiuolaikinis
 02839758-n	lit:lemma	bimetalinė plokštelė
-01378429-s	lit:lemma	suvoktas
-00520892-s	lit:lemma	absoliutus
+01378429-a	lit:lemma	suvoktas
+00520892-a	lit:lemma	absoliutus
 00188779-r	lit:lemma	su užsidegimu
 08361001-n	lit:lemma	autokratija
-01730060-s	lit:lemma	istorinis
+01730060-a	lit:lemma	istorinis
 14989545-n	lit:lemma	fenolis
 00733483-n	lit:lemma	pažeidimas
 13356985-n	lit:lemma	iždas
@@ -5427,7 +5427,7 @@
 05832745-n	lit:lemma	pareiga
 08947319-n	lit:lemma	Gvinėja
 13552270-n	lit:lemma	rūdijimas
-00526062-s	lit:lemma	platus
+00526062-a	lit:lemma	platus
 00271263-n	lit:lemma	smukimas
 08651832-n	lit:lemma	lindynių kvartalas
 15067025-n	lit:lemma	taninas
@@ -5438,13 +5438,13 @@
 07159791-n	lit:lemma	užkeikimas
 02328150-n	lit:lemma	Angoros triušis
 02483224-n	lit:lemma	gibonai
-01610484-s	lit:lemma	pastebėtas
+01610484-a	lit:lemma	pastebėtas
 04921011-n	lit:lemma	paveldas
 05982152-n	lit:lemma	tikslas
-01640124-s	lit:lemma	senų laikų
+01640124-a	lit:lemma	senų laikų
 02669789-v	lit:lemma	pakakti
 09465795-n	lit:lemma	elementarusis narvelis
-02499148-s	lit:lemma	legalus
+02499148-a	lit:lemma	legalus
 13083586-n	lit:lemma	induotis
 00267217-n	lit:lemma	adymas
 10122441-n	lit:lemma	gaučas
@@ -5454,24 +5454,24 @@
 09025728-n	lit:lemma	Kordoba
 00130432-r	lit:lemma	profesionaliai
 07204401-n	lit:lemma	atsisakymas
-00209916-s	lit:lemma	žoliškas
+00209916-a	lit:lemma	žoliškas
 01507134-a	lit:lemma	gailestingas
 13741022-n	lit:lemma	skaitmuo
 00042769-r	lit:lemma	deja
 00391599-n	lit:lemma	pašalinimas
 00065070-v	lit:lemma	skaudėti
 13516597-n	lit:lemma	mitozė
-01082714-s	lit:lemma	nepavykęs
+01082714-a	lit:lemma	nepavykęs
 13349395-n	lit:lemma	užstatas
 08006989-n	lit:lemma	nominalas
 06423619-n	lit:lemma	adresų knyga
 05319936-n	lit:lemma	rainelė
 00868196-n	lit:lemma	verkimas
 06042187-n	lit:lemma	dietologija
-02397496-s	lit:lemma	pipirinis
+02397496-a	lit:lemma	pipirinis
 13669860-n	lit:lemma	Kuveito dinaras
 00074790-n	lit:lemma	liapsusas
-02543034-s	lit:lemma	prirakintas prie lovos
+02543034-a	lit:lemma	prirakintas prie lovos
 00393149-r	lit:lemma	žemai
 03158885-n	lit:lemma	durklas
 13329641-n	lit:lemma	turtas
@@ -5480,21 +5480,21 @@
 08696737-n	lit:lemma	Europos žemynas
 14512817-n	lit:lemma	situacija
 00013793-r	lit:lemma	palankiai
-01711465-s	lit:lemma	skaudantis
+01711465-a	lit:lemma	skaudantis
 00229260-n	lit:lemma	nutraukimas
 05125193-n	lit:lemma	riba
 02289295-v	lit:lemma	uždirbti
-02332845-s	lit:lemma	neabejotinas
-01780343-s	lit:lemma	racionalus
-01497245-s	lit:lemma	turiningas
+02332845-a	lit:lemma	neabejotinas
+01780343-a	lit:lemma	racionalus
+01497245-a	lit:lemma	turiningas
 01825237-v	lit:lemma	norėti
-01276150-s	lit:lemma	esminis
+01276150-a	lit:lemma	esminis
 00507673-n	lit:lemma	azartinis žaidimas
 10034201-n	lit:lemma	girtuoklis
-00169692-s	lit:lemma	niūrus
+00169692-a	lit:lemma	niūrus
 04264628-n	lit:lemma	tarpo klavišas
 03894051-n	lit:lemma	dalelių detektorius
-01808227-s	lit:lemma	nuostabus
+01808227-a	lit:lemma	nuostabus
 02609813-a	lit:lemma	albanų
 00322228-n	lit:lemma	pakuotė
 00067045-r	lit:lemma	iš anksto
@@ -5509,16 +5509,16 @@
 05585665-n	lit:lemma	griaučių struktūra
 13294135-n	lit:lemma	stipendija
 08189659-n	lit:lemma	grupė
-00412788-s	lit:lemma	laukinis
+00412788-a	lit:lemma	laukinis
 00021702-r	lit:lemma	kažkada
 00510050-a	lit:lemma	kompetentingas
 14940386-n	lit:lemma	skystis
-01901186-s	lit:lemma	pavėlavęs
+01901186-a	lit:lemma	pavėlavęs
 10577284-n	lit:lemma	prekiautojas
 10314836-n	lit:lemma	akušerė
 04071102-n	lit:lemma	slėptuvė
-01040752-s	lit:lemma	atmintinas
-00874226-s	lit:lemma	judrus
+01040752-a	lit:lemma	atmintinas
+00874226-a	lit:lemma	judrus
 09620078-n	lit:lemma	gyventojas
 00893955-n	lit:lemma	treniruotė
 14802262-n	lit:lemma	suvirinimo geležis
@@ -5526,7 +5526,7 @@
 01012561-v	lit:lemma	patvirtinti
 13816649-n	lit:lemma	rodiklis
 10285135-n	lit:lemma	aristokratas
-00506601-s	lit:lemma	rūpestingas
+00506601-a	lit:lemma	rūpestingas
 00631737-v	lit:lemma	galvoti
 08222293-n	lit:lemma	publika
 02764438-v	lit:lemma	pliskėti
@@ -5551,16 +5551,16 @@
 00238022-n	lit:lemma	pristatymas
 07387509-n	lit:lemma	garsas
 04486054-n	lit:lemma	triumfo arka
-00127948-s	lit:lemma	kitas
+00127948-a	lit:lemma	kitas
 07260623-n	lit:lemma	norma
 06539770-n	lit:lemma	įsakymas
-01674242-s	lit:lemma	kasdieninis
+01674242-a	lit:lemma	kasdieninis
 03005423-a	lit:lemma	dramaturginis
 02743727-v	lit:lemma	lietis
-02413851-s	lit:lemma	siūliškas
-00182961-s	lit:lemma	rankinis
+02413851-a	lit:lemma	siūliškas
+00182961-a	lit:lemma	rankinis
 00037226-r	lit:lemma	tikrai
-02035086-s	lit:lemma	moralus
+02035086-a	lit:lemma	moralus
 10525436-n	lit:lemma	mažmenininkas
 04953954-n	lit:lemma	švytėjimas
 08182716-n	lit:lemma	tuntas
@@ -5569,7 +5569,7 @@
 06373314-n	lit:lemma	siužetas
 08081668-n	lit:lemma	tikėjimas
 05093080-n	lit:lemma	nedidelis šansas
-01968165-s	lit:lemma	kasdieninis
+01968165-a	lit:lemma	kasdieninis
 10071139-n	lit:lemma	tremtinys
 11667562-n	lit:lemma	vienaskilčiai
 00071165-r	lit:lemma	aplink
@@ -5587,7 +5587,7 @@
 03452953-n	lit:lemma	centrinė tribūna
 13902482-n	lit:lemma	smaigalys
 04371225-n	lit:lemma	maudyklė
-00570322-s	lit:lemma	nenugalimas
+00570322-a	lit:lemma	nenugalimas
 05285275-n	lit:lemma	akiduobė
 06766544-n	lit:lemma	aliuzija
 10037385-n	lit:lemma	alkoholikas
@@ -5597,7 +5597,7 @@
 00924825-n	lit:lemma	gamyba
 06831498-n	lit:lemma	dė
 05640729-n	lit:lemma	kompetentingumas
-01126841-s	lit:lemma	liūdnas
+01126841-a	lit:lemma	liūdnas
 00075998-v	lit:lemma	pervargti
 08350470-n	lit:lemma	Federalinė rezervų sistema
 00622266-n	lit:lemma	grumtynės
@@ -5610,7 +5610,7 @@
 07430770-n	lit:lemma	triukšmas
 01177327-n	lit:lemma	maištas
 02795670-n	lit:lemma	užeiga
-01084297-s	lit:lemma	pilnutėlis
+01084297-a	lit:lemma	pilnutėlis
 00042769-r	lit:lemma	nelaimei
 10197525-n	lit:lemma	kvailys
 09845999-n	lit:lemma	kosmetologas
@@ -5622,19 +5622,19 @@
 05833840-n	lit:lemma	idėja
 00047534-r	lit:lemma	be to
 10324851-n	lit:lemma	modelis
-01603179-s	lit:lemma	pietinis
+01603179-a	lit:lemma	pietinis
 02744323-n	lit:lemma	pagrindinis kelias
 00428000-n	lit:lemma	iškilmės
 08438533-n	lit:lemma	miškas
 08600274-n	lit:lemma	minimumas
-00390539-s	lit:lemma	baltas kaip pienas
+00390539-a	lit:lemma	baltas kaip pienas
 07135080-n	lit:lemma	šnekučiavimasis
 04585745-n	lit:lemma	gervė
-02199177-s	lit:lemma	milijoninis
+02199177-a	lit:lemma	milijoninis
 07343363-n	lit:lemma	pasikartojimas
 05292856-n	lit:lemma	alkūninis raumuo
 01020356-v	lit:lemma	užsirašyti
-00032497-s	lit:lemma	gimnastikos
+00032497-a	lit:lemma	gimnastikos
 06466677-n	lit:lemma	psalmė
 00586183-a	lit:lemma	ardomasis
 00017865-v	lit:lemma	eiti miegoti
@@ -5650,9 +5650,9 @@
 00294459-r	lit:lemma	dėl tos priežasties
 03325088-n	lit:lemma	čiaupas
 10182499-n	lit:lemma	naminis
-01175158-s	lit:lemma	išopėjęs
-01628531-s	lit:lemma	nemandagus
-00218950-s	lit:lemma	gerai atrodantis
+01175158-a	lit:lemma	išopėjęs
+01628531-a	lit:lemma	nemandagus
+00218950-a	lit:lemma	gerai atrodantis
 05667613-n	lit:lemma	paprotys
 03429914-n	lit:lemma	šydas
 09826204-n	lit:lemma	pilotas
@@ -5667,7 +5667,7 @@
 00054750-r	lit:lemma	vienas prieš kitą
 03859280-n	lit:lemma	ūkinis pastatas
 14739360-n	lit:lemma	karboksirūgštis
-02342608-s	lit:lemma	puikus
+02342608-a	lit:lemma	puikus
 14687633-n	lit:lemma	žibalas
 09632274-n	lit:lemma	nekvalifikuotas darbininkas
 00869583-n	lit:lemma	matematikos veiksmas
@@ -5678,7 +5678,7 @@
 06505935-n	lit:lemma	pastabos paraštėje
 00315986-n	lit:lemma	pergabenimas
 10794014-n	lit:lemma	rašytoja
-01807964-s	lit:lemma	žavus
+01807964-a	lit:lemma	žavus
 03093379-a	lit:lemma	olimpinis
 01364008-a	lit:lemma	liūdnas
 06667317-n	lit:lemma	įstatymų rinkinys
@@ -5693,7 +5693,7 @@
 09957523-n	lit:lemma	konservatorių partijos narys
 08179205-n	lit:lemma	varguoliai
 02708420-v	lit:lemma	praleisti
-02573987-s	lit:lemma	džiunglių
+02573987-a	lit:lemma	džiunglių
 00095502-n	lit:lemma	išlaisvinimas
 09620794-n	lit:lemma	čiabuvis
 02762169-n	lit:lemma	autopilotas
@@ -5702,7 +5702,7 @@
 00023773-n	lit:lemma	motyvas
 00136329-n	lit:lemma	spyrimas
 07435533-n	lit:lemma	epidemija
-00330728-s	lit:lemma	vidurinis
+00330728-a	lit:lemma	vidurinis
 02931148-n	lit:lemma	vairuotojo kabina
 04605446-n	lit:lemma	apsiautalas
 00737188-n	lit:lemma	nukrypimas nuo normos
@@ -5716,19 +5716,19 @@
 05732756-n	lit:lemma	rūšiavimas
 10294602-n	lit:lemma	jūreivis
 03208556-n	lit:lemma	diskas
-01916979-s	lit:lemma	abejotinas
+01916979-a	lit:lemma	abejotinas
 15202634-n	lit:lemma	kalendoriniai metai
 13398768-n	lit:lemma	beviltiška skola
 14967730-n	lit:lemma	gazolis
 03137558-a	lit:lemma	komercinis
 04931267-n	lit:lemma	išdėstymas
-01192035-s	lit:lemma	silpnas
+01192035-a	lit:lemma	silpnas
 05490578-n	lit:lemma	žievė
 09289709-n	lit:lemma	žirnelis
 14912387-n	lit:lemma	vandenilio chloridas
 00798245-n	lit:lemma	kampanija
 09018848-n	lit:lemma	Gruzija
-00453053-s	lit:lemma	intymus
+00453053-a	lit:lemma	intymus
 02250899-a	lit:lemma	lydimas
 06214744-n	lit:lemma	komunizmas
 01984317-v	lit:lemma	griūti
@@ -5740,21 +5740,21 @@
 08438223-n	lit:lemma	brūzgynas
 08274565-n	lit:lemma	būrys
 08946187-n	lit:lemma	Ganos Respublika
-01403760-s	lit:lemma	neteisėtas
+01403760-a	lit:lemma	neteisėtas
 08153022-n	lit:lemma	kardinolų kolegija
-02062133-s	lit:lemma	paklausus
-01050088-s	lit:lemma	nelaimingas
+02062133-a	lit:lemma	paklausus
+01050088-a	lit:lemma	nelaimingas
 06151942-n	lit:lemma	kriminologija
 07030718-n	lit:lemma	balsas
 13134059-n	lit:lemma	svogūnėlis
 00018302-r	lit:lemma	gana
-01625063-s	lit:lemma	koktus
+01625063-a	lit:lemma	koktus
 08049401-n	lit:lemma	asociacija
 00026192-n	lit:lemma	jausmas
 08766988-n	lit:lemma	VFR
 13283764-n	lit:lemma	atpildas
 03151916-n	lit:lemma	smailuma
-02405805-s	lit:lemma	nuotykingas
+02405805-a	lit:lemma	nuotykingas
 14931879-n	lit:lemma	vulkaninės kilmės uolienos
 10423589-n	lit:lemma	filosofas
 05667613-n	lit:lemma	norma
@@ -5762,7 +5762,7 @@
 14207561-n	lit:lemma	infarktas
 02959007-a	lit:lemma	portugalų
 08616311-n	lit:lemma	kelias
-02160622-s	lit:lemma	aklas
+02160622-a	lit:lemma	aklas
 10631941-n	lit:lemma	žinovas
 07369604-n	lit:lemma	adaptacija
 01857717-v	lit:lemma	užvesti
@@ -5782,63 +5782,63 @@
 00305431-r	lit:lemma	nenoromis
 04937848-n	lit:lemma	kietumas
 04339291-n	lit:lemma	juosta
-00974159-s	lit:lemma	senovinis
+00974159-a	lit:lemma	senovinis
 03779000-n	lit:lemma	modulis
 09721883-n	lit:lemma	malajietis
-00590163-s	lit:lemma	suirzęs
+00590163-a	lit:lemma	suirzęs
 01507134-a	lit:lemma	geraširdis
 04750164-n	lit:lemma	nepanašumas
 01146039-n	lit:lemma	apynasris
 05726596-n	lit:lemma	suskirstymas
-00796715-s	lit:lemma	vaidinamas
+00796715-a	lit:lemma	vaidinamas
 10009276-n	lit:lemma	seklys
 07560652-n	lit:lemma	maistas
 00739340-v	lit:lemma	galvoti
-01263971-s	lit:lemma	nuožmus
+01263971-a	lit:lemma	nuožmus
 00818466-n	lit:lemma	dispozicija
 09945319-n	lit:lemma	komunistas
-00286837-s	lit:lemma	tolerantiškas
+00286837-a	lit:lemma	tolerantiškas
 09545976-n	lit:lemma	vaiduoklis
 15233989-n	lit:lemma	papildomas laikas
 10641755-n	lit:lemma	šnipas
 00003431-v	lit:lemma	raugėti
-01870636-s	lit:lemma	mėgėjiškas
+01870636-a	lit:lemma	mėgėjiškas
 00039941-r	lit:lemma	rodos
 01471682-n	lit:lemma	stuburinis
 04648207-n	lit:lemma	lengvabūdiškumas
 04395024-n	lit:lemma	brezentas
-00177547-s	lit:lemma	palankus
+00177547-a	lit:lemma	palankus
 06782019-n	lit:lemma	požiūris
 00227023-r	lit:lemma	tiksliau
 11434899-n	lit:lemma	chaosas
-01898722-s	lit:lemma	gudrus
+01898722-a	lit:lemma	gudrus
 06146053-n	lit:lemma	epigrafika
 04714440-n	lit:lemma	nesuderinamumas
 01856553-n	lit:lemma	laukinė žąsis
 07963208-n	lit:lemma	šieno kūgis
 14844693-n	lit:lemma	molis
-00833018-s	lit:lemma	veikiantis
+00833018-a	lit:lemma	veikiantis
 03264542-n	lit:lemma	briauna
 09375085-n	lit:lemma	atomo branduolys
-01277097-s	lit:lemma	svarbiausias
-00511739-s	lit:lemma	nenašus
+01277097-a	lit:lemma	svarbiausias
+00511739-a	lit:lemma	nenašus
 05858936-n	lit:lemma	pastovusis dydis
-00968730-s	lit:lemma	neįprastas
-00461609-s	lit:lemma	ūkanotas
+00968730-a	lit:lemma	neįprastas
+00461609-a	lit:lemma	ūkanotas
 13262663-n	lit:lemma	nešvarūs pinigai
 00996485-v	lit:lemma	pasirašyti
 13518963-n	lit:lemma	gamtos reiškinys
 13367070-n	lit:lemma	atsarga
 05726596-n	lit:lemma	sistema
 06373513-n	lit:lemma	įvykis
-00167829-s	lit:lemma	žavingas
+00167829-a	lit:lemma	žavingas
 01904930-v	lit:lemma	žingsniuoti
 09572425-n	lit:lemma	titanas
-01366062-s	lit:lemma	liūdnas
+01366062-a	lit:lemma	liūdnas
 01219603-a	lit:lemma	žemumų
-00608791-s	lit:lemma	ekstravagantiškas
+00608791-a	lit:lemma	ekstravagantiškas
 05465567-n	lit:lemma	nervinė ląstelė
-01866812-s	lit:lemma	bevaisis
+01866812-a	lit:lemma	bevaisis
 00238022-n	lit:lemma	debiutas
 02555387-a	lit:lemma	vandeninis
 00294452-n	lit:lemma	sprintas
@@ -5850,19 +5850,19 @@
 06771653-n	lit:lemma	rašytinis susitarimas
 02729963-v	lit:lemma	priklausyti
 05710687-n	lit:lemma	nustatymas
-01374183-s	lit:lemma	šiurkštus
-00260100-s	lit:lemma	darbininkiškas
-00699521-s	lit:lemma	pirminis
+01374183-a	lit:lemma	šiurkštus
+00260100-a	lit:lemma	darbininkiškas
+00699521-a	lit:lemma	pirminis
 03445120-n	lit:lemma	aukso kasykla
 05124928-n	lit:lemma	aukščiausias laipsnis
 13867641-n	lit:lemma	kreivė
 00875519-n	lit:lemma	įkainojimas
 06598915-n	lit:lemma	pranešimas
-00422168-s	lit:lemma	riebaluotas
+00422168-a	lit:lemma	riebaluotas
 00512522-n	lit:lemma	flirtas
 01078783-v	lit:lemma	susidurti
-01151740-s	lit:lemma	kietas
-01697878-s	lit:lemma	saulės kepinamas
+01151740-a	lit:lemma	kietas
+01697878-a	lit:lemma	saulės kepinamas
 13453428-n	lit:lemma	korozija
 00443231-n	lit:lemma	plaukimas
 05888929-n	lit:lemma	teorija
@@ -5877,9 +5877,9 @@
 03183080-n	lit:lemma	prietaisas
 02752987-a	lit:lemma	teisinis
 03722288-n	lit:lemma	turgavietė
-02081114-s	lit:lemma	šaunus
-01525320-s	lit:lemma	nepajudinamas
-01059711-s	lit:lemma	nejudantis
+02081114-a	lit:lemma	šaunus
+01525320-a	lit:lemma	nepajudinamas
+01059711-a	lit:lemma	nejudantis
 01176335-n	lit:lemma	peštynės
 01021629-v	lit:lemma	surengti
 05547508-n	lit:lemma	ryklė
@@ -5889,19 +5889,19 @@
 00234201-r	lit:lemma	atskirai
 09996784-n	lit:lemma	dekanas
 06424869-n	lit:lemma	raktas
-00107017-s	lit:lemma	skurdus
+00107017-a	lit:lemma	skurdus
 15155220-n	lit:lemma	para
 02955065-n	lit:lemma	dangtelis
 13962048-n	lit:lemma	kailis
 09851165-n	lit:lemma	pirmūnas
 08182716-n	lit:lemma	minia
-01492596-s	lit:lemma	nebrandus
+01492596-a	lit:lemma	nebrandus
 01754421-a	lit:lemma	pastovus
 01235258-n	lit:lemma	atsilyginimas
 00150432-r	lit:lemma	visiškai
-02523092-s	lit:lemma	vegetacinis
+02523092-a	lit:lemma	vegetacinis
 13796779-n	lit:lemma	gramatinis ryšys
-00507292-s	lit:lemma	kietaširdis
+00507292-a	lit:lemma	kietaširdis
 06725877-n	lit:lemma	pareiškimas
 03173929-n	lit:lemma	furgonas
 00112601-r	lit:lemma	ką tik
@@ -5910,18 +5910,18 @@
 13576355-n	lit:lemma	neapibrėžtasis dydis
 02100709-a	lit:lemma	jaunesnysis
 15091846-n	lit:lemma	folio rūgštis
-00974519-s	lit:lemma	senamadis
+00974519-a	lit:lemma	senamadis
 07092592-n	lit:lemma	poezija
-01397998-s	lit:lemma	skylėtas
+01397998-a	lit:lemma	skylėtas
 00315986-n	lit:lemma	pervežimas
 10001217-n	lit:lemma	išnešiotojas
 00415963-r	lit:lemma	per daug
 02488834-v	lit:lemma	vesti
 11501381-n	lit:lemma	lietus
-01899167-s	lit:lemma	protingas
+01899167-a	lit:lemma	protingas
 09895701-n	lit:lemma	sargas
 00693743-a	lit:lemma	de facto
-01937390-s	lit:lemma	iliuzinis
+01937390-a	lit:lemma	iliuzinis
 00053004-r	lit:lemma	gerai
 01218797-a	lit:lemma	mažaaukštis
 02582615-v	lit:lemma	padaryti
@@ -5929,18 +5929,18 @@
 06722453-n	lit:lemma	žinia
 05833252-n	lit:lemma	ryšulys
 04808639-n	lit:lemma	populiarumas
-00127137-s	lit:lemma	ankstesnis
-01796977-s	lit:lemma	vingiuotas
+00127137-a	lit:lemma	ankstesnis
+01796977-a	lit:lemma	vingiuotas
 01619929-v	lit:lemma	sugriauti
-01645678-s	lit:lemma	žilas
+01645678-a	lit:lemma	žilas
 01012712-n	lit:lemma	klasifikavimas
 05099796-n	lit:lemma	intensyvumas
-01294975-s	lit:lemma	būsimas
+01294975-a	lit:lemma	būsimas
 04139140-n	lit:lemma	katilas
 08303275-n	lit:lemma	konfederacija
 00263272-n	lit:lemma	apiforminimas
 02450256-v	lit:lemma	dalintis
-00012932-s	lit:lemma	ideologinis
+00012932-a	lit:lemma	ideologinis
 10127273-n	lit:lemma	mandagus vyras
 04158956-n	lit:lemma	jūreiviška skrynelė
 00882523-v	lit:lemma	perduoti linkėjimus
@@ -5948,14 +5948,14 @@
 00303221-n	lit:lemma	skridimas oro balionu
 00104539-n	lit:lemma	sviedimas
 02934451-n	lit:lemma	lyninis keltuvas
-01732131-s	lit:lemma	šiandieninis
+01732131-a	lit:lemma	šiandieninis
 07019633-n	lit:lemma	lėlių vaidinimas
 09908678-n	lit:lemma	keliaujantis pirklys
 08750334-n	lit:lemma	Kubos Respublika
 07601999-n	lit:lemma	šokoladas
 09439120-n	lit:lemma	muilo burbulas
 04403638-n	lit:lemma	teleskopas
-01192035-s	lit:lemma	lengvas
+01192035-a	lit:lemma	lengvas
 08929243-n	lit:lemma	Kuveito Valstybė
 05275315-n	lit:lemma	klubakaulis
 01848718-v	lit:lemma	išvykti
@@ -5965,12 +5965,12 @@
 01115585-v	lit:lemma	pasiduoti
 08569998-n	lit:lemma	laukas
 14447908-n	lit:lemma	gerovė
-00910101-s	lit:lemma	plokščias
+00910101-a	lit:lemma	plokščias
 00322634-n	lit:lemma	įšvirkštimas
 00227023-r	lit:lemma	tiesą sakant
 07992116-n	lit:lemma	žąsų pulkas
 01548193-a	lit:lemma	dorinis
-01496311-s	lit:lemma	nežymus
+01496311-a	lit:lemma	nežymus
 00035758-v	lit:lemma	valyti
 03596787-n	lit:lemma	brangakmenis
 02005948-v	lit:lemma	atvykti
@@ -5987,30 +5987,30 @@
 13770729-n	lit:lemma	šaukštelis
 00239064-r	lit:lemma	pėsčiom
 04223580-n	lit:lemma	plautuvė
-02550333-s	lit:lemma	lietingas
+02550333-a	lit:lemma	lietingas
 02973236-n	lit:lemma	vežimo ratas
-01252151-s	lit:lemma	ledinis
-00065064-s	lit:lemma	teigiamas
+01252151-a	lit:lemma	ledinis
+00065064-a	lit:lemma	teigiamas
 01716491-a	lit:lemma	neskanus
 00448466-n	lit:lemma	čiuožimas
 00580880-n	lit:lemma	šeimininkavimas
-01440641-s	lit:lemma	ilgo galiojimo
+01440641-a	lit:lemma	ilgo galiojimo
 09110422-n	lit:lemma	Nevada
 09820263-n	lit:lemma	sportininkas
-00861216-s	lit:lemma	hipotetinis
-01644225-s	lit:lemma	senyvas
+00861216-a	lit:lemma	hipotetinis
+01644225-a	lit:lemma	senyvas
 00540235-v	lit:lemma	išsiplėsti
 00629997-a	lit:lemma	materialus
 11449907-n	lit:lemma	elektra
-00554098-s	lit:lemma	prieštaringas
+00554098-a	lit:lemma	prieštaringas
 00502415-n	lit:lemma	stalo žaidimas
 15154774-n	lit:lemma	laiko vienetas
-02332604-s	lit:lemma	vaisingas
+02332604-a	lit:lemma	vaisingas
 03629986-n	lit:lemma	laboratorija
 09615465-n	lit:lemma	priešininkas
 00373544-n	lit:lemma	paaukštinimas
 01248852-n	lit:lemma	atnaujinimas
-02038126-s	lit:lemma	augalotas
+02038126-a	lit:lemma	augalotas
 00031974-a	lit:lemma	aktyvus
 08541130-n	lit:lemma	miesto ribos
 15157041-n	lit:lemma	para
@@ -6020,40 +6020,40 @@
 10453357-n	lit:lemma	varguolis
 00417787-r	lit:lemma	pro
 09617867-n	lit:lemma	ekspertas
-01706465-s	lit:lemma	paslaptingas
+01706465-a	lit:lemma	paslaptingas
 03002948-n	lit:lemma	taurė
 09792555-n	lit:lemma	pirmtakas
 10020890-n	lit:lemma	gydytojas
 00196417-r	lit:lemma	įdėmiai
-02075321-s	lit:lemma	beprotis
+02075321-a	lit:lemma	beprotis
 00021878-r	lit:lemma	retkarčiais
 02026433-v	lit:lemma	lydėti
 00340715-r	lit:lemma	nejudamai
 00038625-r	lit:lemma	žinoma
 10001217-n	lit:lemma	išvežiotojas
 04531873-n	lit:lemma	liemenė
-02323072-s	lit:lemma	pribloškiantis
+02323072-a	lit:lemma	pribloškiantis
 02881757-n	lit:lemma	katiliukas
 03044566-a	lit:lemma	arabiškas
-00053032-s	lit:lemma	kibus
+00053032-a	lit:lemma	kibus
 08709038-n	lit:lemma	Karibai
 13836371-n	lit:lemma	kampinė padėtis
 15238169-n	lit:lemma	vegetacijos laikotarpis
-00325995-s	lit:lemma	apdairus
-00372111-s	lit:lemma	rudas
+00325995-a	lit:lemma	apdairus
+00372111-a	lit:lemma	rudas
 02931417-n	lit:lemma	naktinis baras
 15159583-n	lit:lemma	data
 05166805-n	lit:lemma	pozityvumas
-00874226-s	lit:lemma	žvitrus
+00874226-a	lit:lemma	žvitrus
 09836519-n	lit:lemma	matadoras
-02033450-s	lit:lemma	kairiausias
+02033450-a	lit:lemma	kairiausias
 00366393-r	lit:lemma	pats
-01855086-s	lit:lemma	atsarginis
+01855086-a	lit:lemma	atsarginis
 15250312-n	lit:lemma	sukaktis
 00964343-n	lit:lemma	mūšis
 01024392-n	lit:lemma	medicininė procedūra
 06722186-n	lit:lemma	interpoliacija
-01419462-s	lit:lemma	panašus
+01419462-a	lit:lemma	panašus
 01654377-a	lit:lemma	atviras
 08322981-n	lit:lemma	valdyba
 13914608-n	lit:lemma	blokas
@@ -6063,7 +6063,7 @@
 00035491-r	lit:lemma	keistai
 15152062-n	lit:lemma	pilnametystė
 04779649-n	lit:lemma	nesmagumas
-00587376-s	lit:lemma	kaustinis
+00587376-a	lit:lemma	kaustinis
 00146572-n	lit:lemma	konvergencija
 03660664-n	lit:lemma	biblioteka
 00442759-n	lit:lemma	deginimasis
@@ -6078,9 +6078,9 @@
 00492745-r	lit:lemma	tikrai
 13515149-n	lit:lemma	metafazė
 14327266-n	lit:lemma	skrandžio skausmas
-00529657-s	lit:lemma	ramus
+00529657-a	lit:lemma	ramus
 00124611-r	lit:lemma	legaliai
-01079052-s	lit:lemma	ledo sukaustytas
+01079052-a	lit:lemma	ledo sukaustytas
 02984061-n	lit:lemma	katedra
 00417397-n	lit:lemma	apkabinimas
 00477392-n	lit:lemma	vartinis tenisas
@@ -6091,19 +6091,19 @@
 00007739-v	lit:lemma	mirksėti
 02725714-v	lit:lemma	susiturėti
 13997253-n	lit:lemma	vergovė
-01214430-s	lit:lemma	spigus
+01214430-a	lit:lemma	spigus
 01022064-a	lit:lemma	lankstus
 00243918-n	lit:lemma	kulinarija
 15059552-n	lit:lemma	tulžies rūgštis
 01062997-n	lit:lemma	atokvėpis
-02083908-s	lit:lemma	sausas
+02083908-a	lit:lemma	sausas
 05548840-n	lit:lemma	petys
 06669513-n	lit:lemma	šališkumas
 03549732-n	lit:lemma	viršutinis denis
 03021866-a	lit:lemma	krūminis
 06664473-n	lit:lemma	leistinas greitis
 04951373-n	lit:lemma	šviesis
-00733297-s	lit:lemma	geidžiamas
+00733297-a	lit:lemma	geidžiamas
 00070965-n	lit:lemma	apsirikimas
 01319874-a	lit:lemma	tyras
 00037226-r	lit:lemma	išties
@@ -6111,8 +6111,8 @@
 13460299-n	lit:lemma	degeneracija
 13954818-n	lit:lemma	realybė
 02555387-a	lit:lemma	hidro-
-02018141-s	lit:lemma	poetiškas
-01277097-s	lit:lemma	pagrindinis
+02018141-a	lit:lemma	poetiškas
+01277097-a	lit:lemma	pagrindinis
 08003935-n	lit:lemma	dukterinė bendrovė
 02620587-v	lit:lemma	būti
 10696508-n	lit:lemma	žinovas
@@ -6128,29 +6128,29 @@
 01581115-a	lit:lemma	nereikalingas
 09831856-n	lit:lemma	priešas
 01101329-n	lit:lemma	reklama
-01308736-s	lit:lemma	nemokšiškas
+01308736-a	lit:lemma	nemokšiškas
 03610270-n	lit:lemma	atminimo dovana
 02722902-v	lit:lemma	siautėti
 00554200-n	lit:lemma	muštynės
-02552646-s	lit:lemma	visiškai sausas
+02552646-a	lit:lemma	visiškai sausas
 01425529-a	lit:lemma	vietinis
 03736970-n	lit:lemma	mechaninis įrenginys
 09972661-n	lit:lemma	kaubojus
 15206744-n	lit:lemma	mėnulio fazė
-02321809-s	lit:lemma	stiprus
+02321809-a	lit:lemma	stiprus
 14034177-n	lit:lemma	fiziologinė būklė
 00100002-r	lit:lemma	mažai
 06741305-n	lit:lemma	atsiprašymas
 13896100-n	lit:lemma	puslankis
 02796623-n	lit:lemma	kliūtis
 01777210-v	lit:lemma	patikti
-01150063-s	lit:lemma	meilės kankinamas
+01150063-a	lit:lemma	meilės kankinamas
 00007739-v	lit:lemma	mirkčioti
 08683548-n	lit:lemma	tyrlaukis
 00054212-r	lit:lemma	vėliau
-02031473-s	lit:lemma	liberalus
+02031473-a	lit:lemma	liberalus
 04438304-n	lit:lemma	laikmatis
-00667079-s	lit:lemma	dabartinis
+00667079-a	lit:lemma	dabartinis
 13864542-n	lit:lemma	entazis
 03148831-a	lit:lemma	priverstinis
 08795232-n	lit:lemma	Betliejus
@@ -6160,8 +6160,8 @@
 00122661-n	lit:lemma	šūvis
 06267564-n	lit:lemma	dienraštis
 00582071-n	lit:lemma	kanceliarinis darbas
-01618376-s	lit:lemma	akivaizdus
-02111095-s	lit:lemma	atskirtas
+01618376-a	lit:lemma	akivaizdus
+02111095-a	lit:lemma	atskirtas
 00259894-n	lit:lemma	kompensacija
 14481929-n	lit:lemma	galimybė
 09239740-n	lit:lemma	dangaus kūnas
@@ -6169,7 +6169,7 @@
 08556491-n	lit:lemma	teritorija
 01105840-a	lit:lemma	nacionalinis
 01063939-n	lit:lemma	laukimas
-00521976-s	lit:lemma	iš viso
+00521976-a	lit:lemma	iš viso
 00095329-n	lit:lemma	kompensacija
 14500341-n	lit:lemma	netvarka
 02789487-n	lit:lemma	baras
@@ -6191,13 +6191,13 @@
 07858595-n	lit:lemma	saldiklis
 04959230-n	lit:lemma	spalvinis tonas
 02997607-n	lit:lemma	keramikos dirbiniai
-01840121-s	lit:lemma	pažangus
+01840121-a	lit:lemma	pažangus
 02810471-n	lit:lemma	elementas
 00283235-r	lit:lemma	amžinai
 00325785-n	lit:lemma	alpinizmas
 08312559-n	lit:lemma	bažnyčios susirinkimas
 00629997-a	lit:lemma	fizinis
-01742119-s	lit:lemma	taikingas
+01742119-a	lit:lemma	taikingas
 00442115-n	lit:lemma	plaukimas
 04608567-n	lit:lemma	rašymo priemonė
 06515662-n	lit:lemma	metraštis
@@ -6209,7 +6209,7 @@
 03722288-n	lit:lemma	prekyvietė
 01749320-a	lit:lemma	tobulas
 03548086-n	lit:lemma	ratlankis
-00803432-s	lit:lemma	aštrus
+00803432-a	lit:lemma	aštrus
 05867413-n	lit:lemma	dalis
 04827652-n	lit:lemma	nedorumas
 00181576-r	lit:lemma	palengva
@@ -6217,11 +6217,11 @@
 04633453-n	lit:lemma	energingumas
 02713715-a	lit:lemma	diplomatinis
 01811909-n	lit:lemma	karvelis
-01581305-s	lit:lemma	papildomas
-01500247-s	lit:lemma	mechaniškas
+01581305-a	lit:lemma	papildomas
+01500247-a	lit:lemma	mechaniškas
 01135952-n	lit:lemma	administravimas
 01722529-a	lit:lemma	motiniškas
-02004685-s	lit:lemma	reguliavimo
+02004685-a	lit:lemma	reguliavimo
 06744396-n	lit:lemma	apibrėžimas
 00257182-r	lit:lemma	laikinai
 07946969-n	lit:lemma	episkopatas
@@ -6231,11 +6231,11 @@
 14434681-n	lit:lemma	svarbumas
 00102736-r	lit:lemma	pirma
 02159955-n	lit:lemma	vabzdys
-00608791-s	lit:lemma	keistas
-02032617-s	lit:lemma	dešiniausias
+00608791-a	lit:lemma	keistas
+02032617-a	lit:lemma	dešiniausias
 01036996-n	lit:lemma	vedybos
 13954253-n	lit:lemma	pragyvenimas
-02506922-s	lit:lemma	įvairialypis
+02506922-a	lit:lemma	įvairialypis
 02929289-n	lit:lemma	kontraforsas
 00033020-n	lit:lemma	pranešimas
 13721695-n	lit:lemma	kilotona
@@ -6260,11 +6260,11 @@
 00098933-a	lit:lemma	artezinis
 01708676-v	lit:lemma	šokti
 14122235-n	lit:lemma	užkrečiama liga
-00523867-s	lit:lemma	autonominis
-02044860-s	lit:lemma	apvalus
+00523867-a	lit:lemma	autonominis
+02044860-a	lit:lemma	apvalus
 04686003-n	lit:lemma	patrauklumas
 01339730-a	lit:lemma	numatytas
-02384077-s	lit:lemma	tauškus
+02384077-a	lit:lemma	tauškus
 06079620-n	lit:lemma	biochemija
 10768585-n	lit:lemma	karys
 05715283-n	lit:lemma	skonis
@@ -6305,8 +6305,8 @@
 00727564-a	lit:lemma	nepriklausomas
 07652401-n	lit:lemma	žąsų kepenėlės
 03145843-n	lit:lemma	atraitas
-01636205-s	lit:lemma	teisingas
-02368247-s	lit:lemma	sausas
+01636205-a	lit:lemma	teisingas
+02368247-a	lit:lemma	sausas
 05832745-n	lit:lemma	krovinys
 08504851-n	lit:lemma	dykynė
 01321579-n	lit:lemma	jauniklis
@@ -6318,35 +6318,35 @@
 08738272-n	lit:lemma	Salvadoras
 00255710-n	lit:lemma	prausimas
 01326148-a	lit:lemma	integruotas
-01175158-s	lit:lemma	opėtas
+01175158-a	lit:lemma	opėtas
 00608808-v	lit:lemma	protauti
 05512139-n	lit:lemma	pūslė
 03051540-n	lit:lemma	apranga
-01287808-s	lit:lemma	ryškus
+01287808-a	lit:lemma	ryškus
 11875691-n	lit:lemma	kopūstas
 03047553-n	lit:lemma	užtvara
 03525454-n	lit:lemma	laikiklis
 04610879-n	lit:lemma	kiemas
-00015720-s	lit:lemma	gausus
+00015720-a	lit:lemma	gausus
 02894605-n	lit:lemma	molas
 05288091-n	lit:lemma	kremzlė
 01301624-a	lit:lemma	pramoninis
 08630985-n	lit:lemma	šaka (mokslo)
 02700064-n	lit:lemma	kintamosios srovės generatorius
 04508163-n	lit:lemma	apatiniai
-02413390-s	lit:lemma	permatomas
+02413390-a	lit:lemma	permatomas
 13268146-n	lit:lemma	prizas
 10113583-n	lit:lemma	nominalus vadovas
-00937341-s	lit:lemma	nepatyręs
+00937341-a	lit:lemma	nepatyręs
 03930630-n	lit:lemma	pikapas
-00566961-s	lit:lemma	gretimas
+00566961-a	lit:lemma	gretimas
 00074524-n	lit:lemma	apsirikimas
 10289462-n	lit:lemma	valdytoja
 00063652-n	lit:lemma	sėkmė
 03021866-a	lit:lemma	krūmiškas
 03626014-n	lit:lemma	rankena
 00182316-r	lit:lemma	nuostabiai
-01695269-s	lit:lemma	apklotas
+01695269-a	lit:lemma	apklotas
 05457973-n	lit:lemma	kiaušinėlis
 07196075-n	lit:lemma	pokalbis
 11537506-n	lit:lemma	samana
@@ -6354,14 +6354,14 @@
 07975026-n	lit:lemma	susirinkimas
 07874780-n	lit:lemma	košė
 10739636-n	lit:lemma	atstumianti moteris
-01935935-s	lit:lemma	išgalvotas
+01935935-a	lit:lemma	išgalvotas
 02159271-n	lit:lemma	vabzdžiai
 00020142-r	lit:lemma	be pertraukos
-01080900-s	lit:lemma	derlingas
+01080900-a	lit:lemma	derlingas
 10002151-n	lit:lemma	demokratų partijos narys
 02471091-a	lit:lemma	paviršinis
 03366823-n	lit:lemma	grindų danga
-02379157-s	lit:lemma	gretiminis
+02379157-a	lit:lemma	gretiminis
 01346804-v	lit:lemma	atsiverti
 00995775-a	lit:lemma	palankus
 03135152-n	lit:lemma	kryžius
@@ -6369,7 +6369,7 @@
 05274959-n	lit:lemma	dubens kaulas
 05984936-n	lit:lemma	kultūra
 01304570-a	lit:lemma	informatyvus
-01455732-s	lit:lemma	silpnas
+01455732-a	lit:lemma	silpnas
 00258175-r	lit:lemma	dykai
 04894037-n	lit:lemma	neapdairumas
 00521562-n	lit:lemma	pristatymas
@@ -6384,32 +6384,32 @@
 13308999-n	lit:lemma	mokestis
 06503224-n	lit:lemma	chronologija
 06756407-n	lit:lemma	netiesa
-02076988-s	lit:lemma	nepakaltinamas
+02076988-a	lit:lemma	nepakaltinamas
 13999206-n	lit:lemma	įkalinimas
 07539790-n	lit:lemma	nuobodumas
 10230580-n	lit:lemma	futbolininkas
 05695554-n	lit:lemma	ekvivalentas
-01634027-s	lit:lemma	neoficialus
+01634027-a	lit:lemma	neoficialus
 13323313-n	lit:lemma	rankpinigiai
-00382173-s	lit:lemma	rožinis
-00698586-s	lit:lemma	nesavitas
+00382173-a	lit:lemma	rožinis
+00698586-a	lit:lemma	nesavitas
 07412993-n	lit:lemma	žaibas
-00746047-s	lit:lemma	nesmagus
+00746047-a	lit:lemma	nesmagus
 02969925-a	lit:lemma	bizantinis
 02825355-a	lit:lemma	balso
 15262120-n	lit:lemma	veikimas
 02673022-a	lit:lemma	kadastro
 12623368-n	lit:lemma	medlieva
 03925226-n	lit:lemma	nuotrauka
-01427333-s	lit:lemma	nuodingas
+01427333-a	lit:lemma	nuodingas
 00050297-r	lit:lemma	laimingai
-01888554-s	lit:lemma	apsauginis
+01888554-a	lit:lemma	apsauginis
 00031181-v	lit:lemma	suparalyžiuoti
 10157744-n	lit:lemma	kvailys
-01856419-s	lit:lemma	esminis
+01856419-a	lit:lemma	esminis
 07997703-n	lit:lemma	klasė
 00850425-n	lit:lemma	hibridizacija
-02344672-s	lit:lemma	primarūšis
+02344672-a	lit:lemma	primarūšis
 10368414-n	lit:lemma	beprotis
 00757080-n	lit:lemma	nusidėjimas
 00017222-n	lit:lemma	augalas
@@ -6417,17 +6417,17 @@
 03264136-n	lit:lemma	aštrus kraštas
 14447908-n	lit:lemma	sveikata
 13810323-n	lit:lemma	elementas
-01440574-s	lit:lemma	ilgokas
+01440574-a	lit:lemma	ilgokas
 00395744-r	lit:lemma	puikiai
 13998014-n	lit:lemma	priverčiamieji darbai
 03621049-n	lit:lemma	indai
-01392249-s	lit:lemma	mažytis
+01392249-a	lit:lemma	mažytis
 13626789-n	lit:lemma	blogas blokas
 06636259-n	lit:lemma	faktas
-01925708-s	lit:lemma	nuoseklus
+01925708-a	lit:lemma	nuoseklus
 00770834-n	lit:lemma	autoriaus teisės pažeidimas
 08221897-n	lit:lemma	publika
-01591394-s	lit:lemma	karališkas
+01591394-a	lit:lemma	karališkas
 07140659-n	lit:lemma	diskusija
 00021265-n	lit:lemma	maisto produktas
 00024279-v	lit:lemma	atgaivinti
@@ -6442,7 +6442,7 @@
 06797169-n	lit:lemma	ženklas
 03720163-n	lit:lemma	žemėlapis
 13586122-n	lit:lemma	pastovus dydis
-00264178-s	lit:lemma	bebaimis
+00264178-a	lit:lemma	bebaimis
 03740161-n	lit:lemma	vaistas
 10344443-n	lit:lemma	svarbus asmuo
 13485525-n	lit:lemma	branduolių sintezė
@@ -6460,8 +6460,8 @@
 03379719-n	lit:lemma	stabdžio pamina
 00121214-v	lit:lemma	keisti
 15256567-n	lit:lemma	geimas
-01357027-s	lit:lemma	gaivus
-02378872-s	lit:lemma	vienalaikis
+01357027-a	lit:lemma	gaivus
+02378872-a	lit:lemma	vienalaikis
 00340192-n	lit:lemma	lenkimas
 07377682-n	lit:lemma	dundėjimas
 05647156-n	lit:lemma	kvailumas
@@ -6487,11 +6487,11 @@
 08381165-n	lit:lemma	vadovybė
 09876701-n	lit:lemma	brolis
 01105259-n	lit:lemma	transportavimas
-01517526-s	lit:lemma	karo
+01517526-a	lit:lemma	karo
 07627931-n	lit:lemma	sluoksniuota tešla
 11424704-n	lit:lemma	srovės stiprumas amperais
 01968569-v	lit:lemma	kilti
-00835292-s	lit:lemma	įspūdingas
+00835292-a	lit:lemma	įspūdingas
 04620216-n	lit:lemma	būdas
 06516955-n	lit:lemma	sąskaita
 01202415-n	lit:lemma	integracija
@@ -6502,7 +6502,7 @@
 06427086-n	lit:lemma	atlasas
 00225410-r	lit:lemma	griežtai
 00473021-r	lit:lemma	numanomai
-02000968-s	lit:lemma	pernelyg didelis
+02000968-a	lit:lemma	pernelyg didelis
 00069012-v	lit:lemma	srūti
 10388440-n	lit:lemma	vyriausiasis valdovas
 01843380-a	lit:lemma	pasiruošęs
@@ -6516,14 +6516,14 @@
 03003344-a	lit:lemma	anglų
 00756598-n	lit:lemma	blefas
 06724066-n	lit:lemma	tiesa
-00935359-s	lit:lemma	pigus
+00935359-a	lit:lemma	pigus
 06516955-n	lit:lemma	sąskaita faktūra
-00440292-s	lit:lemma	paikas
+00440292-a	lit:lemma	paikas
 14036735-n	lit:lemma	įniršis
 00250259-n	lit:lemma	plėtra
 01364008-a	lit:lemma	sielvartingas
 02389128-n	lit:lemma	sartis
-01642657-s	lit:lemma	radikalus
+01642657-a	lit:lemma	radikalus
 03839993-n	lit:lemma	kliuvinys
 00324384-n	lit:lemma	kėlimasis
 13959931-n	lit:lemma	neegzistavimas
@@ -6557,11 +6557,11 @@
 00037226-r	lit:lemma	iš tikrųjų
 00055101-r	lit:lemma	baisiai
 00271263-n	lit:lemma	degradacija
-02576223-s	lit:lemma	ąžuolinis
+02576223-a	lit:lemma	ąžuolinis
 14514039-n	lit:lemma	sritis
 03633091-n	lit:lemma	kaušas
 10299250-n	lit:lemma	pranešinėtojas
-01320474-s	lit:lemma	išteisintas
+01320474-a	lit:lemma	išteisintas
 03416329-n	lit:lemma	spraga
 01322685-n	lit:lemma	jauniklis
 09450708-n	lit:lemma	supermilžinė
@@ -6592,7 +6592,7 @@
 06723452-n	lit:lemma	informavimas
 05553288-n	lit:lemma	krūtinė
 00796315-n	lit:lemma	nuotykis
-01680559-s	lit:lemma	neorganinis
+01680559-a	lit:lemma	neorganinis
 01776727-v	lit:lemma	nemėgti
 07181713-n	lit:lemma	konfrontacija
 10249459-n	lit:lemma	juristas
@@ -6601,14 +6601,14 @@
 00277811-n	lit:lemma	mirkymas
 10435367-n	lit:lemma	piratas
 07500414-n	lit:lemma	pritarimas
-00650900-s	lit:lemma	skubus
+00650900-a	lit:lemma	skubus
 03733281-n	lit:lemma	labirintas
 00523978-a	lit:lemma	ne visas
 03536348-n	lit:lemma	horizontali plokštuma
 03987079-n	lit:lemma	atvaizdas
-02002470-s	lit:lemma	apribotas
+02002470-a	lit:lemma	apribotas
 14411243-n	lit:lemma	sudėtinga situacija
-00563288-s	lit:lemma	ironiškas
+00563288-a	lit:lemma	ironiškas
 01339730-a	lit:lemma	skirtas
 02974615-a	lit:lemma	Palestinos
 00196848-n	lit:lemma	novacija
@@ -6618,20 +6618,20 @@
 03079741-n	lit:lemma	kupė
 10188715-n	lit:lemma	ūkvedys
 03547658-n	lit:lemma	stebulė
-02111981-s	lit:lemma	klano
+02111981-a	lit:lemma	klano
 00276987-n	lit:lemma	teršimas
 02313008-n	lit:lemma	motinėlė
 01579608-a	lit:lemma	artimiausias
 00915722-n	lit:lemma	kultivavimas
-01514141-s	lit:lemma	smarkus
+01514141-a	lit:lemma	smarkus
 03882058-n	lit:lemma	skydas
-00587376-s	lit:lemma	ėdantis
+00587376-a	lit:lemma	ėdantis
 13879320-n	lit:lemma	trikampis
-00119006-s	lit:lemma	gyvas
+00119006-a	lit:lemma	gyvas
 05849040-n	lit:lemma	bruožas
-00032497-s	lit:lemma	akrobatinis
+00032497-a	lit:lemma	akrobatinis
 00317569-v	lit:lemma	praplėsti
-00453053-s	lit:lemma	žinomas
+00453053-a	lit:lemma	žinomas
 07635827-n	lit:lemma	sviestinis sausainis
 04656996-n	lit:lemma	nuošalumas
 01615180-a	lit:lemma	nešališkas
@@ -6647,7 +6647,7 @@
 05802185-n	lit:lemma	kalkuliacija
 09876892-n	lit:lemma	vienuolis
 05613962-n	lit:lemma	įžvalgumas
-01826979-s	lit:lemma	galingas
+01826979-a	lit:lemma	galingas
 08236438-n	lit:lemma	konsorciumas
 08651247-n	lit:lemma	vieta
 00102463-r	lit:lemma	subtiliai
@@ -6657,7 +6657,7 @@
 02931227-a	lit:lemma	sakramentalus
 00317569-v	lit:lemma	plėsti
 00273601-n	lit:lemma	smukimas
-00766102-s	lit:lemma	atviras
+00766102-a	lit:lemma	atviras
 04148936-n	lit:lemma	slėptuvė
 14920844-n	lit:lemma	izoliacija
 02999904-a	lit:lemma	fašistinis
@@ -6666,8 +6666,8 @@
 03975232-n	lit:lemma	žymeklis
 07709333-n	lit:lemma	žalumynai
 08369406-n	lit:lemma	karta
-01726859-s	lit:lemma	fanatiškas
-01830599-s	lit:lemma	stiprus
+01726859-a	lit:lemma	fanatiškas
+01830599-a	lit:lemma	stiprus
 02889746-a	lit:lemma	jūrinis
 02942958-a	lit:lemma	filogenetinis
 07015400-n	lit:lemma	pjesė skaitymui
@@ -6675,21 +6675,21 @@
 07522729-n	lit:lemma	bailumas
 00015953-r	lit:lemma	smarkiai
 10484526-n	lit:lemma	pasiūlymo teikėjas
-01386234-s	lit:lemma	didelis
+01386234-a	lit:lemma	didelis
 00818466-n	lit:lemma	saugojimas
 00206867-r	lit:lemma	skubiai
-00938659-s	lit:lemma	galiojantis
+00938659-a	lit:lemma	galiojantis
 02293321-v	lit:lemma	įduoti
 00435013-a	lit:lemma	aiškiai mąstantis
 04950126-n	lit:lemma	savybė
-00692255-s	lit:lemma	perbrendamas
-01697878-s	lit:lemma	saulėtas
+00692255-a	lit:lemma	perbrendamas
+01697878-a	lit:lemma	saulėtas
 05153520-n	lit:lemma	kompetencija
-00886253-s	lit:lemma	entuziastingas
+00886253-a	lit:lemma	entuziastingas
 02719009-a	lit:lemma	elektrostatinis
 15253139-n	lit:lemma	senovė
 04463679-n	lit:lemma	bėgiai
-00782216-s	lit:lemma	neryškus
+00782216-a	lit:lemma	neryškus
 11466043-n	lit:lemma	šiluminė energija
 00163590-r	lit:lemma	pakrikai
 05454070-n	lit:lemma	raudonasis kraujo kūnelis
@@ -6703,12 +6703,12 @@
 01845720-v	lit:lemma	keliauti
 00319939-n	lit:lemma	gaudymas
 13292613-n	lit:lemma	kompensacija
-01175158-s	lit:lemma	žaizdotas
+01175158-a	lit:lemma	žaizdotas
 09275473-n	lit:lemma	Europa
 01640855-v	lit:lemma	realizuoti
 00007703-r	lit:lemma	dalinai
 00057042-r	lit:lemma	jokiu būdu
-01723543-s	lit:lemma	nesuinteresuotas
+01723543-a	lit:lemma	nesuinteresuotas
 03481172-n	lit:lemma	kūjis
 13990064-n	lit:lemma	skaistumas
 15294607-n	lit:lemma	inkubacinis periodas
@@ -6716,24 +6716,24 @@
 01844917-n	lit:lemma	vandens paukštis
 15248269-n	lit:lemma	epocha
 08160276-n	lit:lemma	piliečiai
-01990653-s	lit:lemma	nepajudinamas
+01990653-a	lit:lemma	nepajudinamas
 03992703-n	lit:lemma	moliniai indai
 02205272-v	lit:lemma	imti
 07000195-n	lit:lemma	diagrama
 14476290-n	lit:lemma	nelaimė
 05773049-n	lit:lemma	samprotavimas
-01082115-s	lit:lemma	vaisingas
+01082115-a	lit:lemma	vaisingas
 06024230-n	lit:lemma	aritmetinis vidurkis
 00830448-n	lit:lemma	valdymas
 01170962-n	lit:lemma	mačas
-00309620-s	lit:lemma	smulkus
+00309620-a	lit:lemma	smulkus
 00766234-n	lit:lemma	nusikaltimas
 02710402-v	lit:lemma	susidurti
 02682773-v	lit:lemma	saugoti
-02418093-s	lit:lemma	galimas
+02418093-a	lit:lemma	galimas
 10002760-n	lit:lemma	demonstracijos dalyvis
 00971075-a	lit:lemma	elegantiškas
-00294579-s	lit:lemma	tingus
+00294579-a	lit:lemma	tingus
 00279523-r	lit:lemma	atvirai
 00512522-n	lit:lemma	flirtavimas
 00063630-r	lit:lemma	apskritai
@@ -6755,7 +6755,7 @@
 00046522-n	lit:lemma	prisilietimas
 08752021-n	lit:lemma	Dominikos Respublika
 10633450-n	lit:lemma	žiūrovas
-00123485-s	lit:lemma	paskesnis
+00123485-a	lit:lemma	paskesnis
 13353280-n	lit:lemma	turtas
 00018813-v	lit:lemma	vėl pabusti
 12711984-n	lit:lemma	rūgščiavaisis citrinmedis
@@ -6765,7 +6765,7 @@
 00204439-n	lit:lemma	apleidimas
 09447666-n	lit:lemma	paplūdimys
 03928116-n	lit:lemma	pianinas
-01443097-s	lit:lemma	provizorinis
+01443097-a	lit:lemma	provizorinis
 02795670-n	lit:lemma	smuklė
 10147935-n	lit:lemma	jaunikis
 01546111-v	lit:lemma	stovėti
@@ -6773,7 +6773,7 @@
 01020356-v	lit:lemma	parašyti
 00054212-r	lit:lemma	po to
 15122231-n	lit:lemma	laikotarpis
-00837977-s	lit:lemma	atkaklus
+00837977-a	lit:lemma	atkaklus
 04019101-n	lit:lemma	viešasis transportas
 09608377-n	lit:lemma	aukcionatorius
 00431005-n	lit:lemma	pokštas
@@ -6789,12 +6789,12 @@
 05835747-n	lit:lemma	samprata
 01775535-v	lit:lemma	mylėti
 09906986-n	lit:lemma	premjeras
-02112701-s	lit:lemma	bendras
+02112701-a	lit:lemma	bendras
 10641755-n	lit:lemma	slaptasis agentas
 02104523-n	lit:lemma	aviganis
 07963613-n	lit:lemma	malkų rietuvė
-01266092-s	lit:lemma	pašiepiantis
-00729439-s	lit:lemma	ekonomiškai nepriklausomas
+01266092-a	lit:lemma	pašiepiantis
+00729439-a	lit:lemma	ekonomiškai nepriklausomas
 00340715-r	lit:lemma	įdėmiai
 07301950-n	lit:lemma	susidūrimas
 07988089-n	lit:lemma	ketvertas
@@ -6804,16 +6804,16 @@
 09956387-n	lit:lemma	žinovas
 00834636-n	lit:lemma	rūkymas
 04547592-n	lit:lemma	mūrinė tvora
-01802774-s	lit:lemma	baisus
+01802774-a	lit:lemma	baisus
 00413086-n	lit:lemma	karjerizmas
 05138958-n	lit:lemma	dorybė
 01067362-n	lit:lemma	vilkinimas
 00255415-r	lit:lemma	pusiaukelėje
-01842468-s	lit:lemma	atsitiktinis
+01842468-a	lit:lemma	atsitiktinis
 15277358-n	lit:lemma	dozė
-01835409-s	lit:lemma	pragmatinis
+01835409-a	lit:lemma	pragmatinis
 04524313-n	lit:lemma	transporto priemonė
-00656507-s	lit:lemma	pagrindinis
+00656507-a	lit:lemma	pagrindinis
 07200813-n	lit:lemma	gynyba (teisme)
 00412596-r	lit:lemma	atidžiai
 10569411-n	lit:lemma	slaptosios tarnybos agentas
@@ -6823,21 +6823,21 @@
 03518305-n	lit:lemma	aukšta komoda
 02763901-n	lit:lemma	tentas
 01563746-n	lit:lemma	nykštukas
-01742912-s	lit:lemma	siautulingas
-01726859-s	lit:lemma	kraštutinis
+01742912-a	lit:lemma	siautulingas
+01726859-a	lit:lemma	kraštutinis
 01400562-a	lit:lemma	legalus
 01413871-a	lit:lemma	neįtikėtinas
 00365012-n	lit:lemma	fluoravimas
-01729566-s	lit:lemma	buvęs
+01729566-a	lit:lemma	buvęs
 05835747-n	lit:lemma	požiūris
-01664310-s	lit:lemma	svajingas
+01664310-a	lit:lemma	svajingas
 00635850-n	lit:lemma	testas
 00869931-v	lit:lemma	apkaltinti
 00471613-n	lit:lemma	beisbolas
 10157744-n	lit:lemma	asilas
 13671182-n	lit:lemma	Jugoslavijos dinaras
 00714884-v	lit:lemma	svarstyti
-01593079-s	lit:lemma	eilinis
+01593079-a	lit:lemma	eilinis
 00076884-n	lit:lemma	nukritimas
 05540121-n	lit:lemma	kaukolė
 00098385-n	lit:lemma	sandara
@@ -6848,7 +6848,7 @@
 03471473-n	lit:lemma	stogvamzdis
 00195194-n	lit:lemma	pakitimas
 04079244-n	lit:lemma	rezidencija
-02226979-s	lit:lemma	virtuoziškas
+02226979-a	lit:lemma	virtuoziškas
 02603699-v	lit:lemma	būti
 00246552-n	lit:lemma	skrudinimas
 13866144-n	lit:lemma	daugiakampis
@@ -6861,10 +6861,10 @@
 14442933-n	lit:lemma	viešpatavimas
 05289861-n	lit:lemma	skersaruožis raumuo
 09275016-n	lit:lemma	Eurazija
-02121123-s	lit:lemma	vėjavaikiškas
+02121123-a	lit:lemma	vėjavaikiškas
 03950228-n	lit:lemma	ąsotis
-01814711-s	lit:lemma	vyriausybinis
-02378496-s	lit:lemma	vienalaikis
+01814711-a	lit:lemma	vyriausybinis
+02378496-a	lit:lemma	vienalaikis
 08081403-n	lit:lemma	gynyba
 13878306-n	lit:lemma	elipsė
 02934168-n	lit:lemma	kabelis
@@ -6872,7 +6872,7 @@
 00329227-n	lit:lemma	srautas
 02754096-a	lit:lemma	teisinis
 10193967-n	lit:lemma	vyras
-02094203-s	lit:lemma	garantuotas
+02094203-a	lit:lemma	garantuotas
 00020476-r	lit:lemma	pastoviai
 00952963-n	lit:lemma	karo veiksmai
 05510173-n	lit:lemma	kvėpavimo takai
@@ -6886,11 +6886,11 @@
 10085970-n	lit:lemma	būsimoji nuotaka
 13126580-n	lit:lemma	šaknelė
 03516011-n	lit:lemma	heroinas
-01945350-s	lit:lemma	nepateisintas
+01945350-a	lit:lemma	nepateisintas
 02687992-n	lit:lemma	aerodromas
-01944088-s	lit:lemma	teisingas
+01944088-a	lit:lemma	teisingas
 01176431-n	lit:lemma	kivirčas
-01042703-s	lit:lemma	tradicinis
+01042703-a	lit:lemma	tradicinis
 00484166-v	lit:lemma	užbaigti
 13865483-n	lit:lemma	apvali figūra
 09488711-n	lit:lemma	šaka (mokslo)
@@ -6900,32 +6900,32 @@
 08182379-n	lit:lemma	krūva
 10183757-n	lit:lemma	jubiliatas
 09851465-n	lit:lemma	pabrolys
-02363614-s	lit:lemma	atsparus
+02363614-a	lit:lemma	atsparus
 00187028-r	lit:lemma	gražiai
 02716205-n	lit:lemma	baktericidas
 00382109-n	lit:lemma	suaugimas
 06502192-n	lit:lemma	kadastras
 06589574-n	lit:lemma	leidinys
-00616532-s	lit:lemma	keptas
+00616532-a	lit:lemma	keptas
 10403162-n	lit:lemma	politinės partijos lyderis
 02796623-n	lit:lemma	užtvara
 00378985-n	lit:lemma	kombinavimas
-02570643-s	lit:lemma	absurdiškas
+02570643-a	lit:lemma	absurdiškas
 15094053-n	lit:lemma	makulatūra
-02104727-s	lit:lemma	jautrus šviesai
-01019713-s	lit:lemma	silpnas
+02104727-a	lit:lemma	jautrus šviesai
+01019713-a	lit:lemma	silpnas
 03790230-n	lit:lemma	kateris
 13130885-n	lit:lemma	meristema
-01888765-s	lit:lemma	apsauginis
+01888765-a	lit:lemma	apsauginis
 00181640-n	lit:lemma	referendumas
 13933560-n	lit:lemma	sunki pereinamoji padėtis
 01105259-n	lit:lemma	pervežimas
 02966372-n	lit:lemma	bagažo juosta
 14633206-n	lit:lemma	anglis
 00689809-v	lit:lemma	galvoti
-01311605-s	lit:lemma	kolonizuotas
+01311605-a	lit:lemma	kolonizuotas
 02968325-a	lit:lemma	europietiškas
-00927978-s	lit:lemma	neturintis
+00927978-a	lit:lemma	neturintis
 08573258-n	lit:lemma	ašigalis
 01236947-n	lit:lemma	kraujo kerštas
 05820620-n	lit:lemma	modelis
@@ -6933,11 +6933,11 @@
 00117959-n	lit:lemma	mirksėjimas
 13250542-n	lit:lemma	turtas
 04876053-n	lit:lemma	melagingumas
-00768397-s	lit:lemma	be sąryšio
-00516231-s	lit:lemma	visas
+00768397-a	lit:lemma	be sąryšio
+00516231-a	lit:lemma	visas
 15234764-n	lit:lemma	minutė
 00167920-r	lit:lemma	tuščiai
-02436995-s	lit:lemma	nenuolaidus
+02436995-a	lit:lemma	nenuolaidus
 08514034-n	lit:lemma	centras
 00036061-n	lit:lemma	pritaikymas
 07223170-n	lit:lemma	apkalba
@@ -6955,20 +6955,20 @@
 15143477-n	lit:lemma	mirtis
 10755080-n	lit:lemma	altininkas
 00081836-n	lit:lemma	apsipirkimas
-01935935-s	lit:lemma	sufabrikuotas
-01698231-s	lit:lemma	apsnigtas
+01935935-a	lit:lemma	sufabrikuotas
+01698231-a	lit:lemma	apsnigtas
 06218623-n	lit:lemma	liberalizmas
 01631072-v	lit:lemma	atnaujinti
 00138611-r	lit:lemma	tikriausiai
 13883885-n	lit:lemma	daugiasienis
-01346978-s	lit:lemma	vidaus
+01346978-a	lit:lemma	vidaus
 00010466-r	lit:lemma	ligi galo
 03025070-n	lit:lemma	kalėjimas
 08358594-n	lit:lemma	kuopelė
 09505418-n	lit:lemma	dievybė
 00160532-n	lit:lemma	sugundymas
 08616050-n	lit:lemma	ganykla
-01474942-s	lit:lemma	paklusnus
+01474942-a	lit:lemma	paklusnus
 07546465-n	lit:lemma	neapykanta
 02997391-n	lit:lemma	keramikos dirbinys
 00925490-v	lit:lemma	žavėtis
@@ -6981,17 +6981,17 @@
 13927383-n	lit:lemma	būklė
 01163047-n	lit:lemma	nuplakimas
 03390075-n	lit:lemma	apkasas
-01814252-s	lit:lemma	neprotingas
+01814252-a	lit:lemma	neprotingas
 03817647-n	lit:lemma	negližė
 13873849-n	lit:lemma	žiedelis
 07551052-n	lit:lemma	nuotaika
 07142566-n	lit:lemma	diskusija
 09436708-n	lit:lemma	padangė
-02101757-s	lit:lemma	sukrečiantis
+02101757-a	lit:lemma	sukrečiantis
 07942152-n	lit:lemma	žmonės
 06539770-n	lit:lemma	potvarkis
 00966809-v	lit:lemma	raportuoti
-01046784-s	lit:lemma	žargoniškas
+01046784-a	lit:lemma	žargoniškas
 00666058-a	lit:lemma	aktualus
 00039941-r	lit:lemma	sprendžiant iš išorės
 04861486-n	lit:lemma	ryžtas
@@ -7000,7 +7000,7 @@
 02393086-v	lit:lemma	perkelti
 14942223-n	lit:lemma	priesmėlis
 02877266-n	lit:lemma	maitinimo buteliukas
-01019000-s	lit:lemma	kuprotas
+01019000-a	lit:lemma	kuprotas
 01000068-n	lit:lemma	lygiavimas
 00759269-v	lit:lemma	maldauti
 14538472-n	lit:lemma	užtikrinimas
@@ -7010,26 +7010,26 @@
 00335182-r	lit:lemma	netikėtai
 14812566-n	lit:lemma	rūkomasis popierius
 09397391-n	lit:lemma	kūdra
-01086915-s	lit:lemma	plikas
+01086915-a	lit:lemma	plikas
 08367880-n	lit:lemma	valdymo forma
 00008007-r	lit:lemma	absoliučiai
-01728614-s	lit:lemma	antikinis
+01728614-a	lit:lemma	antikinis
 00216174-n	lit:lemma	išmesti
 03315805-n	lit:lemma	apdaila
 00034574-n	lit:lemma	geradarybė
 02669789-v	lit:lemma	užtekti
-00049016-s	lit:lemma	papildantis
+00049016-a	lit:lemma	papildantis
 00383390-n	lit:lemma	atvėrimas
 06492939-n	lit:lemma	valgiaraštis
 04150860-n	lit:lemma	iškarpų albumas
-00304949-s	lit:lemma	pašėlęs
+00304949-a	lit:lemma	pašėlęs
 02167052-v	lit:lemma	žiūrėti
 06831391-n	lit:lemma	cė
 03482877-n	lit:lemma	rankinio kamuolys
 02690081-n	lit:lemma	aviakompanija
 15248564-n	lit:lemma	laikotarpis
 03582658-n	lit:lemma	inovacija
-02051616-s	lit:lemma	kaimiškas
+02051616-a	lit:lemma	kaimiškas
 02955065-n	lit:lemma	gaubtuvas
 02798370-a	lit:lemma	socialinis
 05479314-n	lit:lemma	veidinis nervas
@@ -7048,7 +7048,7 @@
 13931889-n	lit:lemma	slaptas romanas
 01014821-v	lit:lemma	duoti parodymus
 08910668-n	lit:lemma	Iranas
-02502994-s	lit:lemma	nereikšmingas
+02502994-a	lit:lemma	nereikšmingas
 01234952-n	lit:lemma	atsakas
 02952622-a	lit:lemma	protestantų
 05123098-n	lit:lemma	negausumas
@@ -7066,14 +7066,14 @@
 04268680-n	lit:lemma	kibirkščių tarpas
 13910019-n	lit:lemma	lašas
 02988060-a	lit:lemma	valstybinis
-01706465-s	lit:lemma	neskelbtinas
+01706465-a	lit:lemma	neskelbtinas
 01148614-n	lit:lemma	izoliavimas
 00355080-r	lit:lemma	daug
 08113443-n	lit:lemma	dvasininkija
 05837850-n	lit:lemma	nuomonė
 03670208-n	lit:lemma	limuzinas
-00876204-s	lit:lemma	apatiškas
-01569166-s	lit:lemma	daugiatautis
+00876204-a	lit:lemma	apatiškas
+01569166-a	lit:lemma	daugiatautis
 00501080-n	lit:lemma	biliardas
 00357680-n	lit:lemma	kondensavimas
 14546432-n	lit:lemma	gera fizinė būklė
@@ -7085,14 +7085,14 @@
 02006834-v	lit:lemma	pasiekti
 14190736-n	lit:lemma	piemija
 14768201-n	lit:lemma	aršenikas
-01789481-s	lit:lemma	taškuotas
+01789481-a	lit:lemma	taškuotas
 14329578-n	lit:lemma	sėklidžių skausmas
 10628222-n	lit:lemma	JAV pietinių valstijų gyventojas
 00168564-r	lit:lemma	pašėlusiai
 08645963-n	lit:lemma	įvykio vieta
 14813182-n	lit:lemma	molis
 02883344-n	lit:lemma	dėžė
-00010726-s	lit:lemma	ėdrus
+00010726-a	lit:lemma	ėdrus
 01062583-n	lit:lemma	neveiklumas
 01595596-a	lit:lemma	anomalus
 06515662-n	lit:lemma	analai
@@ -7101,7 +7101,7 @@
 02964482-a	lit:lemma	Slovakijos
 02932019-n	lit:lemma	kabina
 03172038-n	lit:lemma	deflektorius
-00127543-s	lit:lemma	nuoseklus
+00127543-a	lit:lemma	nuoseklus
 03414162-n	lit:lemma	žaidimo reikmenys
 10112129-n	lit:lemma	vienuolis
 05588551-n	lit:lemma	kaklo slankstelis
@@ -7116,7 +7116,7 @@
 09287968-n	lit:lemma	geologinė formacija
 01385330-n	lit:lemma	ektoparazitas
 00006484-n	lit:lemma	ląstelė
-01567694-s	lit:lemma	pasaulinis
+01567694-a	lit:lemma	pasaulinis
 03133050-n	lit:lemma	vąšelis
 00948670-a	lit:lemma	vidinis
 00368287-r	lit:lemma	tiksliai
@@ -7127,19 +7127,19 @@
 01661818-n	lit:lemma	gyvatė
 01630117-a	lit:lemma	ginamasis
 08946909-n	lit:lemma	Grenada
-02182562-s	lit:lemma	apsimestinis
+02182562-a	lit:lemma	apsimestinis
 00512487-a	lit:lemma	rungtyniaujantis
 07047373-n	lit:lemma	simfoninė poema
 09356320-n	lit:lemma	Misuris
 01170962-n	lit:lemma	kautynės
-01562416-s	lit:lemma	besiartinantis
+01562416-a	lit:lemma	besiartinantis
 08435388-n	lit:lemma	sistema
 07205308-n	lit:lemma	dvigubas neiginys
 05816622-n	lit:lemma	duomuo
 04891184-n	lit:lemma	apdairumas
 13745086-n	lit:lemma	VIII
 00158309-r	lit:lemma	būtent
-01124768-s	lit:lemma	patenkinamas
+01124768-a	lit:lemma	patenkinamas
 09307031-n	lit:lemma	Hadsono įlanka
 05203397-n	lit:lemma	sugebėjimas
 06208021-n	lit:lemma	nusistatymas
@@ -7147,7 +7147,7 @@
 01207609-n	lit:lemma	padėjimas
 10249459-n	lit:lemma	teisininkas
 00448640-n	lit:lemma	čiuožimas
-02325984-s	lit:lemma	blyškus
+02325984-a	lit:lemma	blyškus
 00280853-n	lit:lemma	artėjimas
 07938773-n	lit:lemma	derinys
 07140659-n	lit:lemma	debatai
@@ -7162,7 +7162,7 @@
 03673027-n	lit:lemma	keleivinis laivas
 03781594-n	lit:lemma	kapšas
 03336459-n	lit:lemma	statulėlė
-02131958-s	lit:lemma	koketiškas
+02131958-a	lit:lemma	koketiškas
 14917635-n	lit:lemma	rašalas
 00817680-n	lit:lemma	apsauga
 02969925-a	lit:lemma	Bizantijos
@@ -7170,7 +7170,7 @@
 00027268-v	lit:lemma	ištempti
 10142747-n	lit:lemma	močiutė
 14592610-n	lit:lemma	plastikas
-01166413-s	lit:lemma	naudingas
+01166413-a	lit:lemma	naudingas
 07991364-n	lit:lemma	parapijiečiai
 00962447-v	lit:lemma	šnekėti
 05637558-n	lit:lemma	įgūdis
@@ -7180,7 +7180,7 @@
 03049457-n	lit:lemma	asmeninis kambariukas
 03221720-n	lit:lemma	durys
 04910848-n	lit:lemma	puošeiviškumas
-00473243-s	lit:lemma	degus
+00473243-a	lit:lemma	degus
 13450206-n	lit:lemma	degimas
 00204125-r	lit:lemma	neteisingai
 05222591-n	lit:lemma	įduba
@@ -7190,7 +7190,7 @@
 00681429-v	lit:lemma	įvertinti
 02795925-a	lit:lemma	gaminantis arba nešantis sėklą
 07203696-n	lit:lemma	teigiamas atsakymas
-01081340-s	lit:lemma	derlingas
+01081340-a	lit:lemma	derlingas
 05567217-n	lit:lemma	nykštys
 09633969-n	lit:lemma	pažeidėjas
 00132849-a	lit:lemma	apskųstinas
@@ -7213,17 +7213,17 @@
 05425910-n	lit:lemma	kapiliaras
 05538494-n	lit:lemma	tarpvietė
 05850624-n	lit:lemma	požiūris
-01881478-s	lit:lemma	neteisingas
+01881478-a	lit:lemma	neteisingas
 15143477-n	lit:lemma	galas
-02387413-s	lit:lemma	kresnas
+02387413-a	lit:lemma	kresnas
 02725829-a	lit:lemma	federalinis
 00114310-r	lit:lemma	oficialiai
 06611147-n	lit:lemma	paistalas
 00077950-v	lit:lemma	dusinti
 03668279-n	lit:lemma	šviesplunksnė
-00177547-s	lit:lemma	sėkmingas
+00177547-a	lit:lemma	sėkmingas
 14141490-n	lit:lemma	dėmėtoji šiltinė
-01899167-s	lit:lemma	apdairus
+01899167-a	lit:lemma	apdairus
 02971469-a	lit:lemma	Egipto
 00074407-r	lit:lemma	atgal
 00113113-n	lit:lemma	paspaudimas
@@ -7235,7 +7235,7 @@
 00490678-r	lit:lemma	pirmiausiai
 00106170-r	lit:lemma	slapčia
 11433546-n	lit:lemma	elektrinė talpa
-01664310-s	lit:lemma	naivus
+01664310-a	lit:lemma	naivus
 05675601-n	lit:lemma	savasis aš
 00004475-n	lit:lemma	organizmas
 07125096-n	lit:lemma	keiksmažodis
@@ -7246,9 +7246,9 @@
 02705201-n	lit:lemma	amfiteatras
 01031256-v	lit:lemma	siųsti
 02251743-v	lit:lemma	sumokėti
-00937616-s	lit:lemma	neįgudęs
+00937616-a	lit:lemma	neįgudęs
 13983304-n	lit:lemma	apšvietimas
-02314451-s	lit:lemma	zigzaginis
+02314451-a	lit:lemma	zigzaginis
 09790278-n	lit:lemma	psichoanalitikas
 08266849-n	lit:lemma	kalendorius
 04334599-n	lit:lemma	kelias
@@ -7257,16 +7257,16 @@
 02690081-n	lit:lemma	oro bendrovė
 09022831-n	lit:lemma	Lotynų Amerika
 01108148-v	lit:lemma	nugalėti
-00740217-s	lit:lemma	fiksuotas
+00740217-a	lit:lemma	fiksuotas
 00121214-v	lit:lemma	kaitaliotis
 01831531-v	lit:lemma	pajudėti
-02018649-s	lit:lemma	pilkas
+02018649-a	lit:lemma	pilkas
 02747177-n	lit:lemma	šiukšliadėžė
 00918872-v	lit:lemma	išaiškinti
 03009920-n	lit:lemma	jūrlapis
 05770926-n	lit:lemma	apmąstymas
 05305806-n	lit:lemma	lūpa
-01712753-s	lit:lemma	skausmingas
+01712753-a	lit:lemma	skausmingas
 00987071-v	lit:lemma	aprašyti
 10085736-n	lit:lemma	ponas
 00122626-a	lit:lemma	vėlesnis
@@ -7279,7 +7279,7 @@
 13883885-n	lit:lemma	poliedras
 01009240-v	lit:lemma	sakyti
 13457378-n	lit:lemma	smukimas
-01784401-s	lit:lemma	pagoniškas
+01784401-a	lit:lemma	pagoniškas
 10134001-n	lit:lemma	vartininkas
 02716205-n	lit:lemma	antibakterinis preparatas
 00152684-r	lit:lemma	šitaip
@@ -7291,11 +7291,11 @@
 14445226-n	lit:lemma	prakeikimas
 05710020-n	lit:lemma	percepcija
 00334790-r	lit:lemma	skubiu paštu
-01046226-s	lit:lemma	paprastas
+01046226-a	lit:lemma	paprastas
 05837850-n	lit:lemma	mintis
 00860611-a	lit:lemma	teoriškas
 06594505-n	lit:lemma	mėnesinis leidinys
-02060912-s	lit:lemma	savižudiškas
+02060912-a	lit:lemma	savižudiškas
 02806088-n	lit:lemma	tvirtovė
 10315837-n	lit:lemma	aktyvistas
 00023773-n	lit:lemma	akstinas
@@ -7305,12 +7305,12 @@
 00934199-a	lit:lemma	pigus
 02857099-a	lit:lemma	poetinis
 00575230-a	lit:lemma	laisvų pažiūrų
-01385255-s	lit:lemma	didžiulis
+01385255-a	lit:lemma	didžiulis
 02367363-v	lit:lemma	veikti
-00854255-s	lit:lemma	emocinis
+00854255-a	lit:lemma	emocinis
 01413247-a	lit:lemma	tikėtinas
 05680982-n	lit:lemma	nejauta
-00421875-s	lit:lemma	vargingas
+00421875-a	lit:lemma	vargingas
 13671047-n	lit:lemma	Jugoslavijos piniginis vienetas
 15085682-n	lit:lemma	šlapimo rūgštis
 00586262-n	lit:lemma	pareigos
@@ -7326,14 +7326,14 @@
 10734394-n	lit:lemma	dvynė
 00757080-n	lit:lemma	nuodėmė
 08744236-n	lit:lemma	Meksikas
-01628531-s	lit:lemma	grubus
-01909421-s	lit:lemma	neišgrynintas
+01628531-a	lit:lemma	grubus
+01909421-a	lit:lemma	neišgrynintas
 07184545-n	lit:lemma	peštynės
 02741960-v	lit:lemma	valyti
 00017881-r	lit:lemma	kaip tik tuo metu
 13954253-n	lit:lemma	egzistencija
 07059962-n	lit:lemma	popmuzika
-02132224-s	lit:lemma	nepadorus
+02132224-a	lit:lemma	nepadorus
 08066491-n	lit:lemma	bankininkystė
 14899152-n	lit:lemma	tirpiklis
 09886220-n	lit:lemma	niekšas
@@ -7356,14 +7356,14 @@
 04871720-n	lit:lemma	tiesumas
 13397443-n	lit:lemma	skola
 09469152-n	lit:lemma	kintamoji žvaigždė
-01804422-s	lit:lemma	atstumiantis
+01804422-a	lit:lemma	atstumiantis
 00165269-r	lit:lemma	tinkamu laiku
 00239230-n	lit:lemma	veiklos pradėjimas
 01901828-n	lit:lemma	ūsas
 00331950-n	lit:lemma	krutėjimas
 00089408-r	lit:lemma	nepaprastai
 00161932-r	lit:lemma	viešai
-00488857-s	lit:lemma	retas
+00488857-a	lit:lemma	retas
 10426749-n	lit:lemma	fotografas
 09272085-n	lit:lemma	elementarioji dalelė
 00586262-n	lit:lemma	postas
@@ -7373,10 +7373,10 @@
 09375223-n	lit:lemma	branduolys
 13278375-n	lit:lemma	mokėjimas
 07177437-n	lit:lemma	susitarimas
-01523724-s	lit:lemma	kilnojamas
+01523724-a	lit:lemma	kilnojamas
 02745862-a	lit:lemma	imuninis
 00422281-r	lit:lemma	dalimis
-00901969-s	lit:lemma	esminis
+00901969-a	lit:lemma	esminis
 03996655-n	lit:lemma	elektrinė
 02974003-n	lit:lemma	automobilio ratas
 02971469-a	lit:lemma	egiptietiškas
@@ -7388,7 +7388,7 @@
 08949093-n	lit:lemma	Nyderlandų Karalystė
 02202384-v	lit:lemma	išlaikyti
 13304665-n	lit:lemma	mažiausia pradinė kaina
-00477661-s	lit:lemma	namų
+00477661-a	lit:lemma	namų
 10042845-n	lit:lemma	keistuolis
 12630641-n	lit:lemma	paprastoji žemuogė
 00962129-n	lit:lemma	sukilimas
@@ -7399,12 +7399,12 @@
 00284183-r	lit:lemma	nebrangiai
 02973392-a	lit:lemma	komiškas
 00210518-n	lit:lemma	užbaigimas
-01645678-s	lit:lemma	žilaplaukis
-02587556-s	lit:lemma	vertingas
+01645678-a	lit:lemma	žilaplaukis
+02587556-a	lit:lemma	vertingas
 06643763-n	lit:lemma	ženklas
 14512817-n	lit:lemma	aplinkybės
 09280380-n	lit:lemma	upės žiotys
-01266092-s	lit:lemma	ironiškas
+01266092-a	lit:lemma	ironiškas
 12205694-n	lit:lemma	žolė
 00654885-n	lit:lemma	globa
 07033007-n	lit:lemma	bažnytinė muzika
@@ -7412,16 +7412,16 @@
 05084201-n	lit:lemma	ilgis
 08072536-n	lit:lemma	bendras investicijų fondas
 07343363-n	lit:lemma	sugrįžimas
-02279900-s	lit:lemma	bebaimis
+02279900-a	lit:lemma	bebaimis
 13253255-n	lit:lemma	padidėjimas
 01871979-v	lit:lemma	spausti
-01692512-s	lit:lemma	atviro oro
+01692512-a	lit:lemma	atviro oro
 09305031-n	lit:lemma	loma
-02059381-s	lit:lemma	pavojingas
+02059381-a	lit:lemma	pavojingas
 06408779-n	lit:lemma	pritaikymas
-02587738-s	lit:lemma	vertingas
+02587738-a	lit:lemma	vertingas
 08565506-n	lit:lemma	dausos
-02433975-s	lit:lemma	pavargęs
+02433975-a	lit:lemma	pavargęs
 00385791-n	lit:lemma	dalyba
 02638392-a	lit:lemma	archeologinis
 14612317-n	lit:lemma	adipo rūgštis
@@ -7460,11 +7460,11 @@
 07109196-n	lit:lemma	šnekamoji kalba
 11524662-n	lit:lemma	orai
 04643662-n	lit:lemma	karingumas
-01011753-s	lit:lemma	pagrindinis
-00195383-s	lit:lemma	bauginantis
-00126497-s	lit:lemma	ankstesnis
+01011753-a	lit:lemma	pagrindinis
+00195383-a	lit:lemma	bauginantis
+00126497-a	lit:lemma	ankstesnis
 02898750-a	lit:lemma	psichinis
-00901969-s	lit:lemma	žymus
+00901969-a	lit:lemma	žymus
 07128527-n	lit:lemma	nešvankybė
 03963982-n	lit:lemma	žaidimų korta
 05203397-n	lit:lemma	pajėgumas
@@ -7476,16 +7476,16 @@
 10582746-n	lit:lemma	kareivis
 06371999-n	lit:lemma	apsakymas
 07547805-n	lit:lemma	priešiškumas
-02186132-s	lit:lemma	nulinis
-01947741-s	lit:lemma	išauklėtas
-01523249-s	lit:lemma	manevringas
+02186132-a	lit:lemma	nulinis
+01947741-a	lit:lemma	išauklėtas
+01523249-a	lit:lemma	manevringas
 00715140-a	lit:lemma	demokratiškas
-00704360-s	lit:lemma	vienišas
+00704360-a	lit:lemma	vienišas
 07971582-n	lit:lemma	dinastija
-01984252-s	lit:lemma	diskredituotas
+01984252-a	lit:lemma	diskredituotas
 00305519-n	lit:lemma	avarinis nusileidimas
 05490983-n	lit:lemma	antinksčių žievė
-01253592-s	lit:lemma	labai šaltas
+01253592-a	lit:lemma	labai šaltas
 01480186-a	lit:lemma	pažymėtas
 00077950-v	lit:lemma	uždusinti
 00462520-r	lit:lemma	tylomis
@@ -7501,14 +7501,14 @@
 01916229-a	lit:lemma	abejotinas
 13356112-n	lit:lemma	pagrindinis
 02730326-v	lit:lemma	susidurti
-01211296-s	lit:lemma	pažengęs
+01211296-a	lit:lemma	pažengęs
 08921850-n	lit:lemma	Japonija
 02249147-v	lit:lemma	prisijungti
 08374049-n	lit:lemma	bendruomenė
-00505410-s	lit:lemma	išskirtinis
+00505410-a	lit:lemma	išskirtinis
 08504375-n	lit:lemma	Nubija
 00589769-n	lit:lemma	kapitono rangas
-01878870-s	lit:lemma	tinkamas
+01878870-a	lit:lemma	tinkamas
 00295825-r	lit:lemma	neįtikėtinai
 10197525-n	lit:lemma	idiotas
 08731606-n	lit:lemma	Indokinija
@@ -7517,14 +7517,14 @@
 14548343-n	lit:lemma	negalia
 00461782-n	lit:lemma	boulingas
 04830689-n	lit:lemma	žiaurumas
-02521183-s	lit:lemma	savanoriškas
+02521183-a	lit:lemma	savanoriškas
 07184545-n	lit:lemma	barnis
 09437454-n	lit:lemma	šlaitas
-00382173-s	lit:lemma	rausvas
+00382173-a	lit:lemma	rausvas
 02949691-n	lit:lemma	hašišas
 02106030-n	lit:lemma	škotų aviganis
-01046553-s	lit:lemma	laiško formos
-01808227-s	lit:lemma	puikus
+01046553-a	lit:lemma	laiško formos
+01808227-a	lit:lemma	puikus
 05246796-n	lit:lemma	vamzdelis
 10753546-n	lit:lemma	piktadarys
 02640223-a	lit:lemma	archyvinis
@@ -7541,7 +7541,7 @@
 03160309-n	lit:lemma	damba
 00007703-r	lit:lemma	iš dalies
 00332069-r	lit:lemma	lygiai
-00859632-s	lit:lemma	egzistencinis
+00859632-a	lit:lemma	egzistencinis
 00590390-a	lit:lemma	ginčijamas
 09917593-n	lit:lemma	vaikas
 00003553-n	lit:lemma	visuma
@@ -7563,19 +7563,19 @@
 12202936-n	lit:lemma	liepa
 02926188-a	lit:lemma	magnetinis
 00322391-n	lit:lemma	surišimas
-01082714-s	lit:lemma	nesėkmingas
+01082714-a	lit:lemma	nesėkmingas
 00020280-r	lit:lemma	nuolat
-01300661-s	lit:lemma	pataisos
+01300661-a	lit:lemma	pataisos
 09491966-n	lit:lemma	pabaisa
 06156968-n	lit:lemma	vaizduojamasis menas
 00829107-v	lit:lemma	mokyti
 05329533-n	lit:lemma	endokrininė sistema
 09337686-n	lit:lemma	Lena
 03892178-n	lit:lemma	parketas
-01626562-s	lit:lemma	siaubingas
+01626562-a	lit:lemma	siaubingas
 00372226-n	lit:lemma	telkimas
 01186397-n	lit:lemma	bankrutavimas
-01568092-s	lit:lemma	nacionalistinis
+01568092-a	lit:lemma	nacionalistinis
 02912383-a	lit:lemma	operinis
 02991302-n	lit:lemma	kamera
 05100269-n	lit:lemma	lauko stiprumas
@@ -7584,7 +7584,7 @@
 02810471-n	lit:lemma	baterija
 02943303-a	lit:lemma	aplinkos
 00220023-n	lit:lemma	žmogžudystė
-01917594-s	lit:lemma	keistas
+01917594-a	lit:lemma	keistas
 08166318-n	lit:lemma	teismo organų sistema
 06733939-n	lit:lemma	įrodymas
 00007846-n	lit:lemma	individas
@@ -7600,11 +7600,11 @@
 05790944-n	lit:lemma	alternatyva
 05647643-n	lit:lemma	negabumas
 00416737-n	lit:lemma	lengviausias kelias
-01644847-s	lit:lemma	archajinis
+01644847-a	lit:lemma	archajinis
 09939827-n	lit:lemma	karo pilotas
 05444175-n	lit:lemma	chromatidė
 04346679-n	lit:lemma	adata
-00968010-s	lit:lemma	keistas
+00968010-a	lit:lemma	keistas
 14708720-n	lit:lemma	spiritas
 02109190-v	lit:lemma	iškęsti
 03900979-n	lit:lemma	paviljonas
@@ -7612,31 +7612,31 @@
 15269513-n	lit:lemma	periodas
 00112090-r	lit:lemma	tylomis
 12709688-n	lit:lemma	greipfrutas
-01996875-s	lit:lemma	atskaitingas
+01996875-a	lit:lemma	atskaitingas
 07143624-n	lit:lemma	konsultacija
 10636598-n	lit:lemma	siela
-00421590-s	lit:lemma	nešvankus
+00421590-a	lit:lemma	nešvankus
 03652100-n	lit:lemma	pieštukas
 03098806-n	lit:lemma	kontrolės sistema
 01459791-n	lit:lemma	embrionas
 01218593-n	lit:lemma	pripažinimas
 08081668-n	lit:lemma	tikyba
 09622049-n	lit:lemma	paauglys
-00412788-s	lit:lemma	barbariškas
+00412788-a	lit:lemma	barbariškas
 00394610-n	lit:lemma	ištrynimas
 08361924-n	lit:lemma	viešpatavimas
 13108841-n	lit:lemma	spygliuotis
-00792202-s	lit:lemma	pirmaeilis
+00792202-a	lit:lemma	pirmaeilis
 00008195-v	lit:lemma	mirktelėti
-01560821-s	lit:lemma	jaudinantis
-02094203-s	lit:lemma	patikimas
+01560821-a	lit:lemma	jaudinantis
+02094203-a	lit:lemma	patikimas
 02345647-v	lit:lemma	išsiversti
 09777012-n	lit:lemma	brokeris
 02743261-a	lit:lemma	žmoniškas
 02935387-n	lit:lemma	arbatžolių dėžutė
 14446652-n	lit:lemma	diskomfortas
 00511573-r	lit:lemma	teigiamai
-00331167-s	lit:lemma	centrinis
+00331167-a	lit:lemma	centrinis
 03309356-n	lit:lemma	akies raištis
 03211117-n	lit:lemma	ekranas
 05490204-n	lit:lemma	regos centrai
@@ -7649,7 +7649,7 @@
 00353469-n	lit:lemma	sumažinimas
 03398467-n	lit:lemma	kakta
 00003316-v	lit:lemma	išsiurbti
-01154030-s	lit:lemma	pūkinis
+01154030-a	lit:lemma	pūkinis
 00356926-a	lit:lemma	charakteringas
 07184149-n	lit:lemma	barnis
 10676877-n	lit:lemma	konsultantas
@@ -7657,7 +7657,7 @@
 08913434-n	lit:lemma	Irako Respublika
 14538472-n	lit:lemma	tikrumas
 14899152-n	lit:lemma	terpė
-02214736-s	lit:lemma	vienintelis
+02214736-a	lit:lemma	vienintelis
 11873182-n	lit:lemma	krienai
 15190084-n	lit:lemma	Nepriklausomybės diena
 00270186-n	lit:lemma	atstatymas
@@ -7666,7 +7666,7 @@
 02849154-n	lit:lemma	antklodė
 14490564-n	lit:lemma	skola
 10018021-n	lit:lemma	disidentas
-00360950-s	lit:lemma	laisvas
+00360950-a	lit:lemma	laisvas
 04695176-n	lit:lemma	dėmė
 05784831-n	lit:lemma	svarstymas
 02717402-a	lit:lemma	redaktoriaus
@@ -7676,28 +7676,28 @@
 10179069-n	lit:lemma	mėgėjas
 05119714-n	lit:lemma	perviršis
 00099341-r	lit:lemma	labiau
-02081114-s	lit:lemma	geras
+02081114-a	lit:lemma	geras
 00350030-n	lit:lemma	apsisukimas
 15250312-n	lit:lemma	jubiliejus
 11494638-n	lit:lemma	krituliai
-00169692-s	lit:lemma	tamsus
-00580684-s	lit:lemma	pažymėtas
+00169692-a	lit:lemma	tamsus
+00580684-a	lit:lemma	pažymėtas
 14724436-n	lit:lemma	inhibitorius
 00655779-a	lit:lemma	kritiškas
 02139544-v	lit:lemma	pasirodyti
 00422281-r	lit:lemma	palaipsniui
 11410625-n	lit:lemma	padarinys
-02481012-s	lit:lemma	suskaldytas
-00447472-s	lit:lemma	kaimyninis
-01262284-s	lit:lemma	žmoniškas
+02481012-a	lit:lemma	suskaldytas
+00447472-a	lit:lemma	kaimyninis
+01262284-a	lit:lemma	žmoniškas
 00338821-n	lit:lemma	pertvarkymas
-01243102-s	lit:lemma	kraupus
+01243102-a	lit:lemma	kraupus
 00075966-r	lit:lemma	atvirkščiai
 01148614-n	lit:lemma	apribojimas
 00427944-r	lit:lemma	galingai
 03277771-n	lit:lemma	elektroninis prietaisas
-01383394-s	lit:lemma	gerokas
-00393683-s	lit:lemma	ryškus
+01383394-a	lit:lemma	gerokas
+00393683-a	lit:lemma	ryškus
 09917593-n	lit:lemma	jauniklis
 14867858-n	lit:lemma	fibrilė
 00041899-n	lit:lemma	gavimas
@@ -7708,7 +7708,7 @@
 00285141-n	lit:lemma	lunatizmas
 04710127-n	lit:lemma	sunkumas
 12144313-n	lit:lemma	kukurūzo burbuolė
-01166656-s	lit:lemma	vaistinis
+01166656-a	lit:lemma	vaistinis
 01858094-a	lit:lemma	privatus
 00099184-v	lit:lemma	sveikti
 00370920-r	lit:lemma	aiškiai
@@ -7719,17 +7719,17 @@
 05145118-n	lit:lemma	kaina
 02148788-v	lit:lemma	eksponuoti
 07393161-n	lit:lemma	klyksmas
-00304949-s	lit:lemma	audringas
+00304949-a	lit:lemma	audringas
 03340581-n	lit:lemma	stabilizatorius
 07480068-n	lit:lemma	emocija
-01676517-s	lit:lemma	pasakiškas
+01676517-a	lit:lemma	pasakiškas
 06489659-n	lit:lemma	turinys
 07812184-n	lit:lemma	prieskonis
 05199286-n	lit:lemma	efektyvumas
 00424767-n	lit:lemma	žiaurumas
-02456157-s	lit:lemma	nerimastingas
+02456157-a	lit:lemma	nerimastingas
 00505226-r	lit:lemma	arti
-02507772-s	lit:lemma	įvairus
+02507772-a	lit:lemma	įvairus
 01235946-n	lit:lemma	atsakomasis veiksmas
 00041954-r	lit:lemma	apskritai
 00010466-r	lit:lemma	visiškai
@@ -7737,17 +7737,17 @@
 00231567-n	lit:lemma	panaikinimas
 00140566-r	lit:lemma	nenatūraliai
 04459122-n	lit:lemma	fajetonas
-00015720-s	lit:lemma	perteklinis
+00015720-a	lit:lemma	perteklinis
 06293106-n	lit:lemma	bazinis žodis
 02974615-a	lit:lemma	palestinietiškas
 02791665-n	lit:lemma	barbakanas
-01936184-s	lit:lemma	pasakų
-00750602-s	lit:lemma	nereikalaujantis pastangų
+01936184-a	lit:lemma	pasakų
+00750602-a	lit:lemma	nereikalaujantis pastangų
 01380122-v	lit:lemma	plisti
 00087188-r	lit:lemma	kategoriškai
 07526757-n	lit:lemma	laimė
 00031921-n	lit:lemma	sąryšis
-01462882-s	lit:lemma	privilegijuotas
+01462882-a	lit:lemma	privilegijuotas
 04486054-n	lit:lemma	garbės vartai
 06208021-n	lit:lemma	pažiūros
 09758885-n	lit:lemma	mokslo įstaigos administracijos darbuotojas
@@ -7756,18 +7756,18 @@
 08231184-n	lit:lemma	asociacija
 09013074-n	lit:lemma	Latvija
 11595312-n	lit:lemma	plikasėkliai
-02101942-s	lit:lemma	skandalingas
+02101942-a	lit:lemma	skandalingas
 00017031-v	lit:lemma	knarkti
 01852174-a	lit:lemma	svarbiausias
 10338628-n	lit:lemma	žmogžudystės auka
-01523567-s	lit:lemma	judantis
-01640482-s	lit:lemma	dėvėtas
+01523567-a	lit:lemma	judantis
+01640482-a	lit:lemma	dėvėtas
 14619225-n	lit:lemma	atomas
 00871781-v	lit:lemma	grasinti
-02316992-s	lit:lemma	besiraitantis
+02316992-a	lit:lemma	besiraitantis
 02079029-a	lit:lemma	kandus
 08368907-n	lit:lemma	generacija
-00107017-s	lit:lemma	menkas
+00107017-a	lit:lemma	menkas
 06664845-n	lit:lemma	etiketas
 01114055-n	lit:lemma	prekyba narkotikais
 07945949-n	lit:lemma	kurtieji
@@ -7781,7 +7781,7 @@
 04623612-n	lit:lemma	temperamentas
 01883898-a	lit:lemma	laukiamas
 00250258-r	lit:lemma	labai
-00013662-s	lit:lemma	apčiuopiamas
+00013662-a	lit:lemma	apčiuopiamas
 09715833-n	lit:lemma	izraelietis
 01306273-a	lit:lemma	informuotas
 00199707-n	lit:lemma	pakeitimas
@@ -7804,7 +7804,7 @@
 00079947-r	lit:lemma	viršuje
 00089076-r	lit:lemma	amžinai
 08665504-n	lit:lemma	miestas
-00697691-s	lit:lemma	neapibrėžiamas
+00697691-a	lit:lemma	neapibrėžiamas
 01376894-a	lit:lemma	nežinomas
 08182379-n	lit:lemma	minia
 00300441-n	lit:lemma	kelionė oru
@@ -7827,7 +7827,7 @@
 00896555-a	lit:lemma	vienareikšmis
 05220461-n	lit:lemma	kūno dalis
 10253703-n	lit:lemma	legiono kareivis
-02573443-s	lit:lemma	krūmingas
+02573443-a	lit:lemma	krūmingas
 01199755-v	lit:lemma	įkvėpti
 13746512-n	lit:lemma	dešimt
 04831031-n	lit:lemma	beširdiškumas
@@ -7842,21 +7842,21 @@
 00023773-n	lit:lemma	paskata
 15297472-n	lit:lemma	bandomasis laikotarpis
 05825245-n	lit:lemma	pagrindimas
-01664015-s	lit:lemma	laimingas
+01664015-a	lit:lemma	laimingas
 13384164-n	lit:lemma	pensija
 10443170-n	lit:lemma	grobikas
-02043051-s	lit:lemma	apvalokas
+02043051-a	lit:lemma	apvalokas
 14359952-n	lit:lemma	pykinimas
-00915141-s	lit:lemma	matematinis
+00915141-a	lit:lemma	matematinis
 03620052-n	lit:lemma	virtuvės prietaisai
 00238064-r	lit:lemma	sąmoningai
 05799212-n	lit:lemma	mėginimas
-02323072-s	lit:lemma	triuškinantis
+02323072-a	lit:lemma	triuškinantis
 00343730-n	lit:lemma	piruetas
 03497100-n	lit:lemma	pigi valgykla
 09366017-n	lit:lemma	dauba
 03624767-n	lit:lemma	žirgas
-02199523-s	lit:lemma	trilijoninis
+02199523-a	lit:lemma	trilijoninis
 09020440-n	lit:lemma	Kirgizija
 08053576-n	lit:lemma	įstaiga
 05791602-n	lit:lemma	valia
@@ -7866,7 +7866,7 @@
 01049475-n	lit:lemma	maskavimas
 00450700-n	lit:lemma	jojimas
 03843092-n	lit:lemma	aliejiniai dažai
-01050088-s	lit:lemma	katastrofiškas
+01050088-a	lit:lemma	katastrofiškas
 14781752-n	lit:lemma	sugeriamasis popierius
 00328502-n	lit:lemma	šliuožimas
 03206718-n	lit:lemma	maskavimasis
@@ -7876,11 +7876,11 @@
 02852920-a	lit:lemma	santuokinis
 00189960-r	lit:lemma	rimtai
 01557120-a	lit:lemma	daugelis
-02050841-s	lit:lemma	žemės ūkio
+02050841-a	lit:lemma	žemės ūkio
 13954253-n	lit:lemma	trukmė
 13327676-n	lit:lemma	praradimas
-02179968-s	lit:lemma	nuoširdus
-00414518-s	lit:lemma	populiarus
+02179968-a	lit:lemma	nuoširdus
+00414518-a	lit:lemma	populiarus
 05924519-n	lit:lemma	idealas
 07289588-n	lit:lemma	stebuklas
 00018813-v	lit:lemma	kelti
@@ -7892,7 +7892,7 @@
 10173305-n	lit:lemma	pagrindinė veikėja
 15266164-n	lit:lemma	atskaitos taškas
 04007894-n	lit:lemma	gaminys
-02577734-s	lit:lemma	materialinis
+02577734-a	lit:lemma	materialinis
 00484166-v	lit:lemma	baigti
 05697363-n	lit:lemma	pasitikėjimas
 02725714-v	lit:lemma	susilaikyti
@@ -7900,20 +7900,20 @@
 01968569-v	lit:lemma	keltis
 03471473-n	lit:lemma	stoglatakis
 00605516-a	lit:lemma	priimtas
-00890874-s	lit:lemma	lygus
+00890874-a	lit:lemma	lygus
 02746897-a	lit:lemma	imperinis
 09616922-n	lit:lemma	linksmintojas
 14685881-n	lit:lemma	dyzelinas
 01170962-n	lit:lemma	mūšis
 00252894-n	lit:lemma	apsivalymas
 06694796-n	lit:lemma	rekomendacija
-02372118-s	lit:lemma	simetrinis
+02372118-a	lit:lemma	simetrinis
 13007417-n	lit:lemma	gluosninė kreivabudė
 08984567-n	lit:lemma	Iberijos pusiasalis
 00928077-n	lit:lemma	projektavimas
-01632066-s	lit:lemma	pateisinamasis
+01632066-a	lit:lemma	pateisinamasis
 10405410-n	lit:lemma	patento turėtojas
-02388921-s	lit:lemma	prijaukintas
+02388921-a	lit:lemma	prijaukintas
 04856308-n	lit:lemma	saugumas
 01812337-n	lit:lemma	balandis
 08372411-n	lit:lemma	gentis
@@ -7939,21 +7939,21 @@
 00490035-a	lit:lemma	neįprastas
 00031798-r	lit:lemma	jau
 09503877-n	lit:lemma	okultizmas
-01483677-s	lit:lemma	vyriškas
+01483677-a	lit:lemma	vyriškas
 13748128-n	lit:lemma	dvidešimt
-01984252-s	lit:lemma	sukompromituotas
+01984252-a	lit:lemma	sukompromituotas
 02171039-v	lit:lemma	paklausyti
-00830051-s	lit:lemma	išsilavinęs
+00830051-a	lit:lemma	išsilavinęs
 09271558-n	lit:lemma	Elbė (upė)
-01153595-s	lit:lemma	medvilniškas
-00348018-s	lit:lemma	stabilus
+01153595-a	lit:lemma	medvilniškas
+00348018-a	lit:lemma	stabilus
 05413241-n	lit:lemma	skydliaukės hormonas
 00166146-a	lit:lemma	žavus
 07486229-n	lit:lemma	noras
 01000068-n	lit:lemma	išrikiavimas
-01532454-s	lit:lemma	vidutiniškas
+01532454-a	lit:lemma	vidutiniškas
 02793495-n	lit:lemma	tvartas
-00668053-s	lit:lemma	aktualus
+00668053-a	lit:lemma	aktualus
 13619028-n	lit:lemma	gilis
 13138308-n	lit:lemma	kaulavaisis
 04491769-n	lit:lemma	lagaminas
@@ -7961,7 +7961,7 @@
 09436708-n	lit:lemma	dangus
 13873917-n	lit:lemma	apskritimas
 01438304-v	lit:lemma	atgabenti
-00611281-s	lit:lemma	tradicinis
+00611281-a	lit:lemma	tradicinis
 06200617-n	lit:lemma	palankumas
 11434016-n	lit:lemma	didelė nelaimė
 04895773-n	lit:lemma	nepatiklumas
@@ -7971,8 +7971,8 @@
 02923510-a	lit:lemma	islamo
 02959007-a	lit:lemma	portugališkas
 00018302-r	lit:lemma	pakankamai
-02164913-s	lit:lemma	skystas
-00126830-s	lit:lemma	parengtinis
+02164913-a	lit:lemma	skystas
+00126830-a	lit:lemma	parengtinis
 01237080-n	lit:lemma	dantis už dantį
 09811852-n	lit:lemma	artileristas
 01812662-n	lit:lemma	naminis karvelis
@@ -7984,30 +7984,30 @@
 01323958-v	lit:lemma	užmušti
 08221897-n	lit:lemma	žiūrovai
 04847298-n	lit:lemma	dorumas
-00815000-s	lit:lemma	priešlaikinis
+00815000-a	lit:lemma	priešlaikinis
 08718391-n	lit:lemma	Folklandų salos
-01440641-s	lit:lemma	ilgai negendantis
+01440641-a	lit:lemma	ilgai negendantis
 00186491-r	lit:lemma	oficialiai
 14441230-n	lit:lemma	negarbė
-00219389-s	lit:lemma	nuostabus
-00904745-s	lit:lemma	žemas
+00219389-a	lit:lemma	nuostabus
+00904745-a	lit:lemma	žemas
 13253255-n	lit:lemma	padaugėjimas
 07331400-n	lit:lemma	išsiskyrimas
 10257084-n	lit:lemma	liberalas
 11902389-n	lit:lemma	daržinė aguona
-01392249-s	lit:lemma	miniatiūrinis
+01392249-a	lit:lemma	miniatiūrinis
 05003423-n	lit:lemma	gracingumas
 01856929-a	lit:lemma	atsitiktinis
-00597148-s	lit:lemma	suardytas
+00597148-a	lit:lemma	suardytas
 06722453-n	lit:lemma	skelbimas
 00281132-n	lit:lemma	priėjimas
-00916199-s	lit:lemma	nepažodinis
+00916199-a	lit:lemma	nepažodinis
 15167027-n	lit:lemma	naktis
 10701180-n	lit:lemma	teniso žaidėjas
-02516148-s	lit:lemma	vaizdinis
+02516148-a	lit:lemma	vaizdinis
 09625789-n	lit:lemma	netikintysis
-01677200-s	lit:lemma	siaubingas
-00763272-s	lit:lemma	netikras
+01677200-a	lit:lemma	siaubingas
+00763272-a	lit:lemma	netikras
 05407119-n	lit:lemma	hormonas
 00278040-n	lit:lemma	sušlapinimas
 00059989-n	lit:lemma	pabėgimas
@@ -8015,22 +8015,22 @@
 07526338-n	lit:lemma	tikrumas
 06831498-n	lit:lemma	d
 07327805-n	lit:lemma	faktorius
-01616157-s	lit:lemma	asmeninis
+01616157-a	lit:lemma	asmeninis
 04247736-n	lit:lemma	užkandinė
 02689973-a	lit:lemma	banginių
-00453053-s	lit:lemma	artimas
+00453053-a	lit:lemma	artimas
 01080297-a	lit:lemma	vaisingas
 14610782-n	lit:lemma	chlorato rūgštis
 03080492-a	lit:lemma	lotynų
 08190482-n	lit:lemma	priešas
-00379804-s	lit:lemma	gelsvai rausvas
-00074594-s	lit:lemma	natūralus
-01993408-s	lit:lemma	tinkamas
+00379804-a	lit:lemma	gelsvai rausvas
+00074594-a	lit:lemma	natūralus
+01993408-a	lit:lemma	tinkamas
 00039318-r	lit:lemma	neabejotinai
 00282613-n	lit:lemma	karjera
 10231515-n	lit:lemma	karalius
 02745453-a	lit:lemma	ideografinis
-00065667-s	lit:lemma	neigiamas
+00065667-a	lit:lemma	neigiamas
 07516354-n	lit:lemma	įtūžis
 13724474-n	lit:lemma	hektogramas
 04384016-n	lit:lemma	uodega
@@ -8060,26 +8060,26 @@
 00428270-n	lit:lemma	šokis
 00021265-n	lit:lemma	pašaras
 00081737-r	lit:lemma	kiekvienais metais
-00979862-s	lit:lemma	greitas
+00979862-a	lit:lemma	greitas
 15164463-n	lit:lemma	penktadienis
 00048828-n	lit:lemma	atėjimas
 10660471-n	lit:lemma	keleivis be bilieto
 08570634-n	lit:lemma	lanka
-00891970-s	lit:lemma	izoterminis
+00891970-a	lit:lemma	izoterminis
 05808218-n	lit:lemma	atradimas
 00336831-a	lit:lemma	tikras
 00753685-n	lit:lemma	apdūmimas
-00148852-s	lit:lemma	klastingas
+00148852-a	lit:lemma	klastingas
 02988060-a	lit:lemma	tautinis
 02962272-a	lit:lemma	Rumunijos
 07179342-n	lit:lemma	kompromisas
 03933529-n	lit:lemma	dokas
-02322512-s	lit:lemma	smarkus
+02322512-a	lit:lemma	smarkus
 03875218-n	lit:lemma	dažai
 00575741-n	lit:lemma	užduotis
-00990855-s	lit:lemma	lieknas
+00990855-a	lit:lemma	lieknas
 05773049-n	lit:lemma	argumentas
-00418364-s	lit:lemma	nesuteptas
+00418364-a	lit:lemma	nesuteptas
 09184834-n	lit:lemma	psichinė energija
 11509697-n	lit:lemma	saulės energija
 09297584-n	lit:lemma	Kalifornijos įlanka
@@ -8095,8 +8095,8 @@
 09698517-n	lit:lemma	kolumbietis
 07544647-n	lit:lemma	palankumas
 07962124-n	lit:lemma	krūva
-01552802-s	lit:lemma	nesuskaičiuojamas
-00135455-s	lit:lemma	tinkamas
+01552802-a	lit:lemma	nesuskaičiuojamas
+00135455-a	lit:lemma	tinkamas
 04861486-n	lit:lemma	ryžtingumas
 00816481-a	lit:lemma	vėlus
 02950943-n	lit:lemma	patrankos sviedinys
@@ -8107,13 +8107,13 @@
 05996646-n	lit:lemma	disciplina
 04208210-n	lit:lemma	gaubtas kastuvas
 13978033-n	lit:lemma	incidentas
-01579128-s	lit:lemma	galutinis
-02466566-s	lit:lemma	abejotinas
+01579128-a	lit:lemma	galutinis
+02466566-a	lit:lemma	abejotinas
 10587605-n	lit:lemma	piemuo
 02121808-n	lit:lemma	naminė katė
 07377473-n	lit:lemma	kakofonija
 10182913-n	lit:lemma	homoseksualistas
-01593079-s	lit:lemma	paprastas
+01593079-a	lit:lemma	paprastas
 08552138-n	lit:lemma	perimetras
 13858604-n	lit:lemma	priešingybė
 13955461-n	lit:lemma	apčiuopiamumas
@@ -8137,21 +8137,21 @@
 08236621-n	lit:lemma	trestas
 02738031-n	lit:lemma	ginkluotė
 00332154-v	lit:lemma	susmulkinti
-00856011-s	lit:lemma	lyriškas
+00856011-a	lit:lemma	lyriškas
 01541013-a	lit:lemma	nepakeistas
 00521209-n	lit:lemma	ekspozicija
 14414715-n	lit:lemma	atsiskyrimas
 00611938-a	lit:lemma	netradicinis
-00764484-s	lit:lemma	tiesmukas
+00764484-a	lit:lemma	tiesmukas
 00394803-n	lit:lemma	atidengimas
-00193480-s	lit:lemma	siaubingas
+00193480-a	lit:lemma	siaubingas
 01113068-n	lit:lemma	pardavimas
 00575365-n	lit:lemma	lengvas darbas
 13743605-n	lit:lemma	pora
 04654337-n	lit:lemma	bičiuliškumas
 00236982-r	lit:lemma	tragiškai
 10701180-n	lit:lemma	tenisininkas
-00583842-s	lit:lemma	nesilpstamas
+00583842-a	lit:lemma	nesilpstamas
 00100592-r	lit:lemma	laiku
 10148165-n	lit:lemma	pajaunys
 04093625-n	lit:lemma	čiuožykla
@@ -8160,7 +8160,7 @@
 08949093-n	lit:lemma	Nyderlandai
 09714264-n	lit:lemma	indonezietis
 00124880-n	lit:lemma	kontaktas
-01940651-s	lit:lemma	racionalus
+01940651-a	lit:lemma	racionalus
 03391770-n	lit:lemma	rėmai
 15295045-n	lit:lemma	pakilimas
 15238472-n	lit:lemma	atostogų metas
@@ -8182,11 +8182,11 @@
 00548326-n	lit:lemma	vaidinimas
 00075966-r	lit:lemma	atbulai
 05599769-n	lit:lemma	gurklys
-00595299-s	lit:lemma	nenutrūkstamas
-02180277-s	lit:lemma	atviras
-01035007-s	lit:lemma	egzotiškas
-02050841-s	lit:lemma	agrarinis
-02038994-s	lit:lemma	stiprus
+00595299-a	lit:lemma	nenutrūkstamas
+02180277-a	lit:lemma	atviras
+01035007-a	lit:lemma	egzotiškas
+02050841-a	lit:lemma	agrarinis
+02038994-a	lit:lemma	stiprus
 15032376-n	lit:lemma	nuodinga medžiaga
 05633385-n	lit:lemma	sugalvojimas
 14922107-n	lit:lemma	frakcija
@@ -8219,12 +8219,12 @@
 10720453-n	lit:lemma	prekybininkas
 08179689-n	lit:lemma	žmonės
 02977058-n	lit:lemma	bankomatas
-00065667-s	lit:lemma	negatyvus
+00065667-a	lit:lemma	negatyvus
 02443049-v	lit:lemma	vadovauti
 13134302-n	lit:lemma	svogūninis augalas
 02966972-a	lit:lemma	argentiniškas
 01025913-a	lit:lemma	nenuolaidus
-02227946-s	lit:lemma	specialus
+02227946-a	lit:lemma	specialus
 06832356-n	lit:lemma	L
 00441824-n	lit:lemma	vandens sportas
 02354537-a	lit:lemma	palaikomas
@@ -8239,14 +8239,14 @@
 02682773-v	lit:lemma	apsaugoti
 01321854-n	lit:lemma	žinduolių jauniklis
 00424599-n	lit:lemma	žiaurus elgesys
-02075321-s	lit:lemma	pamišęs
+02075321-a	lit:lemma	pamišęs
 15140190-n	lit:lemma	nedalyvavimas dėl ligos
 02727825-n	lit:lemma	įrenginys
 02728440-n	lit:lemma	apranga
 08440630-n	lit:lemma	tironija
 00625119-v	lit:lemma	skaityti
 08058098-n	lit:lemma	firma
-02020609-s	lit:lemma	monotoniškas
+02020609-a	lit:lemma	monotoniškas
 02965043-a	lit:lemma	japonų
 02271544-a	lit:lemma	nepatyręs
 06812289-n	lit:lemma	trupmenos skirtukas
@@ -8261,8 +8261,8 @@
 02843717-a	lit:lemma	širdies
 02061799-a	lit:lemma	tinkamas parduoti
 14613643-n	lit:lemma	cianido rūgštis
-00789494-s	lit:lemma	romus
-00529191-s	lit:lemma	ribotas
+00789494-a	lit:lemma	romus
+00529191-a	lit:lemma	ribotas
 06473563-n	lit:lemma	anketa
 03147509-n	lit:lemma	puodelis
 11421401-n	lit:lemma	aktinio spinduliai
@@ -8298,14 +8298,14 @@
 03473966-n	lit:lemma	abitas
 09805475-n	lit:lemma	architektas
 00273077-n	lit:lemma	populiarinimas
-00698586-s	lit:lemma	nurašytas
+00698586-a	lit:lemma	nurašytas
 00105958-v	lit:lemma	jaustis
 05054130-n	lit:lemma	nenutrūkstamumas
-00425313-s	lit:lemma	šiurkštus
+00425313-a	lit:lemma	šiurkštus
 04664964-n	lit:lemma	neatsargumas
 00166952-v	lit:lemma	atimti gyvybingumą
 02629535-v	lit:lemma	apimti
-00250739-s	lit:lemma	beatodairiškas
+00250739-a	lit:lemma	beatodairiškas
 07030718-n	lit:lemma	partija
 06079439-n	lit:lemma	teratologija
 07330007-n	lit:lemma	lemtis
@@ -8319,16 +8319,16 @@
 00484166-v	lit:lemma	pabaigti
 08293336-n	lit:lemma	flotilė
 04971928-n	lit:lemma	rudumas
-00850648-s	lit:lemma	dailus
-00674732-s	lit:lemma	naminis
+00850648-a	lit:lemma	dailus
+00674732-a	lit:lemma	naminis
 01982646-a	lit:lemma	garbingas
 03273061-n	lit:lemma	elektros variklis
 07951464-n	lit:lemma	rinkinys
-01223271-s	lit:lemma	dviveidiškas
+01223271-a	lit:lemma	dviveidiškas
 00822970-n	lit:lemma	apsauga
-01792573-s	lit:lemma	nuogas
+01792573-a	lit:lemma	nuogas
 07990956-n	lit:lemma	paukščių pulkas
-02586446-s	lit:lemma	sektinas
+02586446-a	lit:lemma	sektinas
 06637824-n	lit:lemma	bazė
 00959376-n	lit:lemma	susirėmimas
 03777283-n	lit:lemma	modelis
@@ -8341,8 +8341,8 @@
 00115745-r	lit:lemma	politiškai
 14069895-n	lit:lemma	apsinuodijimas švinu
 06892534-n	lit:lemma	benefisas
-00453053-s	lit:lemma	pažįstamas
-01285136-s	lit:lemma	iškilnus
+00453053-a	lit:lemma	pažįstamas
+01285136-a	lit:lemma	iškilnus
 10164997-n	lit:lemma	budelis
 00087542-r	lit:lemma	amžinai
 07551691-n	lit:lemma	gera nuotaika
@@ -8356,10 +8356,10 @@
 15209413-n	lit:lemma	mėnesis
 10625860-n	lit:lemma	kerėtojas
 04191595-n	lit:lemma	priedanga
-02051616-s	lit:lemma	kaimietiškas
+02051616-a	lit:lemma	kaimietiškas
 01349948-n	lit:lemma	bakterija
-01973311-s	lit:lemma	sujungtas
-00750054-s	lit:lemma	malonus
+01973311-a	lit:lemma	sujungtas
+00750054-a	lit:lemma	malonus
 10319796-n	lit:lemma	šachtininkas
 06473940-n	lit:lemma	prašymo forma
 03817647-n	lit:lemma	peniuaras
@@ -8378,7 +8378,7 @@
 08219330-n	lit:lemma	Amerikos aviacijos divizija
 04393095-n	lit:lemma	magnetofonas
 04942869-n	lit:lemma	polinkis
-00070111-s	lit:lemma	plastinis
+00070111-a	lit:lemma	plastinis
 00732746-n	lit:lemma	įstatymo pažeidimas
 06713752-n	lit:lemma	peikimas
 09767700-n	lit:lemma	artistė
@@ -8387,38 +8387,38 @@
 02464693-a	lit:lemma	vertas pasitikėjimo
 10407726-n	lit:lemma	nuolatinis klientas
 07702796-n	lit:lemma	dribsniai
-01807964-s	lit:lemma	malonus
+01807964-a	lit:lemma	malonus
 02632940-v	lit:lemma	turėti
 02403454-n	lit:lemma	karvė
 14993378-n	lit:lemma	nuodingosios dujos
-01134486-s	lit:lemma	taikus
+01134486-a	lit:lemma	taikus
 00623162-n	lit:lemma	rankų darbas
 13275847-n	lit:lemma	išlaidos
 00039941-r	lit:lemma	iš pirmo žvilgsnio
-00651039-s	lit:lemma	grėsmingas
+00651039-a	lit:lemma	grėsmingas
 00992331-n	lit:lemma	datavimas
 00718924-a	lit:lemma	šališkas
 01640855-v	lit:lemma	vykdyti
 00231765-r	lit:lemma	savanoriškai
-01676026-s	lit:lemma	didžiulis
+01676026-a	lit:lemma	didžiulis
 10256537-n	lit:lemma	melagis
 07162194-n	lit:lemma	pasiūlymas
 04338359-n	lit:lemma	vėrinys
-00912094-s	lit:lemma	nelygus
+00912094-a	lit:lemma	nelygus
 01824339-v	lit:lemma	norėti
 01725051-v	lit:lemma	pagroti
 03808564-n	lit:lemma	narkotikas
 06832140-n	lit:lemma	j
 05937112-n	lit:lemma	modelis
-01601981-s	lit:lemma	šiaurės vakarų
+01601981-a	lit:lemma	šiaurės vakarų
 14326607-n	lit:lemma	galvos skausmas
 07208338-n	lit:lemma	nesutikimas
-01111418-s	lit:lemma	dosnus
+01111418-a	lit:lemma	dosnus
 04362025-n	lit:lemma	paviršius
 10673451-n	lit:lemma	pasiūlymo autorius
 09214581-n	lit:lemma	barjeras
 01220984-n	lit:lemma	elgimasis
-02411116-s	lit:lemma	plačiakrūtinis
+02411116-a	lit:lemma	plačiakrūtinis
 06373513-n	lit:lemma	atsitikimas
 01638438-a	lit:lemma	senas
 03649909-n	lit:lemma	žoliapjovė
@@ -8429,24 +8429,24 @@
 02725562-v	lit:lemma	tupėti
 08052549-n	lit:lemma	federalinė valdžia
 00361065-r	lit:lemma	vienodai
-01750386-s	lit:lemma	tobulas
+01750386-a	lit:lemma	tobulas
 01134479-n	lit:lemma	blogas valdymas
 02945971-a	lit:lemma	pedagoginis
-01996875-s	lit:lemma	atsakingas
+01996875-a	lit:lemma	atsakingas
 00089324-v	lit:lemma	dezinfekuoti
-01394075-s	lit:lemma	miniatiūrinis
+01394075-a	lit:lemma	miniatiūrinis
 01330986-a	lit:lemma	integralus
 00829107-v	lit:lemma	išmokyti
 04760771-n	lit:lemma	kūniškumas
 08337324-n	lit:lemma	federalinis biuras
-02229961-s	lit:lemma	juodas
-00414354-s	lit:lemma	modernus
+02229961-a	lit:lemma	juodas
+00414354-a	lit:lemma	modernus
 03536348-n	lit:lemma	lygus paviršius
 05124057-n	lit:lemma	limitas
 03099454-n	lit:lemma	moterų vienuolynas
 12321873-n	lit:lemma	baltoji karija
 01090446-n	lit:lemma	prekiavimas
-00792641-s	lit:lemma	aukščiausias
+00792641-a	lit:lemma	aukščiausias
 00958896-n	lit:lemma	konfliktas
 02749904-v	lit:lemma	būti
 00356957-r	lit:lemma	aukštai
@@ -8454,18 +8454,18 @@
 14015731-n	lit:lemma	laikina padėtis
 01883898-a	lit:lemma	būsimas
 02108654-v	lit:lemma	gauti
-01385773-s	lit:lemma	drambliškas
+01385773-a	lit:lemma	drambliškas
 00504620-r	lit:lemma	pilnai
 01202184-n	lit:lemma	sekvestravimas
 00246802-r	lit:lemma	stulbinančiai
-02199342-s	lit:lemma	milijardinis
+02199342-a	lit:lemma	milijardinis
 03127531-n	lit:lemma	šoninis aptvėrimas
-00709446-s	lit:lemma	lūžus
+00709446-a	lit:lemma	lūžus
 05770664-n	lit:lemma	aukštesnysis pažinimo procesas
 08512736-n	lit:lemma	siena
 05128519-n	lit:lemma	plotas
-01395821-s	lit:lemma	paklusnus
-00304144-s	lit:lemma	smarkus
+01395821-a	lit:lemma	paklusnus
+00304144-a	lit:lemma	smarkus
 04829182-n	lit:lemma	žmogiškumas
 06787429-n	lit:lemma	siuntėjo adresas
 00286166-r	lit:lemma	pakrante
@@ -8477,8 +8477,8 @@
 08540903-n	lit:lemma	didmiestis
 14876066-n	lit:lemma	fumaro rūgštis
 07887634-n	lit:lemma	šviesus alus
-00854255-s	lit:lemma	jausminis
-02249183-s	lit:lemma	tarpasmeninis
+00854255-a	lit:lemma	jausminis
+02249183-a	lit:lemma	tarpasmeninis
 01504625-a	lit:lemma	muzikinis
 10037385-n	lit:lemma	girtuoklis
 02932227-n	lit:lemma	kajutė
@@ -8486,30 +8486,30 @@
 00150134-r	lit:lemma	be abejonės
 05455690-n	lit:lemma	geltonoji dėmė
 01645601-v	lit:lemma	lemti
-00750602-s	lit:lemma	lengvas
+00750602-a	lit:lemma	lengvas
 01764800-v	lit:lemma	numalšinti
 07516997-n	lit:lemma	įsiūtis
 02380583-n	lit:lemma	mustangas
 00674196-a	lit:lemma	mašininis
 01888520-n	lit:lemma	vabzdžiaėdžiai
 10339966-n	lit:lemma	muzikas
-02343110-s	lit:lemma	labai geras
+02343110-a	lit:lemma	labai geras
 00491292-r	lit:lemma	naudingai
 09847010-n	lit:lemma	elgeta
 00334509-n	lit:lemma	judesys
-00251134-s	lit:lemma	herojiškas
-01214430-s	lit:lemma	raižus
+00251134-a	lit:lemma	herojiškas
+01214430-a	lit:lemma	raižus
 15209413-n	lit:lemma	kalendorinis mėnuo
-00514175-s	lit:lemma	protestuojantis
+00514175-a	lit:lemma	protestuojantis
 10508710-n	lit:lemma	skaitytojas
 02681518-n	lit:lemma	puošmena
 04890112-n	lit:lemma	išmintingumas
-01861776-s	lit:lemma	valstybinis
+01861776-a	lit:lemma	valstybinis
 01169704-v	lit:lemma	žįsti
-01258264-s	lit:lemma	šaltas
+01258264-a	lit:lemma	šaltas
 04955633-n	lit:lemma	matiškumas
-00193480-s	lit:lemma	baisus
-00309620-s	lit:lemma	detalus
+00193480-a	lit:lemma	baisus
+00309620-a	lit:lemma	detalus
 02960507-a	lit:lemma	belgų
 13975752-n	lit:lemma	sąmyšis
 03171356-n	lit:lemma	gynybos įtvirtinimas
@@ -8537,23 +8537,23 @@
 09060768-n	lit:lemma	Kalifornija
 02958392-a	lit:lemma	prancūzų
 04726724-n	lit:lemma	svarbiausioji savybė
-01637371-s	lit:lemma	nepatyręs
+01637371-a	lit:lemma	nepatyręs
 00425451-n	lit:lemma	erzinimas
-00343226-s	lit:lemma	fatalus
+00343226-a	lit:lemma	fatalus
 07466195-n	lit:lemma	gaidžių peštynės
 06018022-n	lit:lemma	taikomoji matematika
 00285557-n	lit:lemma	eisena
 01193886-n	lit:lemma	išteisinimas
 13253255-n	lit:lemma	įgijimas
-01520091-s	lit:lemma	užkietėjęs
+01520091-a	lit:lemma	užkietėjęs
 01734884-a	lit:lemma	motiniškas
 14585519-n	lit:lemma	trupinėlis
 02296726-v	lit:lemma	siūlyti
 10018021-n	lit:lemma	priešininkas
-00608791-s	lit:lemma	ekscentriškas
+00608791-a	lit:lemma	ekscentriškas
 03145843-n	lit:lemma	atlankas
 14977504-n	lit:lemma	grindinys
-00526062-s	lit:lemma	visa apimantis
+00526062-a	lit:lemma	visa apimantis
 03412058-n	lit:lemma	galerija
 07217924-n	lit:lemma	pranešimas
 03576955-n	lit:lemma	įleidimo vožtuvas
@@ -8563,7 +8563,7 @@
 15063224-n	lit:lemma	konstrukcinis plienas
 14323683-n	lit:lemma	maudimas
 03563460-n	lit:lemma	rotorius
-01744515-s	lit:lemma	įžvalgus
+01744515-a	lit:lemma	įžvalgus
 02931826-a	lit:lemma	nakties
 13282007-n	lit:lemma	atlyginimas
 00971075-a	lit:lemma	stilingas
@@ -8574,29 +8574,29 @@
 00035189-n	lit:lemma	pasiekimas
 08566028-n	lit:lemma	baiga
 00176880-r	lit:lemma	pakartotinai
-01764351-s	lit:lemma	trukdantis
-01804422-s	lit:lemma	atgrasus
+01764351-a	lit:lemma	trukdantis
+01804422-a	lit:lemma	atgrasus
 08566554-n	lit:lemma	galas
 00395744-r	lit:lemma	meistriškai
-01346978-s	lit:lemma	vidinis
+01346978-a	lit:lemma	vidinis
 10667187-n	lit:lemma	kvailys
 00230331-r	lit:lemma	iš išorės
 08989556-n	lit:lemma	Kingstaunas
 00005205-a	lit:lemma	absoliutus
 10100761-n	lit:lemma	žioplys
-02397496-s	lit:lemma	pipiruotas
+02397496-a	lit:lemma	pipiruotas
 06663617-n	lit:lemma	etika
-01563494-s	lit:lemma	mobilus
+01563494-a	lit:lemma	mobilus
 01459791-n	lit:lemma	vaisius
 14785524-n	lit:lemma	bromato rūgštis
 14033185-n	lit:lemma	kryžkelė
 12396924-n	lit:lemma	kanapė
 00363744-r	lit:lemma	logiškai
-01360962-s	lit:lemma	tapatus
+01360962-a	lit:lemma	tapatus
 10577284-n	lit:lemma	pirklys
 09019726-n	lit:lemma	Kazachstanas
 09263619-n	lit:lemma	Negyvoji jūra
-01384212-s	lit:lemma	erdvus
+01384212-a	lit:lemma	erdvus
 05534333-n	lit:lemma	žarnos
 01093085-n	lit:lemma	atmaina
 02956247-n	lit:lemma	kapitelis
@@ -8605,22 +8605,22 @@
 00993014-v	lit:lemma	rašyti
 00020259-v	lit:lemma	negulti
 03133538-n	lit:lemma	indai
-01744515-s	lit:lemma	aštrus
+01744515-a	lit:lemma	aštrus
 08683548-n	lit:lemma	tyrai
 00009631-v	lit:lemma	trūkčioti
 00431396-r	lit:lemma	patraukliai
-02144436-s	lit:lemma	lankstus
+02144436-a	lit:lemma	lankstus
 11426125-n	lit:lemma	atominė energija
-01710543-s	lit:lemma	nepadengtas
-01443842-s	lit:lemma	trumpalaikis
-01405523-s	lit:lemma	neišskaitomas
+01710543-a	lit:lemma	nepadengtas
+01443842-a	lit:lemma	trumpalaikis
+01405523-a	lit:lemma	neišskaitomas
 06409562-n	lit:lemma	esė
 10193967-n	lit:lemma	sutuoktinis
-01842198-s	lit:lemma	atsitiktinis
+01842198-a	lit:lemma	atsitiktinis
 02325211-n	lit:lemma	amerikiniai triušiai
 00012434-v	lit:lemma	didžiuotis
 03390207-n	lit:lemma	dalelė
-00412171-s	lit:lemma	pažangus
+00412171-a	lit:lemma	pažangus
 00035758-v	lit:lemma	švarinti
 02395115-a	lit:lemma	skanus
 00023773-n	lit:lemma	poreikis
@@ -8628,11 +8628,11 @@
 01856929-a	lit:lemma	papildomas
 02906351-a	lit:lemma	demografinis
 15267536-n	lit:lemma	pabaiga
-02526611-s	lit:lemma	apsaugotas
+02526611-a	lit:lemma	apsaugotas
 07863374-n	lit:lemma	makaronai
 03274265-n	lit:lemma	elektrinis dantų šepetėlis
 01057759-n	lit:lemma	šėrimas
-02477557-s	lit:lemma	integralus
+02477557-a	lit:lemma	integralus
 00682928-v	lit:lemma	cenzūruoti
 15120823-n	lit:lemma	praeitis
 07373602-n	lit:lemma	sintezė
@@ -8645,16 +8645,16 @@
 14817419-n	lit:lemma	episoma
 07499615-n	lit:lemma	draugiškumas
 05838765-n	lit:lemma	klasė
-02090228-s	lit:lemma	slaptas
+02090228-a	lit:lemma	slaptas
 00081486-r	lit:lemma	kasdien
 07551691-n	lit:lemma	nuotaikingumas
 00361781-r	lit:lemma	vangiai
 07891309-n	lit:lemma	imbierinis limonadas
 00262743-n	lit:lemma	dekoravimas
-00696996-s	lit:lemma	romus
+00696996-a	lit:lemma	romus
 05271685-n	lit:lemma	kubakaulis
 04373894-n	lit:lemma	kalavijas
-01771839-s	lit:lemma	tankus
+01771839-a	lit:lemma	tankus
 04779649-n	lit:lemma	nemalonumas
 02148788-v	lit:lemma	demonstruoti
 00408660-a	lit:lemma	šviesus
@@ -8675,11 +8675,11 @@
 04247736-n	lit:lemma	bufetas
 15113229-n	lit:lemma	laikotarpis
 02569030-a	lit:lemma	belaidis
-01662119-s	lit:lemma	pirmalaikis
-00345694-s	lit:lemma	nepastovus
+01662119-a	lit:lemma	pirmalaikis
+00345694-a	lit:lemma	nepastovus
 09979321-n	lit:lemma	kritikas
 07520411-n	lit:lemma	siaubas
-01710260-s	lit:lemma	savanoriškas
+01710260-a	lit:lemma	savanoriškas
 14746048-n	lit:lemma	progesteronas
 00531077-n	lit:lemma	kankanas
 00034213-n	lit:lemma	reiškinys
@@ -8691,13 +8691,13 @@
 13477023-n	lit:lemma	vystymasis
 02978881-n	lit:lemma	kasetė
 00517728-n	lit:lemma	šventė
-01885991-s	lit:lemma	saugus
+01885991-a	lit:lemma	saugus
 00212065-n	lit:lemma	mokslo užbaigimas
 06505935-n	lit:lemma	marginalijos
 08095647-n	lit:lemma	musulmonų kultūra
 05669934-n	lit:lemma	kognityvi būklė
 04880573-n	lit:lemma	naivumas
-02160135-s	lit:lemma	aklas
+02160135-a	lit:lemma	aklas
 13901585-n	lit:lemma	lašas
 00116280-r	lit:lemma	simboliškai
 00221583-r	lit:lemma	bendrai
@@ -8710,7 +8710,7 @@
 07989373-n	lit:lemma	santuoka
 15290132-n	lit:lemma	fazinis kampas
 07625493-n	lit:lemma	pyragas
-00837415-s	lit:lemma	sunkus
+00837415-a	lit:lemma	sunkus
 04862592-n	lit:lemma	tvirtumas
 02005948-v	lit:lemma	atvažiuoti
 08960548-n	lit:lemma	Lichtenšteino Kunigaikštystė
@@ -8719,7 +8719,7 @@
 00464037-n	lit:lemma	vartininkas
 01907258-v	lit:lemma	apsisukti
 08573258-n	lit:lemma	poliarinė zona
-00990855-s	lit:lemma	laibas
+00990855-a	lit:lemma	laibas
 02955065-n	lit:lemma	dangtis
 13243668-n	lit:lemma	visuomeninis turtas
 00358431-v	lit:lemma	numirti
@@ -8728,10 +8728,10 @@
 01812950-v	lit:lemma	pradžiuginti
 09543353-n	lit:lemma	velnias
 10298912-n	lit:lemma	laivo kapitonas
-01313649-s	lit:lemma	nuošalus
+01313649-a	lit:lemma	nuošalus
 03417345-n	lit:lemma	miškelis
 00458890-n	lit:lemma	kompiuterinis žaidimas
-02481012-s	lit:lemma	suskaidytas
+02481012-a	lit:lemma	suskaidytas
 02862797-a	lit:lemma	branduolinis
 12205694-n	lit:lemma	vaistažolė
 10212780-n	lit:lemma	interpretatorius
@@ -8740,21 +8740,21 @@
 01218593-n	lit:lemma	žavėjimasis
 00007846-n	lit:lemma	vėlė
 02963942-a	lit:lemma	serbiškas
-01916784-s	lit:lemma	abejojamas
+01916784-a	lit:lemma	abejojamas
 07501545-n	lit:lemma	atsparumas
 00851744-a	lit:lemma	tinkamas
-01126841-s	lit:lemma	pasigailėtinas
+01126841-a	lit:lemma	pasigailėtinas
 13096159-n	lit:lemma	šerdis
 09087599-n	lit:lemma	Kanzasas
-00357556-s	lit:lemma	savitas
+00357556-a	lit:lemma	savitas
 13872975-n	lit:lemma	kūgis
-01628531-s	lit:lemma	užgaulus
+01628531-a	lit:lemma	užgaulus
 01764800-v	lit:lemma	raminti
 02331479-n	lit:lemma	peliniai
 04491388-n	lit:lemma	policininko lazda
 09251407-n	lit:lemma	kometa
-01149358-s	lit:lemma	džiugus
-01206318-s	lit:lemma	viršesnis
+01149358-a	lit:lemma	džiugus
+01206318-a	lit:lemma	viršesnis
 10727256-n	lit:lemma	kasininkas
 09004068-n	lit:lemma	Maskva
 01277974-v	lit:lemma	sulenkti
@@ -8769,24 +8769,24 @@
 07060440-n	lit:lemma	kantri muzika
 09355850-n	lit:lemma	akivaras
 10116370-n	lit:lemma	fundamentalistas
-00197773-s	lit:lemma	pats užpakalinis
-02516148-s	lit:lemma	optinis
+00197773-a	lit:lemma	pats užpakalinis
+02516148-a	lit:lemma	optinis
 11417672-n	lit:lemma	geologinis darinys
 00657604-n	lit:lemma	sveikatos priežiūra
 03271574-n	lit:lemma	elektrinis ventiliatorius
-02068946-s	lit:lemma	tapatus
+02068946-a	lit:lemma	tapatus
 02200630-n	lit:lemma	uodas
 03789946-n	lit:lemma	variklis
 01927455-a	lit:lemma	racionalus
 13910019-n	lit:lemma	gniutulas
 02753044-n	lit:lemma	plutoninė bomba
-00977699-s	lit:lemma	skubus
+00977699-a	lit:lemma	skubus
 01159655-a	lit:lemma	nekenksmingas
 01112885-n	lit:lemma	platinimas
-00929815-s	lit:lemma	lauktas
+00929815-a	lit:lemma	lauktas
 00789237-n	lit:lemma	dvikova
 09198574-n	lit:lemma	Antarktidos vandenynas
-00127543-s	lit:lemma	iš eilės
+00127543-a	lit:lemma	iš eilės
 07974025-n	lit:lemma	sluoksnis
 01227190-n	lit:lemma	atleidimas
 00383606-n	lit:lemma	separacija
@@ -8798,7 +8798,7 @@
 07537485-n	lit:lemma	prislėgtumas
 00152684-r	lit:lemma	taip
 00927017-a	lit:lemma	egzistuojantis
-00312234-s	lit:lemma	paviršutiniškas
+00312234-a	lit:lemma	paviršutiniškas
 11493827-n	lit:lemma	įtampos krytis
 00235435-n	lit:lemma	pradėjimas
 01189282-n	lit:lemma	nuosprendis
@@ -8812,9 +8812,9 @@
 03925226-n	lit:lemma	fotografija
 09938991-n	lit:lemma	šulas
 10676877-n	lit:lemma	patarėjas
-00304144-s	lit:lemma	laukinis
+00304144-a	lit:lemma	laukinis
 14540765-n	lit:lemma	pavojus
-00934966-s	lit:lemma	pigus
+00934966-a	lit:lemma	pigus
 00829378-n	lit:lemma	apsauga
 10054657-n	lit:lemma	darbdavys
 02957469-a	lit:lemma	vokiečių
@@ -8834,7 +8834,7 @@
 00255614-r	lit:lemma	tokiu būdu
 09928136-n	lit:lemma	dvasininkas
 00207668-r	lit:lemma	pavieniui
-00363031-s	lit:lemma	besišypsantis
+00363031-a	lit:lemma	besišypsantis
 14441230-n	lit:lemma	nešlovė
 06770275-n	lit:lemma	susitarimas
 00285387-n	lit:lemma	kalbėjimas per miegus
@@ -8842,46 +8842,46 @@
 13354420-n	lit:lemma	kapitalas
 00043078-v	lit:lemma	išgražinti
 10669486-n	lit:lemma	pareiškėjas
-01578856-s	lit:lemma	galimas
+01578856-a	lit:lemma	galimas
 00018577-r	lit:lemma	absoliučiai
 06892657-n	lit:lemma	labdaros koncertas
 00513089-n	lit:lemma	pasilinksminimas
 08009834-n	lit:lemma	nevalstybinė organizacija
 00103859-r	lit:lemma	nuo
 04407435-n	lit:lemma	šventovė
-00167829-s	lit:lemma	patrauklus
+00167829-a	lit:lemma	patrauklus
 00625393-a	lit:lemma	apčiuopiamas
 00325343-r	lit:lemma	šonu
 00211462-n	lit:lemma	baigimas
 01953467-a	lit:lemma	neapdirbtas
-01006788-s	lit:lemma	apribotas
+01006788-a	lit:lemma	apribotas
 02806088-n	lit:lemma	citadelė
 00125436-n	lit:lemma	pliaukštelėjimas
-02165432-s	lit:lemma	nežymus
+02165432-a	lit:lemma	nežymus
 07229530-n	lit:lemma	didžiavimasis
 05163807-n	lit:lemma	nuostolis
 07378234-n	lit:lemma	zvimbesys
 09608709-n	lit:lemma	aukotojas
 08973776-n	lit:lemma	Nigerijos Federacinė Respublika
 00628491-v	lit:lemma	apmąstyti
-01723648-s	lit:lemma	šaltas
+01723648-a	lit:lemma	šaltas
 00489086-r	lit:lemma	visiškai
 01177327-n	lit:lemma	sukilimas
-00967646-s	lit:lemma	groteskinis
+00967646-a	lit:lemma	groteskinis
 02920503-n	lit:lemma	bunkeris
 07177437-n	lit:lemma	suderinimas
 03012499-n	lit:lemma	sūrio pjaustyklė
 00047317-v	lit:lemma	pamatuoti
 03022739-a	lit:lemma	propagandinis
-01019713-s	lit:lemma	glebus
-01865967-s	lit:lemma	produktyvus
+01019713-a	lit:lemma	glebus
+01865967-a	lit:lemma	produktyvus
 00030853-v	lit:lemma	iškristi
 14405931-n	lit:lemma	panika
 07185325-n	lit:lemma	prašymas
 07152259-n	lit:lemma	šūkis
 09109444-n	lit:lemma	Nebraska
 06347588-n	lit:lemma	subtitrai
-00521329-s	lit:lemma	užbaigtas
+00521329-a	lit:lemma	užbaigtas
 07409592-n	lit:lemma	palietimas
 03091374-n	lit:lemma	jungiamasis elementas
 00174003-n	lit:lemma	priemonė
@@ -8889,7 +8889,7 @@
 03269401-n	lit:lemma	elektrinis aparatas
 13480541-n	lit:lemma	pripildymas
 01926311-v	lit:lemma	bėgti
-01778935-s	lit:lemma	kūniškas
+01778935-a	lit:lemma	kūniškas
 02526085-v	lit:lemma	atlikti
 04010205-n	lit:lemma	pasivaikščiojimo vieta
 13833886-n	lit:lemma	pietvakariai
@@ -8900,13 +8900,13 @@
 02728440-n	lit:lemma	drabužiai
 00107230-r	lit:lemma	nepaprastai
 00285141-n	lit:lemma	nakvišumas
-01732601-s	lit:lemma	būsimas
+01732601-a	lit:lemma	būsimas
 03042661-a	lit:lemma	aneroidinis
 01347138-a	lit:lemma	nepriklausantis įstaigai
 00428270-n	lit:lemma	šokimas
 04226537-n	lit:lemma	griaučiai
 02872066-a	lit:lemma	santuokinis
-01066787-s	lit:lemma	paprastas
+01066787-a	lit:lemma	paprastas
 02381089-a	lit:lemma	jungiamasis
 04971928-n	lit:lemma	ruda spalva
 07574504-n	lit:lemma	užkandžiai
@@ -8921,7 +8921,7 @@
 09791530-n	lit:lemma	finansų analitikas
 00197772-n	lit:lemma	pakeitimas
 03006398-n	lit:lemma	televizijos kanalas
-02369027-s	lit:lemma	gaižus
+02369027-a	lit:lemma	gaižus
 00372660-r	lit:lemma	taktiškai
 00216278-r	lit:lemma	palaipsniui
 08494231-n	lit:lemma	pramogų parkas
@@ -8937,7 +8937,7 @@
 00590390-a	lit:lemma	ginčytinas
 03775199-n	lit:lemma	plakiklis
 00063291-v	lit:lemma	dirginti
-01234527-s	lit:lemma	pasviręs
+01234527-a	lit:lemma	pasviręs
 13133613-n	lit:lemma	varpa
 05456732-n	lit:lemma	lytinė ląstelė
 09105821-n	lit:lemma	Misuris
@@ -8945,7 +8945,7 @@
 09309046-n	lit:lemma	ledlaukis
 02619424-v	lit:lemma	lankyti
 09214581-n	lit:lemma	užtvara
-00590271-s	lit:lemma	neramus
+00590271-a	lit:lemma	neramus
 13387877-n	lit:lemma	metaliniai pinigai
 05647643-n	lit:lemma	netinkamumas
 05384691-n	lit:lemma	alkūninė vena
@@ -8967,36 +8967,36 @@
 02131777-v	lit:lemma	pažiūrėti
 05329735-n	lit:lemma	endokrininė liauka
 10147935-n	lit:lemma	jaunasis
-01019283-s	lit:lemma	neįgalus
+01019283-a	lit:lemma	neįgalus
 06787429-n	lit:lemma	atgalinis adresas
 10350220-n	lit:lemma	nacis
 01027859-n	lit:lemma	apeigos
-00640660-s	lit:lemma	trumpas
+00640660-a	lit:lemma	trumpas
 05862268-n	lit:lemma	vienalytis daugianaris
 03841666-n	lit:lemma	įstaiga
-01769179-s	lit:lemma	asmeninis
+01769179-a	lit:lemma	asmeninis
 07547805-n	lit:lemma	pikta valia
 09284015-n	lit:lemma	miškas
 02927512-a	lit:lemma	amerikiečių
-01982957-s	lit:lemma	nusipelnęs
+01982957-a	lit:lemma	nusipelnęs
 02116738-n	lit:lemma	hieninis šuo
 02457233-v	lit:lemma	rodyti pagarbą
 01852174-a	lit:lemma	pirmaeilis
 00733483-n	lit:lemma	įsibrovimas
 01238058-n	lit:lemma	decentralizacija
-01492596-s	lit:lemma	paaugliškas
+01492596-a	lit:lemma	paaugliškas
 02238462-a	lit:lemma	šiurkštus
 15143477-n	lit:lemma	pabaiga
 00619869-v	lit:lemma	nesuprasti
 02785874-a	lit:lemma	provincinis
 02403325-n	lit:lemma	bulius
 03545150-n	lit:lemma	pastatas
-01145151-s	lit:lemma	status
+01145151-a	lit:lemma	status
 10605253-n	lit:lemma	slidininkas
 09067277-n	lit:lemma	Koloradas
-01014953-s	lit:lemma	pereinamasis
+01014953-a	lit:lemma	pereinamasis
 06724066-n	lit:lemma	teisingas teiginys
-01143855-s	lit:lemma	neatidėliotinas
+01143855-a	lit:lemma	neatidėliotinas
 07025900-n	lit:lemma	klasikinė muzika
 00744305-n	lit:lemma	žala
 02487347-n	lit:lemma	makaka
@@ -9004,8 +9004,8 @@
 03009920-n	lit:lemma	žvaigždėlapis
 04828925-n	lit:lemma	žmoniškumas
 14830992-n	lit:lemma	egzonas
-02469407-s	lit:lemma	pavyzdinis
-02421364-s	lit:lemma	ekonomiškas
+02469407-a	lit:lemma	pavyzdinis
+02421364-a	lit:lemma	ekonomiškas
 00804476-v	lit:lemma	pasiduoti
 00377002-v	lit:lemma	sudegti
 07254267-n	lit:lemma	atsistatydinimas
@@ -9017,7 +9017,7 @@
 08056231-n	lit:lemma	įmonė
 00259643-n	lit:lemma	atlyginimas
 00404170-n	lit:lemma	atnaujinimas
-00764484-s	lit:lemma	nuoširdus
+00764484-a	lit:lemma	nuoširdus
 08078020-n	lit:lemma	šeima
 15247410-n	lit:lemma	efemeriškumas
 04403413-n	lit:lemma	teleobjektyvas
@@ -9047,13 +9047,13 @@
 08122358-n	lit:lemma	Atominės energijos komisija
 00089408-r	lit:lemma	labai
 00266401-n	lit:lemma	nuosmukis
-00477284-s	lit:lemma	saugus
+00477284-a	lit:lemma	saugus
 00194737-r	lit:lemma	nerangiai
-01357027-s	lit:lemma	gaivinantis
+01357027-a	lit:lemma	gaivinantis
 10126926-n	lit:lemma	genijus
 06427831-n	lit:lemma	redagavimas
-01876261-s	lit:lemma	modernus
-00542359-s	lit:lemma	negausus
+01876261-a	lit:lemma	modernus
+00542359-a	lit:lemma	negausus
 01501113-a	lit:lemma	melodingas
 00029343-a	lit:lemma	gobšus
 00160532-n	lit:lemma	suvedžiojimas
@@ -9070,7 +9070,7 @@
 14830364-n	lit:lemma	deoksiribonukleorūgštis
 04486445-n	lit:lemma	smulkmena
 00210797-n	lit:lemma	galas
-01778935-s	lit:lemma	fizinis
+01778935-a	lit:lemma	fizinis
 06368425-n	lit:lemma	fantazija
 02767308-v	lit:lemma	išskirti
 13431380-n	lit:lemma	anafazė
@@ -9082,10 +9082,10 @@
 03308297-n	lit:lemma	akutė
 15173479-n	lit:lemma	kalendorius
 09026360-n	lit:lemma	Leonas
-00417204-s	lit:lemma	neapdorotas
+00417204-a	lit:lemma	neapdorotas
 04371979-n	lit:lemma	dvivėrės durys
 10182499-n	lit:lemma	savininkas
-02130821-s	lit:lemma	neišspręstas
+02130821-a	lit:lemma	neišspręstas
 02984203-n	lit:lemma	katedra
 00283568-n	lit:lemma	ėjimas
 00308370-n	lit:lemma	ekskursija
@@ -9097,20 +9097,20 @@
 07517737-n	lit:lemma	pasipiktinimas
 13745086-n	lit:lemma	aštuoni
 00061917-n	lit:lemma	įgyvendinimas
-00906099-s	lit:lemma	liaupsinamas
+00906099-a	lit:lemma	liaupsinamas
 11880032-n	lit:lemma	rapsų aliejus
-01935935-s	lit:lemma	fiktyvus
+01935935-a	lit:lemma	fiktyvus
 14943580-n	lit:lemma	mediena
 00181576-r	lit:lemma	pamažu
 11449419-n	lit:lemma	elektrinė galia
 00710260-a	lit:lemma	sunkus
 02972925-a	lit:lemma	Izraelio
-00076127-s	lit:lemma	pritariantis
+00076127-a	lit:lemma	pritariantis
 02964107-a	lit:lemma	kroatiškas
 03219135-n	lit:lemma	lėlė
 14418822-n	lit:lemma	konfederacija
 00041899-n	lit:lemma	įgijimas
-01947741-s	lit:lemma	civilizuotas
+01947741-a	lit:lemma	civilizuotas
 00758795-n	lit:lemma	tingumas
 07301950-n	lit:lemma	avarija
 00342028-n	lit:lemma	sukimasis
@@ -9125,13 +9125,13 @@
 00020280-r	lit:lemma	nuolatos
 00257770-n	lit:lemma	vonia
 00820976-v	lit:lemma	įrodyti
-00975487-s	lit:lemma	elegantiškas
+00975487-a	lit:lemma	elegantiškas
 05074774-n	lit:lemma	pozicija
 08600760-n	lit:lemma	nadyras
 01068773-n	lit:lemma	abstinencija
 07180787-n	lit:lemma	prieštaravimas
 10332385-n	lit:lemma	gimdytoja
-02516148-s	lit:lemma	regimasis
+02516148-a	lit:lemma	regimasis
 08372411-n	lit:lemma	giminė
 10614629-n	lit:lemma	kalvis
 00145854-r	lit:lemma	nepakankamai
@@ -9146,36 +9146,36 @@
 15266164-n	lit:lemma	pradinis taškas
 00239215-r	lit:lemma	kukliai
 09351547-n	lit:lemma	ežerėlis
-02565425-s	lit:lemma	nusiteikęs
+02565425-a	lit:lemma	nusiteikęs
 02086079-n	lit:lemma	pekinas
 06641181-n	lit:lemma	kainų indeksas
 04656748-n	lit:lemma	užsidarymas
 08630985-n	lit:lemma	teritorija
-00729439-s	lit:lemma	apsirūpinantis
+00729439-a	lit:lemma	apsirūpinantis
 15118100-n	lit:lemma	darbo valandos
 00439484-n	lit:lemma	salto
 08686821-n	lit:lemma	Liūtas
-01044730-s	lit:lemma	laisvas
+01044730-a	lit:lemma	laisvas
 00383952-n	lit:lemma	pertraukimas
 00033308-r	lit:lemma	vos
-02312450-s	lit:lemma	skersas
+02312450-a	lit:lemma	skersas
 00664788-v	lit:lemma	įrodyti
 06546261-n	lit:lemma	nuosavybės teisės dokumentas
 10708454-n	lit:lemma	mąstytojas
 01645601-v	lit:lemma	nulemti
 02336449-a	lit:lemma	nepakankamas
 00418394-n	lit:lemma	erzinimas
-01603869-s	lit:lemma	pietvakarinis
+01603869-a	lit:lemma	pietvakarinis
 14685881-n	lit:lemma	dyzeliniai degalai
 07818277-n	lit:lemma	česnakas
 14857497-n	lit:lemma	šiukšlės
 00020090-n	lit:lemma	medžiaga
-01993408-s	lit:lemma	padorus
+01993408-a	lit:lemma	padorus
 00838043-v	lit:lemma	simuliuoti
 05593476-n	lit:lemma	ulna
 00338817-a	lit:lemma	pasitikintis
 05168261-n	lit:lemma	reikšmingumas
-01392633-s	lit:lemma	mažutis
+01392633-a	lit:lemma	mažutis
 10174330-n	lit:lemma	intelektualas
 04644719-n	lit:lemma	užsidegimas
 00394803-n	lit:lemma	išlukštenimas
@@ -9186,31 +9186,31 @@
 00462383-n	lit:lemma	kėgliai
 09213565-n	lit:lemma	skardis
 02960686-a	lit:lemma	olandiškas
-01827946-s	lit:lemma	bejėgis
+01827946-a	lit:lemma	bejėgis
 02267012-a	lit:lemma	išspręstas
 00249164-r	lit:lemma	iš vidaus
-01439072-s	lit:lemma	visos dienos
+01439072-a	lit:lemma	visos dienos
 07170753-n	lit:lemma	aiškinimas
 00079908-n	lit:lemma	terminuotas pardavimas
 06661562-n	lit:lemma	intervencija
 03561345-n	lit:lemma	iliustracija
 02698319-v	lit:lemma	apibrėžti
 08418763-n	lit:lemma	bankas
-02503216-s	lit:lemma	bevertis
+02503216-a	lit:lemma	bevertis
 10753442-n	lit:lemma	kaimietis
 05517578-n	lit:lemma	vezikulė
 13634418-n	lit:lemma	šviesos vienetas
 09545324-n	lit:lemma	siela
 13814336-n	lit:lemma	broliški santykiai
 03744840-n	lit:lemma	atmintinė
-00864461-s	lit:lemma	dirbantis
-02544048-s	lit:lemma	svaigstantis
+00864461-a	lit:lemma	dirbantis
+02544048-a	lit:lemma	svaigstantis
 04610503-n	lit:lemma	gardas
 01848718-v	lit:lemma	nueiti
 03282295-n	lit:lemma	ambasada
 05779568-n	lit:lemma	ideologija
 05084201-n	lit:lemma	tarpas
-02285278-s	lit:lemma	grafinis
+02285278-a	lit:lemma	grafinis
 00387424-n	lit:lemma	pjaustymas
 10709529-n	lit:lemma	metėjas
 07327805-n	lit:lemma	veiksnys
@@ -9222,13 +9222,13 @@
 09480077-n	lit:lemma	tarpas
 00872541-n	lit:lemma	aritmetinis veiksmas
 07142566-n	lit:lemma	konferencija
-00907400-s	lit:lemma	arogantiškas
+00907400-a	lit:lemma	arogantiškas
 00033615-n	lit:lemma	dydis
 00958477-n	lit:lemma	jūrų mūšis
 04811126-n	lit:lemma	nelegalumas
 02654216-a	lit:lemma	avionikos
 04592741-n	lit:lemma	sparnas
-01239410-s	lit:lemma	besidriekiantis
+01239410-a	lit:lemma	besidriekiantis
 03152303-n	lit:lemma	muitinė
 05239808-n	lit:lemma	dengiamasis audinys
 13720096-n	lit:lemma	svaras
@@ -9237,17 +9237,17 @@
 07294423-n	lit:lemma	pelnyta bausmė
 02975994-n	lit:lemma	kazeininiai dažai
 00039021-n	lit:lemma	interakcija
-00904290-s	lit:lemma	pasigėrėtinas
+00904290-a	lit:lemma	pasigėrėtinas
 00005779-r	lit:lemma	žymiai
 13948136-n	lit:lemma	padėtis
 14492373-n	lit:lemma	ištaiga
 08078020-n	lit:lemma	namų ūkis
 06607339-n	lit:lemma	nesąmonė
 00178909-r	lit:lemma	pakankamai
-01212095-s	lit:lemma	didžiausias
+01212095-a	lit:lemma	didžiausias
 13246475-n	lit:lemma	nekilnojamasis turtas
 14752057-n	lit:lemma	gliukokortikoidas
-00808011-s	lit:lemma	blausus
+00808011-a	lit:lemma	blausus
 05199869-n	lit:lemma	veiksmingumas
 01169744-n	lit:lemma	susidūrimas
 01017987-n	lit:lemma	tęsimas
@@ -9259,15 +9259,15 @@
 04776699-n	lit:lemma	nejudamumas
 00037396-n	lit:lemma	veiksmas
 03725968-n	lit:lemma	Masačusetso technologijos institutas
-00926505-s	lit:lemma	neišnaudotas
+00926505-a	lit:lemma	neišnaudotas
 00678923-a	lit:lemma	naktinis
-00733297-s	lit:lemma	trokštamas
+00733297-a	lit:lemma	trokštamas
 02714800-a	lit:lemma	draminis
 06782680-n	lit:lemma	hipotezė
 07317764-n	lit:lemma	nesėkmė
-01612627-s	lit:lemma	paklusnus
+01612627-a	lit:lemma	paklusnus
 09932336-n	lit:lemma	vežikas
-02368566-s	lit:lemma	saldus
+02368566-a	lit:lemma	saldus
 15290337-n	lit:lemma	etapas
 03612814-n	lit:lemma	virdulys
 03073977-n	lit:lemma	piliorius
@@ -9282,12 +9282,12 @@
 02904372-a	lit:lemma	priežiūrinis
 03272562-n	lit:lemma	elektrovežis
 05410315-n	lit:lemma	gonadotropinas
-01539444-s	lit:lemma	kuklus
+01539444-a	lit:lemma	kuklus
 04247440-n	lit:lemma	rūkomasis
 02590340-v	lit:lemma	kolonizuoti
 08377806-n	lit:lemma	hierarchija
 14759722-n	lit:lemma	oda
-00792075-s	lit:lemma	vadovaujamasis
+00792075-a	lit:lemma	vadovaujamasis
 02764779-n	lit:lemma	ašis
 06831712-n	lit:lemma	f
 00145713-r	lit:lemma	gana
@@ -9301,9 +9301,9 @@
 08547655-n	lit:lemma	medžių augimo riba
 04255499-n	lit:lemma	pamatas
 00258904-r	lit:lemma	iki krūtinės
-01729819-s	lit:lemma	ikišiolinis
-02121123-s	lit:lemma	neatsakingas
-00510644-s	lit:lemma	veiksmingas
+01729819-a	lit:lemma	ikišiolinis
+02121123-a	lit:lemma	neatsakingas
+00510644-a	lit:lemma	veiksmingas
 03169390-n	lit:lemma	gražmena
 02131653-n	lit:lemma	meška
 00347180-n	lit:lemma	plakimas
@@ -9313,87 +9313,87 @@
 06624161-n	lit:lemma	laiškas
 00313502-n	lit:lemma	kosminės kelionės
 15140190-n	lit:lemma	atostogos dėl ligos
-01993693-s	lit:lemma	fiksuotas
+01993693-a	lit:lemma	fiksuotas
 00107230-r	lit:lemma	išskirtinai
-00361125-s	lit:lemma	nekaltas
+00361125-a	lit:lemma	nekaltas
 00048374-n	lit:lemma	atvykimas
 13881644-n	lit:lemma	žvaigždė
 10614976-n	lit:lemma	rūkalius
-01572171-s	lit:lemma	dažytas
+01572171-a	lit:lemma	dažytas
 09792237-n	lit:lemma	anatomijos specialistas
-01212095-s	lit:lemma	maksimalus
-00481592-s	lit:lemma	bendramatis
+01212095-a	lit:lemma	maksimalus
+00481592-a	lit:lemma	bendramatis
 01880113-v	lit:lemma	plakti
 00033421-r	lit:lemma	iš karto
-01802774-s	lit:lemma	bjaurus
+01802774-a	lit:lemma	bjaurus
 13347237-n	lit:lemma	gyvybės draudimas
 00120474-r	lit:lemma	nuosekliai
-01562416-s	lit:lemma	artėjantis
+01562416-a	lit:lemma	artėjantis
 09068444-n	lit:lemma	Konektikuto valstija
 01604226-a	lit:lemma	šiaurinis
 13623636-n	lit:lemma	mililitras
 09957156-n	lit:lemma	konservatorius
-01761375-s	lit:lemma	uždraustas
-00710097-s	lit:lemma	nedužus
+01761375-a	lit:lemma	uždraustas
+00710097-a	lit:lemma	nedužus
 02927512-a	lit:lemma	Amerikos
 13400798-n	lit:lemma	mokestis
 03471473-n	lit:lemma	lietvamzdis
 14478684-n	lit:lemma	nuosmūkis
-01903160-s	lit:lemma	atpildo
-01764895-s	lit:lemma	prevencinis
+01903160-a	lit:lemma	atpildo
+01764895-a	lit:lemma	prevencinis
 02251743-v	lit:lemma	mokėti
-02369179-s	lit:lemma	acto
-00324481-s	lit:lemma	motorinis
+02369179-a	lit:lemma	acto
+00324481-a	lit:lemma	motorinis
 03183080-n	lit:lemma	aparatas
 08539717-n	lit:lemma	aglomeracija
 00478262-n	lit:lemma	futbolas
 03259505-n	lit:lemma	namas
 05802185-n	lit:lemma	skaičiavimas
 14499262-n	lit:lemma	netvarka
-01392633-s	lit:lemma	mažas
+01392633-a	lit:lemma	mažas
 08077292-n	lit:lemma	administracinis vienetas
 00594413-a	lit:lemma	nepertraukiamas
 05867413-n	lit:lemma	sekcija
 00285141-n	lit:lemma	somnambulizmas
 00657604-n	lit:lemma	medicinos pagalba
 01628946-a	lit:lemma	puolamasis
-01110470-s	lit:lemma	saugomas autorinės teisės
+01110470-a	lit:lemma	saugomas autorinės teisės
 03259505-n	lit:lemma	gyvenamoji vieta
 13959931-n	lit:lemma	nebūtis
 10450303-n	lit:lemma	politinės partijos narys
-02083908-s	lit:lemma	pedantiškas
+02083908-a	lit:lemma	pedantiškas
 01235137-n	lit:lemma	atsiskaitymas
 00476807-r	lit:lemma	tradiciškai
-00084022-s	lit:lemma	plėšrus
+00084022-a	lit:lemma	plėšrus
 13780719-n	lit:lemma	tarpusavio ryšys
-00709446-s	lit:lemma	trapus
+00709446-a	lit:lemma	trapus
 06111253-n	lit:lemma	harmonija
 01439190-v	lit:lemma	griebti
 00071321-r	lit:lemma	šalia
 01640855-v	lit:lemma	atlikti
 00104990-r	lit:lemma	ramiai
 14077830-n	lit:lemma	maliarija
-02325984-s	lit:lemma	blankus
+02325984-a	lit:lemma	blankus
 08253815-n	lit:lemma	puota
 03165096-n	lit:lemma	tachta
-02562705-s	lit:lemma	siauras
+02562705-a	lit:lemma	siauras
 13931627-n	lit:lemma	narystė
 00522145-n	lit:lemma	parodymas
 00426907-a	lit:lemma	radioaktyvus
 00611433-n	lit:lemma	ugdymas
-01917594-s	lit:lemma	neaiškus
+01917594-a	lit:lemma	neaiškus
 09924742-n	lit:lemma	civilis
 02946348-n	lit:lemma	priekabinis namelis
 05339357-n	lit:lemma	miego arterija
-00515380-s	lit:lemma	visas
+00515380-a	lit:lemma	visas
 00168075-r	lit:lemma	nesėkmingai
 00455599-n	lit:lemma	žaidynės
-02161982-s	lit:lemma	reikšmingas
-00510644-s	lit:lemma	našus
+02161982-a	lit:lemma	reikšmingas
+00510644-a	lit:lemma	našus
 10316013-n	lit:lemma	karo kurstytojas
 00356621-n	lit:lemma	išsekimas
 06607809-n	lit:lemma	beprasmybė
-00708738-s	lit:lemma	trupus
+00708738-a	lit:lemma	trupus
 02986218-a	lit:lemma	logistikos
 14828511-n	lit:lemma	citozinas
 07152259-n	lit:lemma	posakis
@@ -9405,47 +9405,47 @@
 00358931-n	lit:lemma	sutrumpinimas
 04539876-n	lit:lemma	neliekamoji atmintinė
 03273913-n	lit:lemma	šaldytuvas
-00477284-s	lit:lemma	patogus
+00477284-a	lit:lemma	patogus
 07298715-n	lit:lemma	peripetija
 03540595-n	lit:lemma	ligoninė
 08119525-n	lit:lemma	pardavimų skyrius
 14174549-n	lit:lemma	infekcija
-01690606-s	lit:lemma	nusistovėjęs
+01690606-a	lit:lemma	nusistovėjęs
 08081668-n	lit:lemma	religija
 03526198-n	lit:lemma	landa
 09437454-n	lit:lemma	skardis
 01612053-a	lit:lemma	paklusnus
 01413871-a	lit:lemma	neįtikimas
 05128370-n	lit:lemma	paletė
-00837415-s	lit:lemma	reikalaujantis pastangų
+00837415-a	lit:lemma	reikalaujantis pastangų
 10368414-n	lit:lemma	pamišėlis
 00176838-a	lit:lemma	nesėkmingas
-02100968-s	lit:lemma	žemesnis
-01649271-s	lit:lemma	mažamečių
-00792641-s	lit:lemma	svarbiausias
+02100968-a	lit:lemma	žemesnis
+01649271-a	lit:lemma	mažamečių
+00792641-a	lit:lemma	svarbiausias
 07742704-n	lit:lemma	uoga
 06208751-n	lit:lemma	požiūris
 04663319-n	lit:lemma	neatidumas
 05093581-n	lit:lemma	dimensija
 00755745-v	lit:lemma	laukti
-00798103-s	lit:lemma	persigėręs
+00798103-a	lit:lemma	persigėręs
 00176838-a	lit:lemma	nelaimingas
 05762848-n	lit:lemma	prisiminimas
 05867413-n	lit:lemma	padalinys
 03339643-n	lit:lemma	filtras
-00449332-s	lit:lemma	supantis
+00449332-a	lit:lemma	supantis
 03835853-n	lit:lemma	moterų vienuolynas
 00142407-a	lit:lemma	ginkluotas
 01494310-v	lit:lemma	pastatyti
 13659604-n	lit:lemma	hektometras
 10129825-n	lit:lemma	mergaitė
 00823884-n	lit:lemma	vakcinavimas
-01279611-s	lit:lemma	rimtas
+01279611-a	lit:lemma	rimtas
 03287733-n	lit:lemma	motoras
 00348801-n	lit:lemma	šiurpas
 12900987-n	lit:lemma	aitrioji paprika
-00547317-s	lit:lemma	glaustas
-02586446-s	lit:lemma	pavyzdingas
+00547317-a	lit:lemma	glaustas
+02586446-a	lit:lemma	pavyzdingas
 03538179-n	lit:lemma	vagonas arkliams
 00152896-a	lit:lemma	kalbantis
 01418288-a	lit:lemma	įtrauktas į sąrašą
@@ -9459,16 +9459,16 @@
 00230444-r	lit:lemma	palankiai
 02139544-v	lit:lemma	rodyti
 13704529-n	lit:lemma	Mauricijaus piniginis vienetas
-00120784-s	lit:lemma	anoniminis
+00120784-a	lit:lemma	anoniminis
 02665282-v	lit:lemma	priminti
 04635104-n	lit:lemma	aktyvumas
-00197773-s	lit:lemma	paskutinis
+00197773-a	lit:lemma	paskutinis
 10638385-n	lit:lemma	atstovas
-01263445-s	lit:lemma	gyvuliškas
-00989647-s	lit:lemma	ištįsęs
+01263445-a	lit:lemma	gyvuliškas
+00989647-a	lit:lemma	ištįsęs
 03359566-n	lit:lemma	butelis
 00678282-v	lit:lemma	suplanuoti
-01937390-s	lit:lemma	tariamas
+01937390-a	lit:lemma	tariamas
 00021265-n	lit:lemma	maistas
 00975171-a	lit:lemma	elegantiškas
 04060065-n	lit:lemma	užpakalinis langas
@@ -9493,21 +9493,21 @@
 00446980-n	lit:lemma	šaudymas iš lanko
 05926236-n	lit:lemma	išmintis
 00107230-r	lit:lemma	itin
-02332845-s	lit:lemma	tikras
+02332845-a	lit:lemma	tikras
 00377002-v	lit:lemma	degti
 02399000-n	lit:lemma	atrajotojas
 04413631-n	lit:lemma	galinė stotis
 06293106-n	lit:lemma	reikšminis žodis
-01484651-s	lit:lemma	mergaitiškas
+01484651-a	lit:lemma	mergaitiškas
 14493145-n	lit:lemma	skurdas
-02062133-s	lit:lemma	tinkamas parduoti
+02062133-a	lit:lemma	tinkamas parduoti
 13279262-n	lit:lemma	darbo užmokestis
 00752493-v	lit:lemma	prašyti
-00820975-s	lit:lemma	modernus
+00820975-a	lit:lemma	modernus
 07503430-n	lit:lemma	pasišlykštėjimas
-00907400-s	lit:lemma	paniekinantis
+00907400-a	lit:lemma	paniekinantis
 09492123-n	lit:lemma	sritis
-01689442-s	lit:lemma	nuvalkiotas
+01689442-a	lit:lemma	nuvalkiotas
 10513120-n	lit:lemma	redaguotojas
 07570720-n	lit:lemma	maistas
 00041361-a	lit:lemma	aktyvus
@@ -9528,55 +9528,55 @@
 02609764-v	lit:lemma	pasibaigti
 02058794-a	lit:lemma	pavojingas
 00008997-r	lit:lemma	visiškai
-00012071-s	lit:lemma	abstraktus
+00012071-a	lit:lemma	abstraktus
 00246672-r	lit:lemma	raštu
 00820976-v	lit:lemma	liudyti
 09762101-n	lit:lemma	atsakovas
 03429914-n	lit:lemma	marlė
 07429976-n	lit:lemma	įsiveržimas
 13789462-n	lit:lemma	eksponentinė funkcija
-00228645-s	lit:lemma	geriausias
+00228645-a	lit:lemma	geriausias
 00278040-n	lit:lemma	drėkinimas
 08405603-n	lit:lemma	karalystė
 00520214-a	lit:lemma	pilnas
 00376400-n	lit:lemma	sudaužymas
 14757848-n	lit:lemma	kaulinis audinys
-00463399-s	lit:lemma	jūrinis
+00463399-a	lit:lemma	jūrinis
 14431471-n	lit:lemma	karinis laipsnis
 02702807-a	lit:lemma	kosminis
 00507927-r	lit:lemma	drauge
 09926426-n	lit:lemma	klasikas
-02074929-s	lit:lemma	išėjęs iš proto
+02074929-a	lit:lemma	išėjęs iš proto
 05057163-n	lit:lemma	ypač žemas dažnis
-01603518-s	lit:lemma	pietrytinis
+01603518-a	lit:lemma	pietrytinis
 05001482-n	lit:lemma	plonumas
 01789064-n	lit:lemma	vištiniai paukščiai
 09837824-n	lit:lemma	bankininkas
 02435671-a	lit:lemma	nepakenčiamas
 07133701-n	lit:lemma	pokalbis
-00562909-s	lit:lemma	netinkamas
+00562909-a	lit:lemma	netinkamas
 04895773-n	lit:lemma	įtarumas
-00934966-s	lit:lemma	mažo biudžeto
+00934966-a	lit:lemma	mažo biudžeto
 07674617-n	lit:lemma	palmių aliejus
 00070765-r	lit:lemma	be skirtumo
-01274945-s	lit:lemma	sumenkęs
+01274945-a	lit:lemma	sumenkęs
 13969243-n	lit:lemma	harmonija
-02449952-s	lit:lemma	mirtinas
+02449952-a	lit:lemma	mirtinas
 04933544-n	lit:lemma	sudėjimas
 07373602-n	lit:lemma	sujungimas
 00858631-n	lit:lemma	popietės poilsis
-02163602-s	lit:lemma	įsidėmėtinas
+02163602-a	lit:lemma	įsidėmėtinas
 09264803-n	lit:lemma	delta
 15157041-n	lit:lemma	diena
 05805902-n	lit:lemma	supratimas
-01389170-s	lit:lemma	masyvus
+01389170-a	lit:lemma	masyvus
 00542458-n	lit:lemma	hula
 02745172-v	lit:lemma	pridėti
-01536094-s	lit:lemma	modernus
+01536094-a	lit:lemma	modernus
 00852181-n	lit:lemma	kontracepcija
 01064863-n	lit:lemma	neveiklumas
-01253254-s	lit:lemma	šarmotas
-00084795-s	lit:lemma	nuožmus
+01253254-a	lit:lemma	šarmotas
+00084795-a	lit:lemma	nuožmus
 09304465-n	lit:lemma	anga
 08568978-n	lit:lemma	tolimiausias taškas
 07933274-n	lit:lemma	arbata
@@ -9588,7 +9588,7 @@
 00210935-r	lit:lemma	reguliariai
 13669590-n	lit:lemma	Jordanijos dinaras
 03804744-n	lit:lemma	vinis
-02076988-s	lit:lemma	silpnaprotis
+02076988-a	lit:lemma	silpnaprotis
 01637982-v	lit:lemma	atrasti
 09986189-n	lit:lemma	dviratininkas
 08111783-n	lit:lemma	civilizacija
@@ -9597,19 +9597,19 @@
 00058128-r	lit:lemma	tiesiai
 07059255-n	lit:lemma	žanras
 02237338-v	lit:lemma	atsisakyti
-02241988-s	lit:lemma	uolėtas
+02241988-a	lit:lemma	uolėtas
 00776262-n	lit:lemma	papirkinėjimas
 07097346-n	lit:lemma	asonansas
 08929243-n	lit:lemma	Kuveitas
-01755024-s	lit:lemma	begalinis
+01755024-a	lit:lemma	begalinis
 01639765-n	lit:lemma	beuodegis varliagyvis
 03721047-n	lit:lemma	stiklo rutuliukas
-00712877-s	lit:lemma	primygtinis
+00712877-a	lit:lemma	primygtinis
 10077593-n	lit:lemma	entuziastas
 12143676-n	lit:lemma	kukurūzai
 00294868-n	lit:lemma	rėpliojimas
 01239064-n	lit:lemma	dalyvavimas
-02321809-s	lit:lemma	raumeningas
+02321809-a	lit:lemma	raumeningas
 00407215-r	lit:lemma	visos šalies mastu
 02487217-n	lit:lemma	makakos
 05750657-n	lit:lemma	mada
@@ -9620,15 +9620,15 @@
 07456906-n	lit:lemma	imtis
 06776138-n	lit:lemma	sąmojis
 00376063-n	lit:lemma	atmaina
-01405523-s	lit:lemma	neiššifruojamas
+01405523-a	lit:lemma	neiššifruojamas
 03823111-n	lit:lemma	galiukas
 01438304-v	lit:lemma	pristatyti
 11434016-n	lit:lemma	kataklizmas
-00028867-s	lit:lemma	neįvertintas
+00028867-a	lit:lemma	neįvertintas
 01914521-a	lit:lemma	kokybinis
 13716084-n	lit:lemma	britų masės vienetas
 12922933-n	lit:lemma	krotonų aliejus
-01674242-s	lit:lemma	rutiniškas
+01674242-a	lit:lemma	rutiniškas
 02604760-v	lit:lemma	būti
 05018103-n	lit:lemma	skaistumas
 03530910-n	lit:lemma	kapotas
@@ -9640,17 +9640,17 @@
 03959936-n	lit:lemma	plokštė
 02982473-a	lit:lemma	kanadiečių
 06999802-n	lit:lemma	diagrama
-00635244-s	lit:lemma	patobulinamas
+00635244-a	lit:lemma	patobulinamas
 01636859-v	lit:lemma	fantazuoti
 00496673-v	lit:lemma	palikti
-01999085-s	lit:lemma	neatsakingas
+01999085-a	lit:lemma	neatsakingas
 13337322-n	lit:lemma	rinkos kaina
 00996448-a	lit:lemma	blogas
 05025935-n	lit:lemma	atominė masė
 06607809-n	lit:lemma	absurdas
 08512736-n	lit:lemma	skiriamoji linija
 09014586-n	lit:lemma	Moldavija
-02412880-s	lit:lemma	plaukiškas
+02412880-a	lit:lemma	plaukiškas
 09988063-n	lit:lemma	tėtukas
 00006032-a	lit:lemma	santykinis
 01982646-a	lit:lemma	geros reputacijos
@@ -9661,20 +9661,20 @@
 06711855-n	lit:lemma	priekaištavimas
 14478684-n	lit:lemma	nuosmukis
 01517081-a	lit:lemma	karinis
-01638962-s	lit:lemma	senovinis
+01638962-a	lit:lemma	senovinis
 00173761-n	lit:lemma	įrankis
-01165943-s	lit:lemma	gydomasis
+01165943-a	lit:lemma	gydomasis
 02612762-v	lit:lemma	dalyvauti
 04272054-n	lit:lemma	akiniai
 01943406-a	lit:lemma	išmintingas
 03568653-n	lit:lemma	indometacinas
 00085512-r	lit:lemma	specialiai
 14477667-n	lit:lemma	našta
-00951003-s	lit:lemma	išorinis
-02336904-s	lit:lemma	nepakankamas
+00951003-a	lit:lemma	išorinis
+02336904-a	lit:lemma	nepakankamas
 13910384-n	lit:lemma	intervalas
 05565696-n	lit:lemma	delnas
-02029047-s	lit:lemma	dešinys
+02029047-a	lit:lemma	dešinys
 05054130-n	lit:lemma	nepaliaujamumas
 04492264-n	lit:lemma	magistralė
 13353607-n	lit:lemma	kapitalas
@@ -9694,16 +9694,16 @@
 02994872-a	lit:lemma	marmurinis
 10298482-n	lit:lemma	specialistas
 09483738-n	lit:lemma	įsivaizduojama būtybė
-00592880-s	lit:lemma	periodinis
+00592880-a	lit:lemma	periodinis
 00656192-n	lit:lemma	reabilitacija
-01931926-s	lit:lemma	pasirengęs
+01931926-a	lit:lemma	pasirengęs
 00804476-v	lit:lemma	nusileisti
 08401248-n	lit:lemma	šaka
 10676877-n	lit:lemma	vadovas
 04738641-n	lit:lemma	pastovumas
 03098140-n	lit:lemma	valdymo skydelis
-02241988-s	lit:lemma	akmeningas
-02372434-s	lit:lemma	kryžmas
+02241988-a	lit:lemma	akmeningas
+02372434-a	lit:lemma	kryžmas
 00818466-n	lit:lemma	žinia
 14474435-n	lit:lemma	malonė
 09397607-n	lit:lemma	bala
@@ -9721,7 +9721,7 @@
 14442933-n	lit:lemma	valdžia
 00405360-n	lit:lemma	lenkimas
 02577061-a	lit:lemma	žemiškas
-00729439-s	lit:lemma	savarankiškas
+00729439-a	lit:lemma	savarankiškas
 04209509-n	lit:lemma	dušinė
 00372013-n	lit:lemma	susikaupimas
 13994148-n	lit:lemma	nepriklausomybė
@@ -9732,20 +9732,20 @@
 07443210-n	lit:lemma	atpalaidavimas
 02840478-a	lit:lemma	profesinis
 13480848-n	lit:lemma	degimas
-01159907-s	lit:lemma	nežalingas
+01159907-a	lit:lemma	nežalingas
 12593994-n	lit:lemma	datulinis finikas
 00388494-r	lit:lemma	lėtai
 05075602-n	lit:lemma	išdėliojimas
 02704617-v	lit:lemma	pasverti
 02691390-a	lit:lemma	labdaros
 00282050-n	lit:lemma	progresas
-02126430-s	lit:lemma	esantis
+02126430-a	lit:lemma	esantis
 09331251-n	lit:lemma	ežero krantas
-00305700-s	lit:lemma	gūsiuotas
-02344672-s	lit:lemma	puikus
+00305700-a	lit:lemma	gūsiuotas
+02344672-a	lit:lemma	puikus
 00957378-v	lit:lemma	apibrėžti
-00888200-s	lit:lemma	ištroškęs
-01010271-s	lit:lemma	baigiamasis
+00888200-a	lit:lemma	ištroškęs
+01010271-a	lit:lemma	baigiamasis
 11410625-n	lit:lemma	rezultatas
 04150860-n	lit:lemma	albumas
 10044879-n	lit:lemma	vyriausiasis redaktorius
@@ -9771,17 +9771,17 @@
 07557434-n	lit:lemma	patiekalas
 00065575-r	lit:lemma	ilgai
 13717155-n	lit:lemma	svorio vienetas
-01814711-s	lit:lemma	vyriausybės
+01814711-a	lit:lemma	vyriausybės
 09481036-n	lit:lemma	kirmgrauža
 09376526-n	lit:lemma	jūros dugnas
-01681307-s	lit:lemma	paruoštas
+01681307-a	lit:lemma	paruoštas
 04108268-n	lit:lemma	lynas
 14869035-n	lit:lemma	žuvų taukai
 07159791-n	lit:lemma	burtažodis
 01927654-a	lit:lemma	rasinis
 08079613-n	lit:lemma	beisbolo klubas
 09215437-n	lit:lemma	dubuma
-00425313-s	lit:lemma	storžieviškas
+00425313-a	lit:lemma	storžieviškas
 02015571-a	lit:lemma	teikiantis pasitenkinimą
 15237250-n	lit:lemma	vasara
 02904372-a	lit:lemma	priežiūros
@@ -9795,15 +9795,15 @@
 07047679-n	lit:lemma	noktiurnas
 10314836-n	lit:lemma	pribuvėja
 14360459-n	lit:lemma	mėšlungis
-01593079-s	lit:lemma	liaudinis
+01593079-a	lit:lemma	liaudinis
 10112591-n	lit:lemma	bičiulė
 08626283-n	lit:lemma	municipalitetas
 12992868-n	lit:lemma	grybas
 14541044-n	lit:lemma	pavojus
 15039935-n	lit:lemma	silicio rūgštis
 09480077-n	lit:lemma	skylė
-00719442-s	lit:lemma	įnoringas
-01439155-s	lit:lemma	ištęstas
+00719442-a	lit:lemma	įnoringas
+01439155-a	lit:lemma	ištęstas
 00158185-n	lit:lemma	manipuliacija
 00753504-a	lit:lemma	prezidentiškas
 03733925-n	lit:lemma	matavimo prietaisas
@@ -9814,16 +9814,16 @@
 03118790-a	lit:lemma	slavų
 00255214-n	lit:lemma	prausimasis
 15268682-n	lit:lemma	pasibaigęs galiojimo laikas
-00280463-s	lit:lemma	spindintis
+00280463-a	lit:lemma	spindintis
 02759367-a	lit:lemma	motinos
-00324481-s	lit:lemma	varomasis
-01830703-s	lit:lemma	prestižinis
+00324481-a	lit:lemma	varomasis
+01830703-a	lit:lemma	prestižinis
 14066203-n	lit:lemma	jėgų netekimas
-01509367-s	lit:lemma	saikingas
+01509367-a	lit:lemma	saikingas
 00898963-a	lit:lemma	paslaptingas
 05138488-n	lit:lemma	reikšmė
 05552607-n	lit:lemma	krūtinė
-00195383-s	lit:lemma	gąsdinantis
+00195383-a	lit:lemma	gąsdinantis
 11499284-n	lit:lemma	spinduliavimas
 00223983-n	lit:lemma	skerdynės
 05955186-n	lit:lemma	vyraujanti srovė
@@ -9844,24 +9844,24 @@
 04018399-n	lit:lemma	užeiga
 06760722-n	lit:lemma	suktybė
 07003119-n	lit:lemma	piešinys
-01625063-s	lit:lemma	bjaurus
+01625063-a	lit:lemma	bjaurus
 01692786-a	lit:lemma	esantis viduje
 03383099-n	lit:lemma	fokas
 08709399-n	lit:lemma	Kaimanų salos
 10060621-n	lit:lemma	gamtosaugos šalininkas
-01253254-s	lit:lemma	apšerkšnijęs
+01253254-a	lit:lemma	apšerkšnijęs
 09761403-n	lit:lemma	buhalteris
 00302394-n	lit:lemma	skrydis
 04089152-n	lit:lemma	šelmuo
-01420337-s	lit:lemma	poetiškas
+01420337-a	lit:lemma	poetiškas
 14806838-n	lit:lemma	cheminis preparatas
 10388440-n	lit:lemma	viešpats
 03017428-n	lit:lemma	kaminas
 07456188-n	lit:lemma	mačas
-00505410-s	lit:lemma	nepalyginamas
+00505410-a	lit:lemma	nepalyginamas
 00060185-v	lit:lemma	išperėti
 00328230-n	lit:lemma	sugrįžimas
-01513050-s	lit:lemma	stiprus
+01513050-a	lit:lemma	stiprus
 11669335-n	lit:lemma	žiedas (augalo)
 09849598-n	lit:lemma	mielasis
 07018931-n	lit:lemma	vaidinimas
@@ -9877,24 +9877,24 @@
 02734217-n	lit:lemma	garbės vartai
 13985818-n	lit:lemma	ūpas
 05841351-n	lit:lemma	architektūros stilius
-00815000-s	lit:lemma	pirmalaikis
+00815000-a	lit:lemma	pirmalaikis
 00062806-n	lit:lemma	pasiekimas
 14514039-n	lit:lemma	skyrius
-01385663-s	lit:lemma	kosminis
+01385663-a	lit:lemma	kosminis
 09213565-n	lit:lemma	krantas
 02995345-n	lit:lemma	centrinis procesorius
 06065819-n	lit:lemma	žemdirbystė
-01259123-s	lit:lemma	žmogiškas
+01259123-a	lit:lemma	žmogiškas
 00328230-n	lit:lemma	grįžimas
 02555387-a	lit:lemma	turintis vandens
 02057829-a	lit:lemma	saugus
-00051373-s	lit:lemma	tinkamas
-00922051-s	lit:lemma	kerintis
+00051373-a	lit:lemma	tinkamas
+00922051-a	lit:lemma	kerintis
 00346715-r	lit:lemma	apmokamai
 01066881-n	lit:lemma	nukėlimas
 02357479-a	lit:lemma	nustebęs
 00105479-n	lit:lemma	smarkus metimas
-00325995-s	lit:lemma	atsargus
+00325995-a	lit:lemma	atsargus
 00147876-r	lit:lemma	nesunkiai
 01605119-n	lit:lemma	vanaginiai
 00091332-r	lit:lemma	smarkiai
@@ -9918,19 +9918,19 @@
 07503430-n	lit:lemma	pasibjaurėjimas
 01871979-v	lit:lemma	stumti
 06831819-n	lit:lemma	G
-01276482-s	lit:lemma	vyriausias
-01756292-s	lit:lemma	trumpalaikis
-01626562-s	lit:lemma	baisus
+01276482-a	lit:lemma	vyriausias
+01756292-a	lit:lemma	trumpalaikis
+01626562-a	lit:lemma	baisus
 00106921-r	lit:lemma	paprastai
 00914343-n	lit:lemma	gamybos perviršis
 08552138-n	lit:lemma	sritis
-01176973-s	lit:lemma	gangreninis
+01176973-a	lit:lemma	gangreninis
 00050297-r	lit:lemma	linksmai
 03367663-n	lit:lemma	flotilė
 05680982-n	lit:lemma	abejingumas
 03197201-n	lit:lemma	skaitmeninis voltmetras
 00432689-n	lit:lemma	laisvalaikio užsiėmimas
-02291336-s	lit:lemma	stabilus
+02291336-a	lit:lemma	stabilus
 04743024-n	lit:lemma	tapatumas
 00273133-r	lit:lemma	visu greičiu, skubiai
 03128519-n	lit:lemma	kūno pienelis
@@ -9939,30 +9939,30 @@
 09786585-n	lit:lemma	mėgėjas
 14548343-n	lit:lemma	invalidumas
 03848729-n	lit:lemma	langas
-01167540-s	lit:lemma	stiprinamasis
+01167540-a	lit:lemma	stiprinamasis
 14288871-n	lit:lemma	mėlynė
 06832572-n	lit:lemma	N
 02838592-a	lit:lemma	fotografinis
 09686536-n	lit:lemma	europietis
 10391653-n	lit:lemma	dailininkas
-02161982-s	lit:lemma	įsimintinas
+02161982-a	lit:lemma	įsimintinas
 13098186-n	lit:lemma	gysla
 05641556-n	lit:lemma	koordinacija
 13614764-n	lit:lemma	skysčių matas
 03892557-n	lit:lemma	klebonija
 02637938-v	lit:lemma	laukti
-00370869-s	lit:lemma	mėlynas
+00370869-a	lit:lemma	mėlynas
 10411551-n	lit:lemma	keliaujantis prekybininkas
-00522463-s	lit:lemma	išsamus
+00522463-a	lit:lemma	išsamus
 05124057-n	lit:lemma	riba
 00119578-r	lit:lemma	kita vertus
-00432453-s	lit:lemma	tyras
-01122595-s	lit:lemma	nežinomas
+00432453-a	lit:lemma	tyras
+01122595-a	lit:lemma	nežinomas
 13899404-n	lit:lemma	kamuolys
 03528263-n	lit:lemma	buitinė technika
 00064018-n	lit:lemma	laimėjimas
 09976283-n	lit:lemma	pamišėlis
-01105042-s	lit:lemma	būdingas
+01105042-a	lit:lemma	būdingas
 06998748-n	lit:lemma	iliustracijos
 10113753-n	lit:lemma	favoritas
 03279364-n	lit:lemma	elektroninis voltmetras
@@ -9988,44 +9988,44 @@
 14121058-n	lit:lemma	Bazedovo liga
 13771828-n	lit:lemma	lašelis
 07484547-n	lit:lemma	siekimas
-01126841-s	lit:lemma	menkas
-00567860-s	lit:lemma	atskirtas
+01126841-a	lit:lemma	menkas
+00567860-a	lit:lemma	atskirtas
 09614684-n	lit:lemma	sargas
 03813078-n	lit:lemma	nava
 09369169-n	lit:lemma	lizdas
-00487198-s	lit:lemma	visuotinis
+00487198-a	lit:lemma	visuotinis
 04849972-n	lit:lemma	skaistumas
 04665210-n	lit:lemma	neatsargumas
 00513089-n	lit:lemma	žaidimas
-00583842-s	lit:lemma	neišsenkamas
+00583842-a	lit:lemma	neišsenkamas
 15277730-n	lit:lemma	srautas
 02914991-n	lit:lemma	pastatų kompleksas
-00972642-s	lit:lemma	naujoviškas
+00972642-a	lit:lemma	naujoviškas
 09835506-n	lit:lemma	beisbolininkas
 04018155-n	lit:lemma	viešos kalbos transliavimas
-01912858-s	lit:lemma	paprastas
+01912858-a	lit:lemma	paprastas
 04325208-n	lit:lemma	diendaržis
 06797169-n	lit:lemma	simptomas
-01492596-s	lit:lemma	vaikiškas
-00138782-s	lit:lemma	netinkamas
+01492596-a	lit:lemma	vaikiškas
+00138782-a	lit:lemma	netinkamas
 03276179-n	lit:lemma	elektromagnetas
 02906254-n	lit:lemma	bronzos medalis
 10696508-n	lit:lemma	specialistas
-01440159-s	lit:lemma	iki gyvos galvos
+01440159-a	lit:lemma	iki gyvos galvos
 14740915-n	lit:lemma	nesočioji riebalų rūgštis
 06529219-n	lit:lemma	užsakymas
 00385266-n	lit:lemma	atsiskyrimas
 06172789-n	lit:lemma	kalbotyra
-01512275-s	lit:lemma	intensyvus
+01512275-a	lit:lemma	intensyvus
 10794014-n	lit:lemma	rašytojas
-01385773-s	lit:lemma	didžiulis
+01385773-a	lit:lemma	didžiulis
 02504562-v	lit:lemma	spausti
 01644746-v	lit:lemma	realizuoti
 09767197-n	lit:lemma	veikėjas
 02528380-v	lit:lemma	žlugti
 01428580-n	lit:lemma	menkiažuvė
 03307573-n	lit:lemma	išorės degimo variklis
-01740358-s	lit:lemma	šovinistinis
+01740358-a	lit:lemma	šovinistinis
 04830689-n	lit:lemma	nuožmumas
 14883206-n	lit:lemma	kristalas
 04849972-n	lit:lemma	nekaltumas
@@ -10036,16 +10036,16 @@
 07969695-n	lit:lemma	šeima
 00918872-v	lit:lemma	nustatyti
 06623614-n	lit:lemma	korespondencija
-00339742-s	lit:lemma	pasitikintis savimi
+00339742-a	lit:lemma	pasitikintis savimi
 00006024-n	lit:lemma	heterotrofas
 00327683-n	lit:lemma	pažeminimas
 02745611-n	lit:lemma	dirbtinis horizontas
 02940759-a	lit:lemma	šeimyninis
 13669237-n	lit:lemma	Irako piniginis vienetas
-01990653-s	lit:lemma	tvirtas
-01037885-s	lit:lemma	tarptautinis
+01990653-a	lit:lemma	tvirtas
+01037885-a	lit:lemma	tarptautinis
 05794694-n	lit:lemma	pasiruošimas
-01234527-s	lit:lemma	pakrypęs
+01234527-a	lit:lemma	pakrypęs
 05868954-n	lit:lemma	bruožas
 00620424-n	lit:lemma	mėsos prekyba
 00097108-r	lit:lemma	prieš srovę
@@ -10054,21 +10054,21 @@
 00029836-v	lit:lemma	kvatotis
 00203922-r	lit:lemma	teisingai
 01718158-a	lit:lemma	lygiagretus
-01266397-s	lit:lemma	juokingas
+01266397-a	lit:lemma	juokingas
 14052046-n	lit:lemma	ligotumas
 07093158-n	lit:lemma	epinė poezija
 06880533-n	lit:lemma	demonstracija
 02848787-a	lit:lemma	pieno
 05128519-n	lit:lemma	paviršiaus plotas
 09210604-n	lit:lemma	oras
-00585202-s	lit:lemma	kūrybinis
+00585202-a	lit:lemma	kūrybinis
 08721559-n	lit:lemma	Santjagas
 04179271-n	lit:lemma	kanalizacijos vamzdis
 00102736-r	lit:lemma	pirmiausiai
 00071321-r	lit:lemma	netoliese
 01245813-n	lit:lemma	ridenimas
-00337172-s	lit:lemma	įsitikinęs
-00969556-s	lit:lemma	žavus
+00337172-a	lit:lemma	įsitikinęs
+00969556-a	lit:lemma	žavus
 00582388-n	lit:lemma	darbas
 02961505-a	lit:lemma	vengrų
 13709591-n	lit:lemma	Japonijos piniginis vienetas
@@ -10077,11 +10077,11 @@
 14557898-n	lit:lemma	disfunkcija
 09379111-n	lit:lemma	skylė
 11519253-n	lit:lemma	audra
-00135092-s	lit:lemma	deramas
-01706465-s	lit:lemma	nelegalus
-00602117-s	lit:lemma	ginčytinas
+00135092-a	lit:lemma	deramas
+01706465-a	lit:lemma	nelegalus
+00602117-a	lit:lemma	ginčytinas
 13250398-n	lit:lemma	turtas
-00683531-s	lit:lemma	vulgarus
+00683531-a	lit:lemma	vulgarus
 00205375-r	lit:lemma	teisingai
 00353100-n	lit:lemma	mokesčių mažinimas
 04831031-n	lit:lemma	žiaurumas
@@ -10098,27 +10098,27 @@
 03118969-n	lit:lemma	užmiesčio namas
 08986905-n	lit:lemma	Kataras
 13998014-n	lit:lemma	vergija
-02248693-s	lit:lemma	kultūrinis
+02248693-a	lit:lemma	kultūrinis
 04225729-n	lit:lemma	riedutis
-00032733-s	lit:lemma	žvitrus
+00032733-a	lit:lemma	žvitrus
 03871628-n	lit:lemma	paketas
 04373894-n	lit:lemma	kardas
 03449858-n	lit:lemma	valdžios pareigūnai
 02748635-a	lit:lemma	gamybinis
-00922840-s	lit:lemma	įprastas
+00922840-a	lit:lemma	įprastas
 02950256-n	lit:lemma	pabūklas
 01927455-a	lit:lemma	intelektualus
 00099712-r	lit:lemma	daugiau
 02899666-a	lit:lemma	kunigiškas
 02945161-n	lit:lemma	stovykla
-02291336-s	lit:lemma	pastovus
+02291336-a	lit:lemma	pastovus
 07670731-n	lit:lemma	žievė
 10453533-n	lit:lemma	popiežius
-01284212-s	lit:lemma	ryškus
+01284212-a	lit:lemma	ryškus
 00687926-v	lit:lemma	įtarti
 14481929-n	lit:lemma	galimumas
 02609764-v	lit:lemma	baigtis
-01533974-s	lit:lemma	per didelis
+01533974-a	lit:lemma	per didelis
 00020476-r	lit:lemma	visada
 09798811-n	lit:lemma	apaštalas
 04218142-n	lit:lemma	antspaudas
@@ -10132,15 +10132,15 @@
 09972157-n	lit:lemma	mados kūrėjas
 15245515-n	lit:lemma	laikas
 02817031-n	lit:lemma	guolis
-01874331-s	lit:lemma	diletantiškas
+01874331-a	lit:lemma	diletantiškas
 07412092-n	lit:lemma	žybsnis
-01742912-s	lit:lemma	smarkus
+01742912-a	lit:lemma	smarkus
 01606648-a	lit:lemma	pietietiškas
 00023271-n	lit:lemma	išmanymas
 12144117-n	lit:lemma	javas
 14173484-n	lit:lemma	gerklės uždegimas
-01517526-s	lit:lemma	karinis
-01144102-s	lit:lemma	staigus
+01517526-a	lit:lemma	karinis
+01144102-a	lit:lemma	staigus
 09890749-n	lit:lemma	kandidatas
 13371030-n	lit:lemma	brangenybė
 03051540-n	lit:lemma	drabužis
@@ -10158,7 +10158,7 @@
 13662190-n	lit:lemma	frankas
 09344863-n	lit:lemma	Makenzis
 07969695-n	lit:lemma	giminė
-01280908-s	lit:lemma	smulkus
+01280908-a	lit:lemma	smulkus
 03100315-a	lit:lemma	žvejybinis
 03453696-n	lit:lemma	kompiuterinė grafika
 03545150-n	lit:lemma	būstinė
@@ -10169,7 +10169,7 @@
 06364641-n	lit:lemma	literatūra
 10090020-n	lit:lemma	bankininkas
 02763901-n	lit:lemma	pavėsinė
-00746451-s	lit:lemma	sudėtingas
+00746451-a	lit:lemma	sudėtingas
 00994623-n	lit:lemma	kanonada
 04351550-n	lit:lemma	apartamentai
 00114029-r	lit:lemma	mašinaliai
@@ -10179,22 +10179,22 @@
 00230058-r	lit:lemma	išoriškai
 00103859-r	lit:lemma	vėliau
 02899112-a	lit:lemma	faktinis
-02512641-s	lit:lemma	chuliganiškas
+02512641-a	lit:lemma	chuliganiškas
 08078020-n	lit:lemma	šeimyna
 12353203-n	lit:lemma	valgomasis bananas
-01762257-s	lit:lemma	leidžiamas
+01762257-a	lit:lemma	leidžiamas
 03336459-n	lit:lemma	figūrėlė
 01018630-n	lit:lemma	pakartojimas
 00163233-n	lit:lemma	ketinimas
 01717851-v	lit:lemma	debiutuoti
 00045123-a	lit:lemma	chroniškas
 04105893-n	lit:lemma	kambarys
-01533974-s	lit:lemma	perdėtas
+01533974-a	lit:lemma	perdėtas
 07578093-n	lit:lemma	banketas
 15247110-n	lit:lemma	momentas
-00704360-s	lit:lemma	apleistas
+00704360-a	lit:lemma	apleistas
 00019448-v	lit:lemma	paveikti
-01649031-s	lit:lemma	mažas
+01649031-a	lit:lemma	mažas
 01177033-n	lit:lemma	protestas
 02001428-n	lit:lemma	gandriniai paukščiai
 03109881-n	lit:lemma	kertė
@@ -10203,40 +10203,40 @@
 14709265-n	lit:lemma	etilo alkoholis
 15098161-n	lit:lemma	mediena
 07340094-n	lit:lemma	žuvusysis
-01892506-s	lit:lemma	išdidus
+01892506-a	lit:lemma	išdidus
 15247110-n	lit:lemma	sekundė
-00377702-s	lit:lemma	kaštoninis
+00377702-a	lit:lemma	kaštoninis
 14322699-n	lit:lemma	skausmas
 09612848-n	lit:lemma	vartotojas
-02097480-s	lit:lemma	žavus
+02097480-a	lit:lemma	žavus
 10292052-n	lit:lemma	turtuolis
 00010241-v	lit:lemma	daryti
 07731952-n	lit:lemma	kukurūzai
 01557120-a	lit:lemma	daugiausiai
-01154030-s	lit:lemma	purus
+01154030-a	lit:lemma	purus
 07069948-n	lit:lemma	išraiška
-02506922-s	lit:lemma	įvairiapusis
+02506922-a	lit:lemma	įvairiapusis
 14526182-n	lit:lemma	atmosfera
 02968473-n	lit:lemma	vežimas
-02112108-s	lit:lemma	bendras
+02112108-a	lit:lemma	bendras
 07959016-n	lit:lemma	visuma
 08271801-n	lit:lemma	legionas
-02544048-s	lit:lemma	svaiginamas
+02544048-a	lit:lemma	svaiginamas
 03892557-n	lit:lemma	vikariatas
 15022171-n	lit:lemma	globulinas
 13903738-n	lit:lemma	kraštas
 09945603-n	lit:lemma	komunistas
-01131454-s	lit:lemma	žiaurus
+01131454-a	lit:lemma	žiaurus
 13712120-n	lit:lemma	absoliutus baras
-01722140-s	lit:lemma	pateisinamas
+01722140-a	lit:lemma	pateisinamas
 09005153-n	lit:lemma	Kaluga
-01254165-s	lit:lemma	ledinis
+01254165-a	lit:lemma	ledinis
 00061203-r	lit:lemma	po to
 10034201-n	lit:lemma	alkoholikas
 05999266-n	lit:lemma	šaka (mokslo)
 02801938-n	lit:lemma	kraitė
 04777852-n	lit:lemma	tvirtumas
-00264178-s	lit:lemma	narsus
+00264178-a	lit:lemma	narsus
 03674270-n	lit:lemma	saitas
 00426005-r	lit:lemma	triūsliai
 06611147-n	lit:lemma	nesąmonė
@@ -10246,13 +10246,13 @@
 05808557-n	lit:lemma	kalba
 00006105-r	lit:lemma	svarbiausiai
 01176431-n	lit:lemma	peštynės
-02090228-s	lit:lemma	slepiamas
+02090228-a	lit:lemma	slepiamas
 06069747-n	lit:lemma	mikologija
-00848466-s	lit:lemma	būtinas
+00848466-a	lit:lemma	būtinas
 00662527-n	lit:lemma	korekcija
 06640016-n	lit:lemma	kūno masės rodiklis
 00137709-n	lit:lemma	kampinis
-01062393-s	lit:lemma	autonominis
+01062393-a	lit:lemma	autonominis
 00958896-n	lit:lemma	kova
 00781480-n	lit:lemma	vagiliavimas parduotuvėse
 05641720-n	lit:lemma	koordinacijos stoka
@@ -10263,12 +10263,12 @@
 00628491-v	lit:lemma	svarstyti
 00314835-r	lit:lemma	nuoširdžiai
 05578251-n	lit:lemma	lygusis sąnarys
-02038126-s	lit:lemma	raumeningas
+02038126-a	lit:lemma	raumeningas
 01020356-v	lit:lemma	pasižymėti
 00062330-r	lit:lemma	tyčia
 10106080-n	lit:lemma	globotinis
-00090219-s	lit:lemma	šiurkštus
-00224515-s	lit:lemma	bloga linkintis
+00090219-a	lit:lemma	šiurkštus
+00224515-a	lit:lemma	bloga linkintis
 04295881-n	lit:lemma	stadionas
 14841267-n	lit:lemma	oras
 10122645-n	lit:lemma	homoseksualistas
@@ -10285,7 +10285,7 @@
 00196203-r	lit:lemma	prideramai
 10439851-n	lit:lemma	žaidėjas
 11877860-n	lit:lemma	sėtinys
-01752953-s	lit:lemma	klaidingas
+01752953-a	lit:lemma	klaidingas
 00739340-v	lit:lemma	sugalvoti
 01206218-v	lit:lemma	paliesti
 00258854-n	lit:lemma	taisymas
@@ -10293,17 +10293,17 @@
 00235435-n	lit:lemma	pradžia
 01867295-a	lit:lemma	produktyvus
 07454452-n	lit:lemma	ceremonijos
-01569166-s	lit:lemma	tarptautinis
+01569166-a	lit:lemma	tarptautinis
 06471345-n	lit:lemma	liudijimas
 00251820-r	lit:lemma	de jure
-02573708-s	lit:lemma	apaugęs krūmais
+02573708-a	lit:lemma	apaugęs krūmais
 03953416-n	lit:lemma	šventykla
 13721529-n	lit:lemma	mažoji tona
 05622723-n	lit:lemma	instinktas
 00173761-n	lit:lemma	priemonė
 02164694-v	lit:lemma	žavėtis
 00043765-a	lit:lemma	esantis
-01856419-s	lit:lemma	pagrindinis
+01856419-a	lit:lemma	pagrindinis
 01852174-a	lit:lemma	pagrindinis
 07007945-n	lit:lemma	dramos kūrinys
 10371450-n	lit:lemma	valdininkas
@@ -10319,7 +10319,7 @@
 00930290-a	lit:lemma	netikėtas
 02802976-a	lit:lemma	žvaigždinis
 01849288-a	lit:lemma	pretenzingas
-01518860-s	lit:lemma	karinis
+01518860-a	lit:lemma	karinis
 13977184-n	lit:lemma	chuliganiškumas
 00671351-n	lit:lemma	operacija
 05772356-n	lit:lemma	samprotavimas
@@ -10352,25 +10352,25 @@
 09864891-n	lit:lemma	vergas
 00512843-n	lit:lemma	paikystė
 00608808-v	lit:lemma	galvoti
-00661640-s	lit:lemma	smulkintas
-00135092-s	lit:lemma	tinkamas
+00661640-a	lit:lemma	smulkintas
+00135092-a	lit:lemma	tinkamas
 05929008-n	lit:lemma	vaidmuo
 04565233-n	lit:lemma	šalikelė
 06539770-n	lit:lemma	įsakas
 08613593-n	lit:lemma	išorė
 09371360-n	lit:lemma	Nilas
-00065064-s	lit:lemma	pliusinis
+00065064-a	lit:lemma	pliusinis
 02853449-n	lit:lemma	užsikimšimas
 13767350-n	lit:lemma	sauja
 00033020-n	lit:lemma	informacija
 11443721-n	lit:lemma	ciklonas
-00481592-s	lit:lemma	sulyginamas
+00481592-a	lit:lemma	sulyginamas
 06710546-n	lit:lemma	kritika
 00167816-r	lit:lemma	laiku
 04351550-n	lit:lemma	liukso kambariai
 05924920-n	lit:lemma	etalonas
 03833564-n	lit:lemma	purkštukas
-01619475-s	lit:lemma	elementarus
+01619475-a	lit:lemma	elementarus
 02504562-v	lit:lemma	priversti
 00860611-a	lit:lemma	teorinis
 13981137-n	lit:lemma	konfliktas
@@ -10389,14 +10389,14 @@
 00976531-n	lit:lemma	invazija
 08699654-n	lit:lemma	Namibijos Respublika
 03322099-n	lit:lemma	ferma
-02456157-s	lit:lemma	nervingas
+02456157-a	lit:lemma	nervingas
 06832572-n	lit:lemma	n
 04210390-n	lit:lemma	šventovė
 00297403-a	lit:lemma	kapitalistiškas
 15291498-n	lit:lemma	kadencija
-00279092-s	lit:lemma	švytintis
-01780343-s	lit:lemma	intelektinis
-01840880-s	lit:lemma	kvailas
+00279092-a	lit:lemma	švytintis
+01780343-a	lit:lemma	intelektinis
+01840880-a	lit:lemma	kvailas
 14462666-n	lit:lemma	netobulumas
 02743050-n	lit:lemma	strėlės smaigalys
 09772029-n	lit:lemma	paauglys
@@ -10408,7 +10408,7 @@
 00100044-v	lit:lemma	treniruoti
 00686447-v	lit:lemma	priimti
 06100555-n	lit:lemma	branduolinė fizika
-02401288-s	lit:lemma	neapmokestintas
+02401288-a	lit:lemma	neapmokestintas
 03992703-n	lit:lemma	molio dirbiniai
 08439694-n	lit:lemma	krūmai
 09503282-n	lit:lemma	ragana
@@ -10417,7 +10417,7 @@
 02528380-v	lit:lemma	nepavykti
 00331655-n	lit:lemma	postūmis
 02348405-n	lit:lemma	maišiaskruosčiai šokliniai
-01762065-s	lit:lemma	įleistinas
+01762065-a	lit:lemma	įleistinas
 01234345-n	lit:lemma	nebuvimas
 00015806-v	lit:lemma	ilgai miegoti
 10189776-n	lit:lemma	šeimininkė
@@ -10428,11 +10428,11 @@
 04228054-n	lit:lemma	slidė
 13869547-n	lit:lemma	vąšas
 12645754-n	lit:lemma	migdolų aliejus
-00228025-s	lit:lemma	pergalingas
+00228025-a	lit:lemma	pergalingas
 09608709-n	lit:lemma	geradarys
 15119536-n	lit:lemma	dabartis
 02910506-a	lit:lemma	astrologinis
-01249137-s	lit:lemma	įkaistantis
+01249137-a	lit:lemma	įkaistantis
 08699654-n	lit:lemma	Namibija
 04602762-n	lit:lemma	dirbtuvė
 13477023-n	lit:lemma	evoliucija
@@ -10446,7 +10446,7 @@
 05577741-n	lit:lemma	kojos nykštys
 04485423-n	lit:lemma	triptikas
 08225090-n	lit:lemma	kaimynystė
-01263971-s	lit:lemma	nežmoniškas
+01263971-a	lit:lemma	nežmoniškas
 00095502-n	lit:lemma	išvadavimas
 09623038-n	lit:lemma	lyderis
 10569411-n	lit:lemma	slaptasis agentas
@@ -10468,7 +10468,7 @@
 00401639-n	lit:lemma	atjauninimas
 02843717-a	lit:lemma	kardialinis
 00805376-v	lit:lemma	susitarti
-00533452-s	lit:lemma	suprantamas
+00533452-a	lit:lemma	suprantamas
 00059171-r	lit:lemma	daug
 01022064-a	lit:lemma	liaunas
 13129165-n	lit:lemma	stiebas
@@ -10478,11 +10478,11 @@
 04010205-n	lit:lemma	pasivaikščiojimo takas
 02376277-a	lit:lemma	malonus
 00016756-a	lit:lemma	nepakankamas
-01629681-s	lit:lemma	invazinis
-00531087-s	lit:lemma	ramus
+01629681-a	lit:lemma	invazinis
+00531087-a	lit:lemma	ramus
 02968325-a	lit:lemma	europinis
 00013793-r	lit:lemma	naudingai
-02218314-s	lit:lemma	daugeriopas
+02218314-a	lit:lemma	daugeriopas
 04468847-n	lit:lemma	kasyklose naudojamas vežimėlis
 06904171-n	lit:lemma	natūrali kalba
 02677861-a	lit:lemma	iltinis
@@ -10492,51 +10492,51 @@
 07911371-n	lit:lemma	kokteilis
 03427296-n	lit:lemma	vartai
 15212739-n	lit:lemma	rugsėjis
-00028471-s	lit:lemma	menamas
+00028471-a	lit:lemma	menamas
 02494923-a	lit:lemma	naudojamas
-00363031-s	lit:lemma	linksmas
+00363031-a	lit:lemma	linksmas
 13681661-n	lit:lemma	krona
 07248320-n	lit:lemma	knygos aplankas
 08651832-n	lit:lemma	lūšnynas
-01126841-s	lit:lemma	apverktinas
+01126841-a	lit:lemma	apverktinas
 03308297-n	lit:lemma	ąselė
-00746451-s	lit:lemma	komplikuotas
-00071242-s	lit:lemma	užlietas
+00746451-a	lit:lemma	komplikuotas
+00071242-a	lit:lemma	užlietas
 00631737-v	lit:lemma	manyti
 05134547-n	lit:lemma	gilumas
 13954253-n	lit:lemma	gyvenimas
 02768864-n	lit:lemma	atpakalys
 06224136-n	lit:lemma	monoteizmas
-02328012-s	lit:lemma	nesukalbamas
+02328012-a	lit:lemma	nesukalbamas
 00124702-r	lit:lemma	rankiniu būdu
 01286569-n	lit:lemma	Maratono mūšis
-01514141-s	lit:lemma	intensyvus
+01514141-a	lit:lemma	intensyvus
 05013809-n	lit:lemma	pliūpsnio temperatūra
 13624873-n	lit:lemma	kubinis metras
 02444147-a	lit:lemma	poliarinis
 04645943-n	lit:lemma	abejojimas
-01155968-s	lit:lemma	tvirtas
+01155968-a	lit:lemma	tvirtas
 10150556-n	lit:lemma	partizanas
 00242808-n	lit:lemma	sužadinimas
 03055374-a	lit:lemma	klimatinis
 02703911-a	lit:lemma	belaidis
 00265119-n	lit:lemma	atnaujinimas
 02230990-a	lit:lemma	rupus
-02090567-s	lit:lemma	žymus
+02090567-a	lit:lemma	žymus
 13990064-n	lit:lemma	tyrumas
 06392001-n	lit:lemma	pastraipa
 02615804-a	lit:lemma	aklas
 13723577-n	lit:lemma	karatas
 02549581-v	lit:lemma	rūpintis
-00901060-s	lit:lemma	pirminis
+00901060-a	lit:lemma	pirminis
 02547317-a	lit:lemma	šlapias
 03592773-n	lit:lemma	rėmas
-00978199-s	lit:lemma	skubus
+00978199-a	lit:lemma	skubus
 08751494-n	lit:lemma	Haičio Respublika
-01270486-s	lit:lemma	skubus
-01878870-s	lit:lemma	padorus
+01270486-a	lit:lemma	skubus
+01878870-a	lit:lemma	padorus
 14699752-n	lit:lemma	brangakmenis
-02542148-s	lit:lemma	kamuojamas
+02542148-a	lit:lemma	kamuojamas
 00057257-r	lit:lemma	išsamiai
 01636397-v	lit:lemma	įsivaizduoti
 07587023-n	lit:lemma	tiršta sriuba
@@ -10544,10 +10544,10 @@
 03570372-n	lit:lemma	infrastruktūra
 10412055-n	lit:lemma	pėsčiasis
 00075442-r	lit:lemma	į priekį
-01149358-s	lit:lemma	besijuokiantis
+01149358-a	lit:lemma	besijuokiantis
 06212839-n	lit:lemma	politinės pažiūros
 14759003-n	lit:lemma	avino oda
-01564881-s	lit:lemma	sustingęs
+01564881-a	lit:lemma	sustingęs
 08497294-n	lit:lemma	kraštas
 05689249-n	lit:lemma	kliuvinys
 04255499-n	lit:lemma	cokolis
@@ -10559,17 +10559,17 @@
 02971469-a	lit:lemma	egiptiečių
 00151040-r	lit:lemma	taip sau
 13369074-n	lit:lemma	degalų kiekis
-00122844-s	lit:lemma	išplaukiantis
+00122844-a	lit:lemma	išplaukiantis
 05099796-n	lit:lemma	stiprumas
 01817500-a	lit:lemma	geras
 02826877-a	lit:lemma	elektrinis
 10201366-n	lit:lemma	importuotojas
-00048858-s	lit:lemma	pridėtinis
+00048858-a	lit:lemma	pridėtinis
 02801184-n	lit:lemma	bazilika
 00393161-n	lit:lemma	kūlimas
-02144436-s	lit:lemma	plastiškas
+02144436-a	lit:lemma	plastiškas
 09129442-n	lit:lemma	Šiaurės Dakota
-02070342-s	lit:lemma	atskiras
+02070342-a	lit:lemma	atskiras
 00697365-n	lit:lemma	injekcija
 04038727-n	lit:lemma	laikiklis
 00138611-r	lit:lemma	turbūt
@@ -10577,7 +10577,7 @@
 14946424-n	lit:lemma	maleino rūgštis
 14034177-n	lit:lemma	fizinė būklė
 00229568-r	lit:lemma	ramiai
-01143006-s	lit:lemma	palaipsniui
+01143006-a	lit:lemma	palaipsniui
 00077950-v	lit:lemma	smaugti
 05770926-n	lit:lemma	mąstymo procesas
 09886220-n	lit:lemma	šunsnukis
@@ -10587,14 +10587,14 @@
 15247110-n	lit:lemma	akimirka
 08406486-n	lit:lemma	fondas
 14420464-n	lit:lemma	kohezija
-00304144-s	lit:lemma	šėlstantis
+00304144-a	lit:lemma	šėlstantis
 00065070-v	lit:lemma	kentėti
-02448324-s	lit:lemma	jautrus
+02448324-a	lit:lemma	jautrus
 05119714-n	lit:lemma	perteklius
-00930765-s	lit:lemma	nelauktas
-00195684-s	lit:lemma	kraupus
+00930765-a	lit:lemma	nelauktas
+00195684-a	lit:lemma	kraupus
 01091556-a	lit:lemma	veikiantis
-01789481-s	lit:lemma	keršas
+01789481-a	lit:lemma	keršas
 03313333-n	lit:lemma	fasadas
 00625119-v	lit:lemma	perskaityti
 02232190-v	lit:lemma	perkelti
@@ -10604,30 +10604,30 @@
 03122748-n	lit:lemma	apdangalas
 05868477-n	lit:lemma	pabaiga
 09605289-n	lit:lemma	suaugėlis
-00666960-s	lit:lemma	cirkuliuojantis
+00666960-a	lit:lemma	cirkuliuojantis
 00069901-r	lit:lemma	garsiai
 01684426-a	lit:lemma	orientacinis
 00605516-a	lit:lemma	įprastas
 11419404-n	lit:lemma	fizinis fenomenas
 02492198-v	lit:lemma	linksminti
-01930004-s	lit:lemma	inertinis
+01930004-a	lit:lemma	inertinis
 13696893-n	lit:lemma	Irano dinaras
 06642138-n	lit:lemma	naujiena
-02177584-s	lit:lemma	sudėtingas
+02177584-a	lit:lemma	sudėtingas
 03118790-a	lit:lemma	slaviškas
 00758795-n	lit:lemma	vangumas
 04223580-n	lit:lemma	praustuvė
-01673946-s	lit:lemma	eilinis
+01673946-a	lit:lemma	eilinis
 04849759-n	lit:lemma	skaistumas
 02472987-n	lit:lemma	žmonės
 09026614-n	lit:lemma	Malaga
 14066203-n	lit:lemma	išsekimas
 00180756-r	lit:lemma	atskirai
-01945350-s	lit:lemma	neteisėtas
+01945350-a	lit:lemma	neteisėtas
 00138611-r	lit:lemma	matyt
 10093818-n	lit:lemma	žuvų pardavėja
 11446067-n	lit:lemma	klodas
-00997036-s	lit:lemma	neigiamas
+00997036-a	lit:lemma	neigiamas
 05303402-n	lit:lemma	kūno ertmė
 07143624-n	lit:lemma	audiencija
 00876989-a	lit:lemma	tinkamas eksportui
@@ -10648,25 +10648,25 @@
 15032376-n	lit:lemma	nuodai
 08168978-n	lit:lemma	valstybė
 00385649-n	lit:lemma	atsiejimas
-00936523-s	lit:lemma	patyręs
+00936523-a	lit:lemma	patyręs
 00432689-n	lit:lemma	pomėgis
 08292756-n	lit:lemma	flotilė
 00413239-n	lit:lemma	įprotis
-02418412-s	lit:lemma	tikėtinas
+02418412-a	lit:lemma	tikėtinas
 13461162-n	lit:lemma	paklausa
 03601840-n	lit:lemma	sija
 03738472-n	lit:lemma	įrenginys
 01028082-n	lit:lemma	religinė ceremonija
 00289860-r	lit:lemma	glaustai
-01238914-s	lit:lemma	miegantis
+01238914-a	lit:lemma	miegantis
 00213875-r	lit:lemma	vaisingai
 02540347-v	lit:lemma	užaugti
-01729566-s	lit:lemma	ankstesnis
+01729566-a	lit:lemma	ankstesnis
 08566028-n	lit:lemma	galas
 02659763-v	lit:lemma	tikti
 03249342-n	lit:lemma	vaistinė
 00816481-a	lit:lemma	vėlyvas
-01035559-s	lit:lemma	kitatautis
+01035559-a	lit:lemma	kitatautis
 08233056-n	lit:lemma	profesinė sąjunga
 15255195-n	lit:lemma	ledynmetis
 13998576-n	lit:lemma	įkalinimas
@@ -10680,7 +10680,7 @@
 00403783-n	lit:lemma	sužeidimas
 00024720-n	lit:lemma	būvis
 07151380-n	lit:lemma	posakis
-00304949-s	lit:lemma	smarkus
+00304949-a	lit:lemma	smarkus
 01632537-a	lit:lemma	oficialus
 00147091-n	lit:lemma	minia
 08246613-n	lit:lemma	muzikos grupė
@@ -10688,14 +10688,14 @@
 00999245-n	lit:lemma	kalibravimas
 10183757-n	lit:lemma	solenizantas
 06831284-n	lit:lemma	b
-00097768-s	lit:lemma	miręs
+00097768-a	lit:lemma	miręs
 10169796-n	lit:lemma	šturmanas
 06316048-n	lit:lemma	frazė
-02465350-s	lit:lemma	kreditingas
+02465350-a	lit:lemma	kreditingas
 09288769-n	lit:lemma	žvaigždė milžinė
 04555897-n	lit:lemma	laikrodis
-01167269-s	lit:lemma	profilaktinis
-02408977-s	lit:lemma	sritinis
+01167269-a	lit:lemma	profilaktinis
+02408977-a	lit:lemma	sritinis
 02968074-n	lit:lemma	pastogė automobiliui
 06615561-n	lit:lemma	atrakcionas
 13252168-n	lit:lemma	dvaras
@@ -10704,16 +10704,16 @@
 05470189-n	lit:lemma	atauga
 03274435-n	lit:lemma	elektrinė rašomoji mašinėlė
 00681429-v	lit:lemma	nuspręsti
-01037022-s	lit:lemma	senbuvis
+01037022-a	lit:lemma	senbuvis
 01672607-a	lit:lemma	paprastas
 04033287-n	lit:lemma	valdovė
-00989647-s	lit:lemma	išstypęs
+00989647-a	lit:lemma	išstypęs
 08734044-n	lit:lemma	Kongas
 02432983-n	lit:lemma	briedis
 00288970-n	lit:lemma	žygis
 05203397-n	lit:lemma	kompetencija
-02070342-s	lit:lemma	kitas
-00758800-s	lit:lemma	taktiškas
+02070342-a	lit:lemma	kitas
+00758800-a	lit:lemma	taktiškas
 10042845-n	lit:lemma	ekscentrikas
 02765924-v	lit:lemma	blizgėti
 06120769-n	lit:lemma	magnetizmas
@@ -10723,47 +10723,47 @@
 06696483-n	lit:lemma	pagyrimas
 14759003-n	lit:lemma	ėriuko oda
 08646902-n	lit:lemma	kraštovaizdis
-02395810-s	lit:lemma	rūgštus
+02395810-a	lit:lemma	rūgštus
 00227969-n	lit:lemma	aukojimas
 09678009-n	lit:lemma	krikščionis
 02015598-v	lit:lemma	išeiti
-00341655-s	lit:lemma	nepastovus
+00341655-a	lit:lemma	nepastovus
 00182316-r	lit:lemma	puikiai
 01348258-a	lit:lemma	vidinis
 08307589-n	lit:lemma	susirinkimas
 09225146-n	lit:lemma	vandenys
 06780069-n	lit:lemma	karikatūra
-00412788-s	lit:lemma	pirmykštis
+00412788-a	lit:lemma	pirmykštis
 04556204-n	lit:lemma	laikrodžio apyrankė
 00838043-v	lit:lemma	dėtis
 05985602-n	lit:lemma	tautosaka
 07258332-n	lit:lemma	gairė
-00158864-s	lit:lemma	pridėtas
-01499269-s	lit:lemma	neišmatuojamas
+00158864-a	lit:lemma	pridėtas
+01499269-a	lit:lemma	neišmatuojamas
 00189401-r	lit:lemma	vieną dieną
 00233335-v	lit:lemma	apriboti
-02526124-s	lit:lemma	nepalaužiamas
+02526124-a	lit:lemma	nepalaužiamas
 15140405-n	lit:lemma	gyvavimo laikas
 01805889-a	lit:lemma	gižus
-01179241-s	lit:lemma	dieviškas
+01179241-a	lit:lemma	dieviškas
 08187033-n	lit:lemma	artistų kolektyvas
 02888968-a	lit:lemma	operacinis
-01525320-s	lit:lemma	tvirtas
-02476338-s	lit:lemma	sutinkantis
-00837977-s	lit:lemma	sunkus
+01525320-a	lit:lemma	tvirtas
+02476338-a	lit:lemma	sutinkantis
+00837977-a	lit:lemma	sunkus
 02684971-a	lit:lemma	dieviškas
 05517578-n	lit:lemma	pūslelė
 10370381-n	lit:lemma	okultizmo šalininkas
 03472232-n	lit:lemma	gimnastikos įrankis
-00051373-s	lit:lemma	adekvatus
+00051373-a	lit:lemma	adekvatus
 03457184-n	lit:lemma	didysis valstybės antspaudas
-00567860-s	lit:lemma	nuošalus
+00567860-a	lit:lemma	nuošalus
 05132221-n	lit:lemma	vandens lygis
 15278281-n	lit:lemma	dažnis
 00308370-n	lit:lemma	kelionė
 00165906-r	lit:lemma	tuoj pat
 00036762-n	lit:lemma	žygdarbis
-01011753-s	lit:lemma	įvadinis
+01011753-a	lit:lemma	įvadinis
 01202184-n	lit:lemma	segregacija
 05301752-n	lit:lemma	antgerklis
 07997703-n	lit:lemma	kategorija
@@ -10780,13 +10780,13 @@
 01823092-a	lit:lemma	nerealus
 00008055-v	lit:lemma	mirkčioti
 09785992-n	lit:lemma	antrasis aš
-02269142-s	lit:lemma	nulinis
+02269142-a	lit:lemma	nulinis
 00988232-a	lit:lemma	plonas
 00958712-a	lit:lemma	neteisingas
 05849284-n	lit:lemma	skiriamasis bruožas
 04948241-n	lit:lemma	šiurkštumas
-00413861-s	lit:lemma	antikinis
-01674242-s	lit:lemma	įprastas
+00413861-a	lit:lemma	antikinis
+01674242-a	lit:lemma	įprastas
 08308313-n	lit:lemma	uždaras politinis pasitarimas
 08408900-n	lit:lemma	darbo grupė
 02210119-v	lit:lemma	įgyti
@@ -10798,25 +10798,25 @@
 03769881-n	lit:lemma	autobusiukas
 07328305-n	lit:lemma	parametras
 14327266-n	lit:lemma	pilvo skausmas
-00453308-s	lit:lemma	artimas
-02226979-s	lit:lemma	meistriškas
-02500590-s	lit:lemma	tuščias
+00453308-a	lit:lemma	artimas
+02226979-a	lit:lemma	meistriškas
+02500590-a	lit:lemma	tuščias
 06574473-n	lit:lemma	tvarkyklė
 00046299-r	lit:lemma	labai
 02472987-n	lit:lemma	žmonių rasė
 00107416-r	lit:lemma	pastaruoju metu
 01062255-n	lit:lemma	eikvojimas
 14478684-n	lit:lemma	žlugimas
-00574884-s	lit:lemma	senamadis
+00574884-a	lit:lemma	senamadis
 01238424-n	lit:lemma	susivienijimas
-01732131-s	lit:lemma	šiuometinis
-00515380-s	lit:lemma	visiškas
+01732131-a	lit:lemma	šiuometinis
+00515380-a	lit:lemma	visiškas
 14373582-n	lit:lemma	psichinė būklė
 00070765-r	lit:lemma	atsitiktinai
 04941325-n	lit:lemma	kompaktiškumas
 12662772-n	lit:lemma	kavamedis
-00282675-s	lit:lemma	švelnus
-00860932-s	lit:lemma	abstraktaus mąstymo
+00282675-a	lit:lemma	švelnus
+00860932-a	lit:lemma	abstraktaus mąstymo
 00248534-n	lit:lemma	sūdymas
 02412210-n	lit:lemma	kastruotas avinas
 00322391-n	lit:lemma	supakavimas
@@ -10824,7 +10824,7 @@
 10112591-n	lit:lemma	draugė
 07623136-n	lit:lemma	sluoksniuota tešla
 15236338-n	lit:lemma	milisekundė
-01006788-s	lit:lemma	apibrėžtas
+01006788-a	lit:lemma	apibrėžtas
 04647185-n	lit:lemma	įdėjimas
 15247110-n	lit:lemma	akies mirksnis
 03544143-n	lit:lemma	smėlio laikrodis
@@ -10833,21 +10833,21 @@
 00865331-a	lit:lemma	nepriimtinas į darbą
 02161314-a	lit:lemma	nepasirašytas
 05996646-n	lit:lemma	dėstomasis dalykas
-02030562-s	lit:lemma	reakcingas
+02030562-a	lit:lemma	reakcingas
 00432689-n	lit:lemma	laisvalaikio veikla
 08876975-n	lit:lemma	Mančesteris
-02124253-s	lit:lemma	veikiantis
+02124253-a	lit:lemma	veikiantis
 01059400-a	lit:lemma	įtvirtintas
-01626562-s	lit:lemma	klaikus
-01601981-s	lit:lemma	šiaurvakarinis
-00012071-s	lit:lemma	sąvokinis
+01626562-a	lit:lemma	klaikus
+01601981-a	lit:lemma	šiaurvakarinis
+00012071-a	lit:lemma	sąvokinis
 05706228-n	lit:lemma	neatidumas
 09536058-n	lit:lemma	Visagalis
 00208273-r	lit:lemma	įtemptai
 02870092-n	lit:lemma	knyga
 15268239-n	lit:lemma	atvanga
-00218950-s	lit:lemma	gražus
-00298293-s	lit:lemma	kolektyvinis
+00218950-a	lit:lemma	gražus
+00298293-a	lit:lemma	kolektyvinis
 05217859-n	lit:lemma	kūnas
 09345932-n	lit:lemma	vandenynas
 04723816-n	lit:lemma	ypatybė
@@ -10855,23 +10855,23 @@
 00074201-r	lit:lemma	atgal
 11667562-n	lit:lemma	lelijainiai
 00040719-r	lit:lemma	nelauktai
-00978754-s	lit:lemma	betarpiškas
+00978754-a	lit:lemma	betarpiškas
 00007549-v	lit:lemma	šnirpšti
-00414919-s	lit:lemma	suklasifikuotas
+00414919-a	lit:lemma	suklasifikuotas
 10298912-n	lit:lemma	kapitonas
-01419462-s	lit:lemma	analogiškas
-01401105-s	lit:lemma	teisinis
+01419462-a	lit:lemma	analogiškas
+01401105-a	lit:lemma	teisinis
 01080297-a	lit:lemma	produktyvus
 06053280-n	lit:lemma	nozologija
 08732116-n	lit:lemma	Kolumbija
 04274530-n	lit:lemma	kamuolys
-01780740-s	lit:lemma	dvasinis
+01780740-a	lit:lemma	dvasinis
 07289014-n	lit:lemma	problema
 07148573-n	lit:lemma	diplomatija
 00333613-r	lit:lemma	lupikiškai
 02724630-a	lit:lemma	egzistencialinis
 00316989-n	lit:lemma	persėdimas
-02344070-s	lit:lemma	pirmosios rūšies
+02344070-a	lit:lemma	pirmosios rūšies
 00019613-n	lit:lemma	materija
 09201998-n	lit:lemma	vandeningasis sluoksnis
 03058107-n	lit:lemma	danga
@@ -10893,10 +10893,10 @@
 10070219-n	lit:lemma	testamento vykdytojas
 03900509-n	lit:lemma	išgrįstas paviršius
 08969291-n	lit:lemma	Maroko Karalystė
-00082766-s	lit:lemma	karingas
-00828661-s	lit:lemma	atletiškas
-01282510-s	lit:lemma	siaubingas
-00590163-s	lit:lemma	nepatenkintas
+00082766-a	lit:lemma	karingas
+00828661-a	lit:lemma	atletiškas
+01282510-a	lit:lemma	siaubingas
+00590163-a	lit:lemma	nepatenkintas
 00797218-a	lit:lemma	negeriamas
 01116380-a	lit:lemma	suklastotas
 07503987-n	lit:lemma	pasibjaurėjimas
@@ -10907,8 +10907,8 @@
 00020280-r	lit:lemma	be paliovos
 00157412-r	lit:lemma	retkarčiais
 02888659-a	lit:lemma	pajūrinis
-00444984-s	lit:lemma	kaimyninis
-01178134-s	lit:lemma	išbalęs
+00444984-a	lit:lemma	kaimyninis
+01178134-a	lit:lemma	išbalęs
 09984659-n	lit:lemma	klientas
 01434278-v	lit:lemma	nuvesti
 07989373-n	lit:lemma	sutuoktiniai
@@ -10919,24 +10919,24 @@
 07503260-n	lit:lemma	bjaurėjimasis
 07860988-n	lit:lemma	tešla
 07484547-n	lit:lemma	troškimas
-01166656-s	lit:lemma	gydomasis
+01166656-a	lit:lemma	gydomasis
 00355919-n	lit:lemma	sumažinimas
 00010054-v	lit:lemma	sujudėti
 02401590-a	lit:lemma	santūrus
 01029852-v	lit:lemma	priskirti
 01439190-v	lit:lemma	stverti
-02403505-s	lit:lemma	standus
+02403505-a	lit:lemma	standus
 03942920-n	lit:lemma	segtuko galvutė
 08058098-n	lit:lemma	įmonė
 06155567-n	lit:lemma	istorija
 02053941-v	lit:lemma	artėti
-02476485-s	lit:lemma	sąjunginis
+02476485-a	lit:lemma	sąjunginis
 04544979-n	lit:lemma	pėsčiųjų takas
 00021878-r	lit:lemma	kartais
 06453849-n	lit:lemma	Naujasis Testamentas
-02044860-s	lit:lemma	apskritas
+02044860-a	lit:lemma	apskritas
 04877530-n	lit:lemma	ištikimumas
-01619475-s	lit:lemma	akivaizdus
+01619475-a	lit:lemma	akivaizdus
 03738241-n	lit:lemma	mechaninė sistema
 04550426-n	lit:lemma	garderobas
 09918248-n	lit:lemma	palikuonis
@@ -10947,7 +10947,7 @@
 10372373-n	lit:lemma	tarnautojas
 07085375-n	lit:lemma	akcentas
 07289956-n	lit:lemma	epizodas
-01038580-s	lit:lemma	municipalinis
+01038580-a	lit:lemma	municipalinis
 03206718-n	lit:lemma	persirengimas
 05839024-n	lit:lemma	klasė
 13285176-n	lit:lemma	dalis
@@ -10961,8 +10961,8 @@
 04297476-n	lit:lemma	dekoracija
 01059400-a	lit:lemma	pritvirtintas
 15246853-n	lit:lemma	sekundė
-01993693-s	lit:lemma	garbingas
-01151740-s	lit:lemma	tvirtas
+01993693-a	lit:lemma	garbingas
+01151740-a	lit:lemma	tvirtas
 07578093-n	lit:lemma	pokylis
 13163250-n	lit:lemma	šaka
 02601456-v	lit:lemma	vadinti
@@ -10980,7 +10980,7 @@
 08566028-n	lit:lemma	pabaiga
 02089984-v	lit:lemma	apsukti
 06117562-n	lit:lemma	geofizika
-02215087-s	lit:lemma	vienintelis
+02215087-a	lit:lemma	vienintelis
 10323634-n	lit:lemma	vadovė
 02623529-v	lit:lemma	tapti
 05243879-n	lit:lemma	derma
@@ -10998,11 +10998,11 @@
 00021939-n	lit:lemma	artefaktas
 09955015-n	lit:lemma	sukčius
 02744323-n	lit:lemma	magistralė
-01080900-s	lit:lemma	vešlus
-01676517-s	lit:lemma	nerealus
+01080900-a	lit:lemma	vešlus
+01676517-a	lit:lemma	nerealus
 11449002-n	lit:lemma	elektrinis reiškinys
 10136959-n	lit:lemma	golfo žaidėjas
-00562909-s	lit:lemma	nederamas
+00562909-a	lit:lemma	nederamas
 01084637-n	lit:lemma	padalijimas
 06252954-n	lit:lemma	informavimas
 05186306-n	lit:lemma	balsavimo teisė
@@ -11022,30 +11022,30 @@
 11417129-n	lit:lemma	atsakymas
 11455695-n	lit:lemma	židinio taškas
 08565506-n	lit:lemma	nirvana
-01958259-s	lit:lemma	sertifikuotas
+01958259-a	lit:lemma	sertifikuotas
 09193705-n	lit:lemma	aukšti kalnai
 02696795-a	lit:lemma	kinematografinis
 00163590-r	lit:lemma	chaotiškai
 12023108-n	lit:lemma	vaistinis skaistenis
 07548567-n	lit:lemma	priešiškumas
-00890351-s	lit:lemma	lygiavertis
+00890351-a	lit:lemma	lygiavertis
 01129920-n	lit:lemma	prievolė
-00238310-s	lit:lemma	daugialypis
+00238310-a	lit:lemma	daugialypis
 13165815-n	lit:lemma	kamienas
 01814385-a	lit:lemma	politiškas
-00459553-s	lit:lemma	kaip ką tik gimęs
+00459553-a	lit:lemma	kaip ką tik gimęs
 09874862-n	lit:lemma	pamergė
 09807754-n	lit:lemma	aristokratas
-00417204-s	lit:lemma	žalias
+00417204-a	lit:lemma	žalias
 01101391-a	lit:lemma	bendras
-01413501-s	lit:lemma	vienodai tikėtinas
+01413501-a	lit:lemma	vienodai tikėtinas
 03099454-n	lit:lemma	vienuolynas
 01845627-n	lit:lemma	antiniai
-00978754-s	lit:lemma	greitas
+00978754-a	lit:lemma	greitas
 06630017-n	lit:lemma	sveikinimas
 01156438-n	lit:lemma	mobilizacija
 00284101-n	lit:lemma	vaikštinėjimas
-02500179-s	lit:lemma	neteisingas
+02500179-a	lit:lemma	neteisingas
 00476140-n	lit:lemma	ritinis
 00171135-r	lit:lemma	neapgalvojus
 01116380-a	lit:lemma	netikras
@@ -11054,9 +11054,9 @@
 10345804-n	lit:lemma	pasakotojas
 04296261-n	lit:lemma	lazda
 08910668-n	lit:lemma	Irano Islamo Respublika
-02248693-s	lit:lemma	etninis
+02248693-a	lit:lemma	etninis
 00022401-r	lit:lemma	labai seniai
-01592857-s	lit:lemma	žemas
+01592857-a	lit:lemma	žemas
 05166397-n	lit:lemma	nuodai
 07184735-n	lit:lemma	ginčas
 12663254-n	lit:lemma	liberinis kavamedis
@@ -11065,7 +11065,7 @@
 07024929-n	lit:lemma	daugiabalsė muzika
 00874067-n	lit:lemma	nuosprendis
 13763384-n	lit:lemma	minimumas
-01642657-s	lit:lemma	revoliucinis
+01642657-a	lit:lemma	revoliucinis
 06023821-n	lit:lemma	mediana
 00413239-n	lit:lemma	įprastas elgesys
 01158872-v	lit:lemma	panaudoti
@@ -11078,7 +11078,7 @@
 14610347-n	lit:lemma	arseno rūgštis
 00203783-r	lit:lemma	neribotam laikui
 07393161-n	lit:lemma	žviegimas
-01302544-s	lit:lemma	besivystantis
+01302544-a	lit:lemma	besivystantis
 02416278-v	lit:lemma	bendradarbiauti
 14330046-n	lit:lemma	šonkaulių skausmas
 00335182-r	lit:lemma	ekspromtu
@@ -11092,7 +11092,7 @@
 00462520-r	lit:lemma	tyliai
 00079499-r	lit:lemma	šiąnakt
 00317569-v	lit:lemma	praplatinti
-01930004-s	lit:lemma	nereaguojantis
+01930004-a	lit:lemma	nereaguojantis
 02821627-n	lit:lemma	miegamasis
 13085113-n	lit:lemma	piktžolė
 03003730-n	lit:lemma	uždara ertmė
@@ -11111,42 +11111,42 @@
 05106633-n	lit:lemma	mažumas
 04782116-n	lit:lemma	baisumas
 01495725-a	lit:lemma	maksimalus
-00936523-s	lit:lemma	užgrūdintas
+00936523-a	lit:lemma	užgrūdintas
 01169317-n	lit:lemma	rezistencija
 10726786-n	lit:lemma	prekeivis
 13097338-n	lit:lemma	kambis
 04341686-n	lit:lemma	konstrukcija
 08542081-n	lit:lemma	klimato juosta
-01392633-s	lit:lemma	mažytis
+01392633-a	lit:lemma	mažytis
 15140405-n	lit:lemma	gyvenimas
 03359950-n	lit:lemma	nuleista padanga
 02704928-v	lit:lemma	trukti
 09738708-n	lit:lemma	amerikietis
 09210604-n	lit:lemma	atmosfera
-01574925-s	lit:lemma	šmėkliškas
+01574925-a	lit:lemma	šmėkliškas
 01639765-n	lit:lemma	varlė
 02708420-v	lit:lemma	leisti
 13603305-n	lit:lemma	ilgio vienetas
 13969243-n	lit:lemma	darnumas
 08102555-n	lit:lemma	tipas
 01452593-a	lit:lemma	triukšmingas
-00974697-s	lit:lemma	senamadis
+00974697-a	lit:lemma	senamadis
 07653394-n	lit:lemma	mėsos išpjova
 13867492-n	lit:lemma	amorfizmas
-01397998-s	lit:lemma	kiauras
+01397998-a	lit:lemma	kiauras
 01136614-v	lit:lemma	šauti
-01618376-s	lit:lemma	aiškus
+01618376-a	lit:lemma	aiškus
 13267014-n	lit:lemma	subsidija
 00526948-n	lit:lemma	pavana
 05981230-n	lit:lemma	tikslas
 07235335-n	lit:lemma	kaltinimas (oficialus)
-00389310-s	lit:lemma	pilkas
+00389310-a	lit:lemma	pilkas
 07887099-n	lit:lemma	pilstomas alus
-01610484-s	lit:lemma	atrastas
+01610484-a	lit:lemma	atrastas
 01733661-a	lit:lemma	negimęs
 03944672-n	lit:lemma	vamzdis
 01223766-n	lit:lemma	nešvarus žaidimas
-00072281-s	lit:lemma	atsparus
+00072281-a	lit:lemma	atsparus
 13162297-n	lit:lemma	žievė
 03264542-n	lit:lemma	riba
 00110659-r	lit:lemma	lauke
@@ -11158,18 +11158,18 @@
 05305136-n	lit:lemma	skonio svogūnėlis
 06651577-n	lit:lemma	užuomina
 02203362-v	lit:lemma	turėti
-02368566-s	lit:lemma	pernelyg lipšnus
+02368566-a	lit:lemma	pernelyg lipšnus
 00945401-n	lit:lemma	ieškojimas
 05200169-n	lit:lemma	galėjimas
 14323974-n	lit:lemma	danties skausmas
 00510869-v	lit:lemma	pažymėti
 00535956-n	lit:lemma	fokstrotas
-01564315-s	lit:lemma	nejudantis
+01564315-a	lit:lemma	nejudantis
 09939313-n	lit:lemma	karys
-02549691-s	lit:lemma	tvankus
+02549691-a	lit:lemma	tvankus
 00100543-n	lit:lemma	perteikimas
 08418420-n	lit:lemma	komercinis bankas
-01265308-s	lit:lemma	smagus
+01265308-a	lit:lemma	smagus
 05599769-n	lit:lemma	pagurklis
 04323026-n	lit:lemma	fondų birža
 02754197-a	lit:lemma	teisinis
@@ -11183,39 +11183,39 @@
 13444703-n	lit:lemma	ląstelių dalijimasis
 05622456-n	lit:lemma	gabumas
 03398467-n	lit:lemma	dalis
-02568480-s	lit:lemma	neskraidantis
+02568480-a	lit:lemma	neskraidantis
 03563460-n	lit:lemma	sparnuotė
 06803636-n	lit:lemma	pagalbos šauksmas
 13384341-n	lit:lemma	senatvės pensija
 05690916-n	lit:lemma	kliūtis
 10174330-n	lit:lemma	inteligentas
-01732601-s	lit:lemma	artėjantis
-00668208-s	lit:lemma	naujausias
-00521976-s	lit:lemma	paviršius
+01732601-a	lit:lemma	artėjantis
+00668208-a	lit:lemma	naujausias
+00521976-a	lit:lemma	paviršius
 07587206-n	lit:lemma	vėžlių sriuba
 00451370-n	lit:lemma	dviračių sportas
 00971075-a	lit:lemma	madingas
 05243879-n	lit:lemma	tikroji oda
 07843636-n	lit:lemma	keptas kiaušinis
 00207761-n	lit:lemma	tremtis
-01676517-s	lit:lemma	puikus
+01676517-a	lit:lemma	puikus
 01568375-a	lit:lemma	tarptautinis
 00305519-n	lit:lemma	priverstinis nusileidimas
 05751794-n	lit:lemma	kultūra
-01625893-s	lit:lemma	bjaurus
+01625893-a	lit:lemma	bjaurus
 00893955-n	lit:lemma	treniravimas
 01400562-a	lit:lemma	teisėtas
 02755352-n	lit:lemma	ryšys
-02476485-s	lit:lemma	konfederacinis
+02476485-a	lit:lemma	konfederacinis
 02137710-v	lit:lemma	atskleisti
 00496127-r	lit:lemma	sąmoningai
 00897746-v	lit:lemma	paklausti
 01349948-n	lit:lemma	bacila
 00055315-n	lit:lemma	nebesirūpinimas
-01482551-s	lit:lemma	išsiskyręs
-01277426-s	lit:lemma	pagrindinis
-02018649-s	lit:lemma	nuobodus
-01139832-s	lit:lemma	lygus
+01482551-a	lit:lemma	išsiskyręs
+01277426-a	lit:lemma	pagrindinis
+02018649-a	lit:lemma	nuobodus
+01139832-a	lit:lemma	lygus
 09816771-n	lit:lemma	partneris
 01270175-a	lit:lemma	skubotas
 04831031-n	lit:lemma	negailestingumas
@@ -11224,18 +11224,18 @@
 15241507-n	lit:lemma	adventas
 05607863-n	lit:lemma	kamieninė ląstelė
 13265011-n	lit:lemma	dovana
-00803275-s	lit:lemma	intensyvus
+00803275-a	lit:lemma	intensyvus
 01932973-a	lit:lemma	realus
 15290930-n	lit:lemma	karta
-01335903-s	lit:lemma	greitas
-01143138-s	lit:lemma	palaipsninis
+01335903-a	lit:lemma	greitas
+01143138-a	lit:lemma	palaipsninis
 10624074-n	lit:lemma	sūnus
 05372428-n	lit:lemma	ašarų liaukos vena
 07537485-n	lit:lemma	melancholija
-00821603-s	lit:lemma	pasiektas
+00821603-a	lit:lemma	pasiektas
 04005090-n	lit:lemma	spaustuvė
-01144102-s	lit:lemma	ūmus
-00301951-s	lit:lemma	nesuskaičiuojamas
+01144102-a	lit:lemma	ūmus
+00301951-a	lit:lemma	nesuskaičiuojamas
 13983304-n	lit:lemma	šviesa
 03659292-n	lit:lemma	svertas
 01926376-a	lit:lemma	neprotingas
@@ -11248,7 +11248,7 @@
 00303849-n	lit:lemma	šuolis su parašiutu
 06647206-n	lit:lemma	dokumentas
 07413629-n	lit:lemma	blykstelėjimas
-01084644-s	lit:lemma	pripildytas
+01084644-a	lit:lemma	pripildytas
 00329031-n	lit:lemma	paslydimas
 07903841-n	lit:lemma	konjakas
 09144851-n	lit:lemma	Hiustonas
@@ -11263,7 +11263,7 @@
 06265475-n	lit:lemma	greitasis paštas
 05118437-n	lit:lemma	nesaikingumas
 01922562-a	lit:lemma	neraminantis
-00666960-s	lit:lemma	apyvartinis
+00666960-a	lit:lemma	apyvartinis
 10369528-n	lit:lemma	apžvalgininkas
 03016202-a	lit:lemma	graikiškas
 08630039-n	lit:lemma	kraštas
@@ -11277,14 +11277,14 @@
 00598318-n	lit:lemma	valstybinė įstaiga
 00092366-n	lit:lemma	varžytynės
 14395403-n	lit:lemma	demencija
-00876204-s	lit:lemma	abejingas
+00876204-a	lit:lemma	abejingas
 02931013-n	lit:lemma	kebas
 02774152-n	lit:lemma	rankinė
 06427831-n	lit:lemma	taisymas
 02735208-a	lit:lemma	geometrinis
 10122645-n	lit:lemma	gėjus
 13931145-n	lit:lemma	draugystė
-02062133-s	lit:lemma	prekinis
+02062133-a	lit:lemma	prekinis
 02722782-v	lit:lemma	būti neatidėliotinam
 06962600-n	lit:lemma	lotynų kalba
 13981137-n	lit:lemma	nesutarimas
@@ -11297,31 +11297,31 @@
 03537866-n	lit:lemma	baisenybė
 09355850-n	lit:lemma	pelkė
 00407535-n	lit:lemma	veikimas
-00011327-s	lit:lemma	kiauliškas
+00011327-a	lit:lemma	kiauliškas
 01503061-n	lit:lemma	paukštis
 00009650-r	lit:lemma	idealiai
 00145571-r	lit:lemma	pakankamai
 08500213-n	lit:lemma	gelmė
-00904290-s	lit:lemma	puikus
-01427333-s	lit:lemma	užkrečiamas
+00904290-a	lit:lemma	puikus
+01427333-a	lit:lemma	užkrečiamas
 02431337-n	lit:lemma	elnias
 00836277-a	lit:lemma	įtemptas
 03709206-n	lit:lemma	didinamasis stiklas
 06816935-n	lit:lemma	cheminė formulė
 01183638-n	lit:lemma	mokomasis teismo procesas
 07836731-n	lit:lemma	sūrio padažas
-00900071-s	lit:lemma	mįslingas
+00900071-a	lit:lemma	mįslingas
 10437852-n	lit:lemma	ieškovas
 14446652-n	lit:lemma	nepatogumas
 00810598-n	lit:lemma	saugojimas
-01730444-s	lit:lemma	paskutinis
+01730444-a	lit:lemma	paskutinis
 03365592-n	lit:lemma	grindys
 10242791-n	lit:lemma	ponia
 06474122-n	lit:lemma	anketa
 02541509-v	lit:lemma	reprezentuoti
 01409581-a	lit:lemma	panašus
 09927451-n	lit:lemma	šventikas
-00150505-s	lit:lemma	iškalbus
+00150505-a	lit:lemma	iškalbus
 09614315-n	lit:lemma	kūrėjas
 04857490-n	lit:lemma	užsidegimas
 02510337-v	lit:lemma	valdyti
@@ -11329,15 +11329,15 @@
 00451563-n	lit:lemma	važiavimas dviračiu
 08797619-n	lit:lemma	Raudų siena
 02830501-a	lit:lemma	literatūrinis
-01662119-s	lit:lemma	priešlaikinis
+01662119-a	lit:lemma	priešlaikinis
 00262249-n	lit:lemma	puošimas
-01532149-s	lit:lemma	atsargus
+01532149-a	lit:lemma	atsargus
 04952242-n	lit:lemma	šviesumas
 06396142-n	lit:lemma	skyrius
 10409011-n	lit:lemma	vargšas
 00492724-n	lit:lemma	faraonas
 02322712-n	lit:lemma	pieniai
-01719779-s	lit:lemma	įstrižas
+01719779-a	lit:lemma	įstrižas
 02323186-n	lit:lemma	kiškiažvėriai
 07509996-n	lit:lemma	nustebimas
 00550777-a	lit:lemma	nedavęs rezultato
@@ -11349,7 +11349,7 @@
 14985383-n	lit:lemma	dažomoji medžiaga
 02233704-v	lit:lemma	atsiųsti
 00020926-v	lit:lemma	užburti
-00251134-s	lit:lemma	didvyriškas
+00251134-a	lit:lemma	didvyriškas
 05921123-n	lit:lemma	branduolys
 02879638-a	lit:lemma	apaštalų
 05618056-n	lit:lemma	protas
@@ -11358,7 +11358,7 @@
 00163704-r	lit:lemma	aukštyn kojomis
 08732116-n	lit:lemma	Kolumbijos Respublika
 03438071-n	lit:lemma	juosta
-02007067-s	lit:lemma	tinkliškas
+02007067-a	lit:lemma	tinkliškas
 00957176-a	lit:lemma	neteisingas
 05036394-n	lit:lemma	stiprumas
 02753394-n	lit:lemma	atominis laikrodis
@@ -11371,14 +11371,14 @@
 01047803-n	lit:lemma	atgimimas
 00088725-n	lit:lemma	suėmimas
 01578575-n	lit:lemma	varninių šeimos paukštis
-01375831-s	lit:lemma	įžymus
+01375831-a	lit:lemma	įžymus
 05699770-n	lit:lemma	nežinia
 07948314-n	lit:lemma	benamiai
 02966972-a	lit:lemma	argentiniečių
 00005779-r	lit:lemma	nepaprastai
 09605289-n	lit:lemma	pilnametis
 09815790-n	lit:lemma	pagalbininkas
-01898722-s	lit:lemma	išmintingas
+01898722-a	lit:lemma	išmintingas
 00804502-a	lit:lemma	nuobodus
 00018577-r	lit:lemma	visiškai
 05131283-n	lit:lemma	aukštuma
@@ -11387,8 +11387,8 @@
 06766544-n	lit:lemma	užuomina
 04652635-n	lit:lemma	socialumas
 02734192-a	lit:lemma	genetinis
-00625055-s	lit:lemma	žymus
-01423851-s	lit:lemma	tinkamas gyventi
+00625055-a	lit:lemma	žymus
+01423851-a	lit:lemma	tinkamas gyventi
 02801938-n	lit:lemma	pintinė
 00398704-n	lit:lemma	keitimas
 00210768-r	lit:lemma	iš įpročio
@@ -11430,7 +11430,7 @@
 02941790-a	lit:lemma	afrikietiškas
 02870880-n	lit:lemma	knygų spinta
 00327824-n	lit:lemma	svyravimas
-00814902-s	lit:lemma	ankstyvas
+00814902-a	lit:lemma	ankstyvas
 08276720-n	lit:lemma	mokykla
 08253141-n	lit:lemma	šokiai
 00404073-r	lit:lemma	mirtinai
@@ -11440,7 +11440,7 @@
 04334599-n	lit:lemma	gatvė
 03512911-n	lit:lemma	vairaratis
 05010801-n	lit:lemma	aidas
-02275412-s	lit:lemma	tvirtas
+02275412-a	lit:lemma	tvirtas
 02858304-n	lit:lemma	valtis
 03602562-n	lit:lemma	žurnalas
 09857852-n	lit:lemma	kandėjas
@@ -11451,40 +11451,40 @@
 02254155-v	lit:lemma	būti skolingam
 03044083-a	lit:lemma	apeliacinis
 01096245-n	lit:lemma	verslas
-00194357-s	lit:lemma	blogas
+00194357-a	lit:lemma	blogas
 05012272-n	lit:lemma	entalpija
 05895723-n	lit:lemma	nesusipratimas
-02114613-s	lit:lemma	pūlingas
-02241988-s	lit:lemma	uolingas
+02114613-a	lit:lemma	pūlingas
+02241988-a	lit:lemma	uolingas
 06193203-n	lit:lemma	požiūris
 07496463-n	lit:lemma	širdgėla
 05031012-n	lit:lemma	tvirtumas
-00746451-s	lit:lemma	sunkiai suprantamas
+00746451-a	lit:lemma	sunkiai suprantamas
 05085572-n	lit:lemma	artybė
 07497473-n	lit:lemma	simpatija
 03098140-n	lit:lemma	valdymo pultas
-01035559-s	lit:lemma	užsienio kilmės
+01035559-a	lit:lemma	užsienio kilmės
 15147097-n	lit:lemma	vaikystė
 08189211-n	lit:lemma	cirkas
 08179205-n	lit:lemma	beturčiai
 04953380-n	lit:lemma	kibirkštis
 04778401-n	lit:lemma	tvirtumas
 05464104-n	lit:lemma	nervinė skaidula
-01383582-s	lit:lemma	didžiulis
+01383582-a	lit:lemma	didžiulis
 00358431-v	lit:lemma	mirti
-01024228-s	lit:lemma	lankstus
+01024228-a	lit:lemma	lankstus
 00040719-r	lit:lemma	visai netikėtai
-01898722-s	lit:lemma	galvotas
+01898722-a	lit:lemma	galvotas
 00644839-a	lit:lemma	tikėtinas
 08363812-n	lit:lemma	monarchija
 06710546-n	lit:lemma	nepalankus vertinimas
-00624576-s	lit:lemma	didelis
+00624576-a	lit:lemma	didelis
 05159725-n	lit:lemma	nauda
 05076472-n	lit:lemma	kompozicija
 06611147-n	lit:lemma	kvailystė
 06693502-n	lit:lemma	garbinimas
 00100543-n	lit:lemma	interpretacija
-01066787-s	lit:lemma	įprastas
+01066787-a	lit:lemma	įprastas
 15276427-n	lit:lemma	gimstamumas
 07534430-n	lit:lemma	sielvartas
 02122164-v	lit:lemma	skaudėti
@@ -11493,37 +11493,37 @@
 02598211-a	lit:lemma	augalinis
 15210045-n	lit:lemma	sausis
 00172980-r	lit:lemma	drąsiai
-01392633-s	lit:lemma	mažutėlis
-00667353-s	lit:lemma	aktualus
+01392633-a	lit:lemma	mažutėlis
+00667353-a	lit:lemma	aktualus
 03859280-n	lit:lemma	atskiras priestatas
 10102800-n	lit:lemma	protėvis
 00032863-r	lit:lemma	nuo šiol
 01905661-n	lit:lemma	bestuburis
-01982186-s	lit:lemma	simbolinis
+01982186-a	lit:lemma	simbolinis
 00478647-n	lit:lemma	kamuolio varymas
-01991166-s	lit:lemma	apsėstas
+01991166-a	lit:lemma	apsėstas
 08766988-n	lit:lemma	Vokietija
-02502578-s	lit:lemma	bevertis
+02502578-a	lit:lemma	bevertis
 09835506-n	lit:lemma	beisbolo žaidėjas
 00332154-v	lit:lemma	sutrinti
 03144592-n	lit:lemma	kubas
 11421401-n	lit:lemma	aktinio spinduliavimas
 02951565-a	lit:lemma	cirkuliuojantis
-00445169-s	lit:lemma	artimas
+00445169-a	lit:lemma	artimas
 10148305-n	lit:lemma	niurzga
 00166608-r	lit:lemma	slaptai
 08615001-n	lit:lemma	parapija
 10627082-n	lit:lemma	dvasia
 04694809-n	lit:lemma	dėmė
 04697267-n	lit:lemma	paprastumas
-02097480-s	lit:lemma	viliojantis
+02097480-a	lit:lemma	viliojantis
 02764251-a	lit:lemma	karinis
-01401413-s	lit:lemma	ratifikuotas
+01401413-a	lit:lemma	ratifikuotas
 00358021-r	lit:lemma	palaidai
 08053576-n	lit:lemma	organizacija
 04018399-n	lit:lemma	baras
-01067415-s	lit:lemma	retkarčiais pasitaikantis
-01149358-s	lit:lemma	besišypsantis
+01067415-a	lit:lemma	retkarčiais pasitaikantis
+01149358-a	lit:lemma	besišypsantis
 02297409-v	lit:lemma	siūlyti
 04709253-n	lit:lemma	sudėtingumas
 06065819-n	lit:lemma	agronomija
@@ -11539,13 +11539,13 @@
 14440137-n	lit:lemma	gėda
 00593374-a	lit:lemma	sporadiškas
 05872742-n	lit:lemma	pagrindas
-02398378-s	lit:lemma	pikantiškas
+02398378-a	lit:lemma	pikantiškas
 05711084-n	lit:lemma	spalvų kontrastas
 15067025-n	lit:lemma	tanino rūgštis
 14434681-n	lit:lemma	reikšmingumas
 05033906-n	lit:lemma	neimlumas
 02026312-a	lit:lemma	mokus
-00012362-s	lit:lemma	abstraktus
+00012362-a	lit:lemma	abstraktus
 06832248-n	lit:lemma	k
 00770543-n	lit:lemma	sulaužymas
 02172870-n	lit:lemma	karkvabalis
@@ -11555,19 +11555,19 @@
 05892096-n	lit:lemma	prielaida
 10628644-n	lit:lemma	valdovas
 05090441-n	lit:lemma	dydis
-01284212-s	lit:lemma	stulbinantis
+01284212-a	lit:lemma	stulbinantis
 00079499-r	lit:lemma	šįvakar
-00780352-s	lit:lemma	ryškus
-00878086-s	lit:lemma	preliminarinis
+00780352-a	lit:lemma	ryškus
+00878086-a	lit:lemma	preliminarinis
 00939452-n	lit:lemma	komponavimas
 05514905-n	lit:lemma	vyrų genitalijos
-00683531-s	lit:lemma	šiurkštus
-02340458-s	lit:lemma	kuklus
+00683531-a	lit:lemma	šiurkštus
+02340458-a	lit:lemma	kuklus
 10371450-n	lit:lemma	tarnautojas
 08716738-n	lit:lemma	Kambodžos Karalystė
 10171567-n	lit:lemma	piemuo
-01074335-s	lit:lemma	druskos
-02282651-s	lit:lemma	savaiminis
+01074335-a	lit:lemma	druskos
+02282651-a	lit:lemma	savaiminis
 00463543-n	lit:lemma	ledo ritulys
 00768701-n	lit:lemma	sunkus nusikaltimas
 04074482-n	lit:lemma	vaistas
@@ -11576,7 +11576,7 @@
 07110615-n	lit:lemma	balsas
 00380083-n	lit:lemma	maišymas
 07997703-n	lit:lemma	grupė
-00904745-s	lit:lemma	niekingas
+00904745-a	lit:lemma	niekingas
 09084750-n	lit:lemma	Indiana
 05715283-n	lit:lemma	skonio pojūtis
 00039941-r	lit:lemma	regis
@@ -11586,12 +11586,12 @@
 07227589-n	lit:lemma	sveikatos pažymėjimas
 00169659-r	lit:lemma	vidutiniškai
 00329227-n	lit:lemma	tėkmė
-00164308-s	lit:lemma	dėmesingas
+00164308-a	lit:lemma	dėmesingas
 03257343-n	lit:lemma	dublikatas
 10151760-n	lit:lemma	gitaristas
-01185916-s	lit:lemma	masyvus
+01185916-a	lit:lemma	masyvus
 00664110-n	lit:lemma	gydymas vaistais
-02165432-s	lit:lemma	paviršutiniškas
+02165432-a	lit:lemma	paviršutiniškas
 01234952-n	lit:lemma	reakcija
 00014201-v	lit:lemma	virpėti
 00593613-n	lit:lemma	inspektoriaus pareigos
@@ -11603,7 +11603,7 @@
 07927931-n	lit:lemma	kokakola
 03379204-n	lit:lemma	futbolo stadionas
 00079947-r	lit:lemma	aukščiau
-00846625-s	lit:lemma	paskirtas
+00846625-a	lit:lemma	paskirtas
 00033421-r	lit:lemma	akimirksniu
 00550771-n	lit:lemma	atlikimas
 07199565-n	lit:lemma	replika
@@ -11616,7 +11616,7 @@
 07136711-n	lit:lemma	paistalas
 04340935-n	lit:lemma	citadelė
 15118228-n	lit:lemma	darbo laikas
-01612627-s	lit:lemma	nuolankus
+01612627-a	lit:lemma	nuolankus
 07809368-n	lit:lemma	pagardai
 05017757-n	lit:lemma	matymo nuotolis
 00598318-n	lit:lemma	viešoji įstaiga
@@ -11633,13 +11633,13 @@
 02152881-n	lit:lemma	grobis
 00119568-n	lit:lemma	šuoliavimas
 00063559-n	lit:lemma	pasaulinis rekordas
-01944088-s	lit:lemma	sveikas
-01952643-s	lit:lemma	neapdirbtas
-00066933-s	lit:lemma	saugus
+01944088-a	lit:lemma	sveikas
+01952643-a	lit:lemma	neapdirbtas
+00066933-a	lit:lemma	saugus
 02123475-a	lit:lemma	pasirinktas
 01234345-n	lit:lemma	nedalyvavimas
 08381165-n	lit:lemma	direkcija
-00566835-s	lit:lemma	giminingas
+00566835-a	lit:lemma	giminingas
 00895983-n	lit:lemma	dresavimas
 08672562-n	lit:lemma	gyvenvietė
 00406243-v	lit:lemma	ruošti
@@ -11648,14 +11648,14 @@
 06879180-n	lit:lemma	demonstravimas
 05483677-n	lit:lemma	smegenų baltoji medžiaga
 01780202-v	lit:lemma	bijoti
-01263445-s	lit:lemma	brutalus
+01263445-a	lit:lemma	brutalus
 04566257-n	lit:lemma	ginkluotė
-01443097-s	lit:lemma	laikinas
+01443097-a	lit:lemma	laikinas
 05698982-n	lit:lemma	abejojimas
-01689223-s	lit:lemma	nuvalkiotas
+01689223-a	lit:lemma	nuvalkiotas
 07550079-n	lit:lemma	pavydas
 00151755-r	lit:lemma	apskritai
-00667079-s	lit:lemma	šiandieninis
+00667079-a	lit:lemma	šiandieninis
 04157703-n	lit:lemma	nuoviros
 13349395-n	lit:lemma	laidas
 13308864-n	lit:lemma	rinkliava
@@ -11671,26 +11671,26 @@
 03257877-n	lit:lemma	ilgalaikio naudojimo prekės
 04358381-n	lit:lemma	paviršius
 00231567-n	lit:lemma	anuliavimas
-01277426-s	lit:lemma	aukščiausias
-02123579-s	lit:lemma	elitinis
+01277426-a	lit:lemma	aukščiausias
+02123579-a	lit:lemma	elitinis
 07721456-n	lit:lemma	ankštinis pipiras
-01591394-s	lit:lemma	imperatoriškas
+01591394-a	lit:lemma	imperatoriškas
 03665924-n	lit:lemma	elektros lemputė
 09942697-n	lit:lemma	liaudies komisaras
 05517406-n	lit:lemma	sėklidžių kapšelis
-01936528-s	lit:lemma	įsivaizduojamas
+01936528-a	lit:lemma	įsivaizduojamas
 06755947-n	lit:lemma	išlyga
-01991586-s	lit:lemma	ištikimas
+01991586-a	lit:lemma	ištikimas
 09461170-n	lit:lemma	miškininkystės medelynas
-00097674-s	lit:lemma	miręs
+00097674-a	lit:lemma	miręs
 05726596-n	lit:lemma	išdėstymas
 00007328-v	lit:lemma	žiovauti
 15221718-n	lit:lemma	vardadienis
 10627082-n	lit:lemma	siela
 00305683-r	lit:lemma	toli
-02092460-s	lit:lemma	ekumeninis
+02092460-a	lit:lemma	ekumeninis
 13096035-n	lit:lemma	minkštimas
-02279900-s	lit:lemma	drąsus
+02279900-a	lit:lemma	drąsus
 13577934-n	lit:lemma	metrinė matų sistema
 08672738-n	lit:lemma	sodžius
 00021212-r	lit:lemma	kai kada
@@ -11698,30 +11698,30 @@
 14749543-n	lit:lemma	prolaktinas
 00046299-r	lit:lemma	nepaprastai
 13810323-n	lit:lemma	vienetas
-02347086-s	lit:lemma	skurdus
+02347086-a	lit:lemma	skurdus
 08168978-n	lit:lemma	šalis
 13329641-n	lit:lemma	aktyvai
 00212065-n	lit:lemma	mokslo baigimas
 08981244-n	lit:lemma	Filipinai
-00123485-s	lit:lemma	vėlesnis
+00123485-a	lit:lemma	vėlesnis
 09630641-n	lit:lemma	bėdžius
 00059086-r	lit:lemma	žymiai
-00152629-s	lit:lemma	bežadis
-01394075-s	lit:lemma	smulkus
+00152629-a	lit:lemma	bežadis
+01394075-a	lit:lemma	smulkus
 05517837-n	lit:lemma	pūslė
 00079018-n	lit:lemma	pirkimas
 09505418-n	lit:lemma	dieviška būtybė
-02462375-s	lit:lemma	suklastotas
+02462375-a	lit:lemma	suklastotas
 10669486-n	lit:lemma	pateikėjas
 14857151-n	lit:lemma	atliekos
-01592857-s	lit:lemma	varganas
-00126830-s	lit:lemma	parengiamasis
+01592857-a	lit:lemma	varganas
+00126830-a	lit:lemma	parengiamasis
 04248607-n	lit:lemma	momentinė nuotrauka
 02904075-a	lit:lemma	administracinis
-00330728-s	lit:lemma	centrinis
+00330728-a	lit:lemma	centrinis
 14920844-n	lit:lemma	izoliacinė medžiaga
 07524760-n	lit:lemma	nerimas
-01045518-s	lit:lemma	literatūrinis
+01045518-a	lit:lemma	literatūrinis
 02760116-a	lit:lemma	medicininis
 04690196-n	lit:lemma	bjaurumas
 03017428-n	lit:lemma	dūmtraukis
@@ -11731,7 +11731,7 @@
 00611674-n	lit:lemma	žurnalistika
 06793231-n	lit:lemma	pranešimas
 02850483-a	lit:lemma	kraujo
-01742912-s	lit:lemma	audringas
+01742912-a	lit:lemma	audringas
 03398467-n	lit:lemma	priekis
 02876657-n	lit:lemma	butelis
 09450163-n	lit:lemma	saulė
@@ -11740,7 +11740,7 @@
 01764800-v	lit:lemma	nuraminti
 04317420-n	lit:lemma	pagalys
 00978173-n	lit:lemma	priešpuolis
-00160768-s	lit:lemma	stovintis vienas
+00160768-a	lit:lemma	stovintis vienas
 00150351-r	lit:lemma	puiku!
 00318735-n	lit:lemma	transportavimas
 03719053-n	lit:lemma	rezidencija
@@ -11748,7 +11748,7 @@
 13676396-n	lit:lemma	Vengrijos piniginis vienetas
 07254267-n	lit:lemma	atsisakymas
 02297664-a	lit:lemma	literatūrinis
-02508514-s	lit:lemma	atskleistas
+02508514-a	lit:lemma	atskleistas
 04081281-n	lit:lemma	restoranas
 00220869-v	lit:lemma	sustiprinti
 01199751-a	lit:lemma	vienarūšis
@@ -11760,7 +11760,7 @@
 08748280-n	lit:lemma	Mažosios Antilų salos
 14488813-n	lit:lemma	bumas
 00499477-n	lit:lemma	domino
-00640660-s	lit:lemma	šiurkštus
+00640660-a	lit:lemma	šiurkštus
 04737430-n	lit:lemma	likvidumas
 13396485-n	lit:lemma	biudžeto deficitas
 02908217-n	lit:lemma	teptukas
@@ -11776,25 +11776,25 @@
 05921123-n	lit:lemma	pagrindas
 00877345-a	lit:lemma	tiriamasis
 08177958-n	lit:lemma	miestas valstybė
-01936778-s	lit:lemma	fantastiškas
-00965176-s	lit:lemma	patikimas
-00937341-s	lit:lemma	nesusipažinęs
+01936778-a	lit:lemma	fantastiškas
+00965176-a	lit:lemma	patikimas
+00937341-a	lit:lemma	nesusipažinęs
 00251820-r	lit:lemma	juridiškai
-00459330-s	lit:lemma	plikas
+00459330-a	lit:lemma	plikas
 04727559-n	lit:lemma	mistika
 07500159-n	lit:lemma	palanki nuomonė
 07995164-n	lit:lemma	pulkelis
 00024649-v	lit:lemma	atšviežinti
-01520091-s	lit:lemma	visiškas
+01520091-a	lit:lemma	visiškas
 13480394-n	lit:lemma	autoelektroninė emisija
 12630763-n	lit:lemma	čilinė žemuogė
 00251780-n	lit:lemma	šveitimas
 10222353-n	lit:lemma	asas
 10113583-n	lit:lemma	statytinis
-02394793-s	lit:lemma	netaktiškas
+02394793-a	lit:lemma	netaktiškas
 08284481-n	lit:lemma	gimnazija
-02370625-s	lit:lemma	nežinomas
-01336837-s	lit:lemma	tuščiagalvis
+02370625-a	lit:lemma	nežinomas
+01336837-a	lit:lemma	tuščiagalvis
 09331251-n	lit:lemma	ežero pakrantė
 00228724-r	lit:lemma	psichiškai
 09623038-n	lit:lemma	vadas
@@ -11806,7 +11806,7 @@
 10028123-n	lit:lemma	taikos šalininkas
 00340403-r	lit:lemma	tiesiogiai
 10289462-n	lit:lemma	vedėja
-01664310-s	lit:lemma	atitrūkęs nuo gyvenimo
+01664310-a	lit:lemma	atitrūkęs nuo gyvenimo
 00755745-v	lit:lemma	tikėtis
 02822064-n	lit:lemma	gyvenamasis kambarys
 08776687-n	lit:lemma	Ekvadoro Respublika
@@ -11817,13 +11817,13 @@
 01975138-a	lit:lemma	atitinkamas
 06272803-n	lit:lemma	telefono skambutis
 14580897-n	lit:lemma	audinys
-02363811-s	lit:lemma	paskiepytas
-02570643-s	lit:lemma	beprasmiškas
+02363811-a	lit:lemma	paskiepytas
+02570643-a	lit:lemma	beprasmiškas
 10128909-n	lit:lemma	milžinas
 00024257-r	lit:lemma	nė kiek
 05534333-n	lit:lemma	viduriai
 05849040-n	lit:lemma	ypatybė
-01263013-s	lit:lemma	žiaurus
+01263013-a	lit:lemma	žiaurus
 05124928-n	lit:lemma	maksimumas
 04530566-n	lit:lemma	laivas
 05859630-n	lit:lemma	sandauga
@@ -11836,10 +11836,10 @@
 04424418-n	lit:lemma	dalykas
 03823111-n	lit:lemma	smaigalys
 01992503-v	lit:lemma	progresuoti
-00378892-s	lit:lemma	oranžinis
+00378892-a	lit:lemma	oranžinis
 07497473-n	lit:lemma	palankumas
-01318741-s	lit:lemma	sužalotas
-01223271-s	lit:lemma	apsimestinis
+01318741-a	lit:lemma	sužalotas
+01223271-a	lit:lemma	apsimestinis
 00002724-v	lit:lemma	dusti
 05498773-n	lit:lemma	limbinė sistema
 07903208-n	lit:lemma	konjakas
@@ -11855,9 +11855,9 @@
 13459322-n	lit:lemma	gynybos mechanizmas
 02787772-n	lit:lemma	bankas
 03895293-n	lit:lemma	praėjimas
-00218305-s	lit:lemma	puikus
+00218305-a	lit:lemma	puikus
 00273877-n	lit:lemma	šviesinimas
-02344672-s	lit:lemma	geriausias
+02344672-a	lit:lemma	geriausias
 00770997-n	lit:lemma	pražanga (sporte)
 00096513-n	lit:lemma	išgelbėjimas
 03079741-n	lit:lemma	skyrius
@@ -11880,18 +11880,18 @@
 03532342-n	lit:lemma	kablys
 01060745-n	lit:lemma	logistika
 00293916-n	lit:lemma	bėgimas
-02378496-s	lit:lemma	vykstantis tuo pat metu
+02378496-a	lit:lemma	vykstantis tuo pat metu
 01754421-a	lit:lemma	permanentinis
 06374587-n	lit:lemma	recenzija
 04808639-n	lit:lemma	mėgstamumas
 05625465-n	lit:lemma	vaizduotė
-00408445-s	lit:lemma	blankus
+00408445-a	lit:lemma	blankus
 01452593-a	lit:lemma	garsus
-02466566-s	lit:lemma	nepatikimas
+02466566-a	lit:lemma	nepatikimas
 08891415-n	lit:lemma	Kaledonija
 02106006-v	lit:lemma	pajusti
 00196848-n	lit:lemma	prievolės pakeitimas
-00475308-s	lit:lemma	liepsnojantis
+00475308-a	lit:lemma	liepsnojantis
 08986905-n	lit:lemma	Kataro Valstybė
 00103194-r	lit:lemma	iš pradžių
 09304465-n	lit:lemma	landa
@@ -11900,7 +11900,7 @@
 00384055-v	lit:lemma	pasikeisti
 08053576-n	lit:lemma	institucija
 00319939-n	lit:lemma	persekiojimas
-00803275-s	lit:lemma	stiprus
+00803275-a	lit:lemma	stiprus
 01686439-a	lit:lemma	savitas
 09628382-n	lit:lemma	tikintysis
 03006105-n	lit:lemma	griovys
@@ -11909,8 +11909,8 @@
 06519253-n	lit:lemma	lėktuvo bilietas
 02058794-a	lit:lemma	rizikingas
 05217859-n	lit:lemma	lavonas
-00890874-s	lit:lemma	vienos kategorijos
-02321809-s	lit:lemma	tvirtas
+00890874-a	lit:lemma	vienos kategorijos
+02321809-a	lit:lemma	tvirtas
 05617107-n	lit:lemma	protingumas
 02829422-a	lit:lemma	įstatyminis
 05621439-n	lit:lemma	įžvalgumas
@@ -11923,7 +11923,7 @@
 08253268-n	lit:lemma	pokylis
 00007015-r	lit:lemma	maždaug
 08388207-n	lit:lemma	aristokratija
-00713853-s	lit:lemma	rėksmingas
+00713853-a	lit:lemma	rėksmingas
 08971025-n	lit:lemma	Mozambiko Respublika
 15283433-n	lit:lemma	skridimo greitis
 14441825-n	lit:lemma	įtaka
@@ -11932,7 +11932,7 @@
 02746897-a	lit:lemma	imperatoriškas
 06155432-n	lit:lemma	anglistika
 00540235-v	lit:lemma	išplėsti
-01536276-s	lit:lemma	neo-
+01536276-a	lit:lemma	neo-
 01217043-v	lit:lemma	paremti
 05869584-n	lit:lemma	visybė
 08405723-n	lit:lemma	imperija
@@ -11943,9 +11943,9 @@
 08397856-n	lit:lemma	raitininkai
 09891730-n	lit:lemma	kanonų teisės žinovas
 04847298-n	lit:lemma	dora
-00966753-s	lit:lemma	nepažįstamas
+00966753-a	lit:lemma	nepažįstamas
 04509592-n	lit:lemma	uniforma
-00211564-s	lit:lemma	plikas
+00211564-a	lit:lemma	plikas
 06193203-n	lit:lemma	pozicija
 02271544-a	lit:lemma	naivus
 00451838-v	lit:lemma	prisipildyti
@@ -11954,7 +11954,7 @@
 02962272-a	lit:lemma	rumuniškas
 13679739-n	lit:lemma	Olandijos piniginis vienetas
 14407795-n	lit:lemma	apsėdimas
-00282675-s	lit:lemma	žvilgantis
+00282675-a	lit:lemma	žvilgantis
 09820263-n	lit:lemma	atletė
 15205719-n	lit:lemma	ketverių metų laikotarpis
 14204095-n	lit:lemma	šilumos smūgis
@@ -11976,40 +11976,40 @@
 02842445-a	lit:lemma	kalbinis
 03013162-n	lit:lemma	cheminis ginklas
 00032613-n	lit:lemma	turtas
-00063953-s	lit:lemma	netaktiškas
-01402763-s	lit:lemma	nusikalstamas
-00527188-s	lit:lemma	pasaulinis
+00063953-a	lit:lemma	netaktiškas
+01402763-a	lit:lemma	nusikalstamas
+00527188-a	lit:lemma	pasaulinis
 00031899-r	lit:lemma	nepaprastai
 02725286-v	lit:lemma	būti sustingusiam
 10791221-n	lit:lemma	darbininkas
 04603081-n	lit:lemma	studija
-01253254-s	lit:lemma	apšalęs
+01253254-a	lit:lemma	apšalęs
 03533972-n	lit:lemma	lankas
 14540765-n	lit:lemma	grėsmė
 07143137-n	lit:lemma	konsultacija
 03265479-n	lit:lemma	kraštelis
 10499857-n	lit:lemma	karalienė
 08223802-n	lit:lemma	visuomenė
-00014490-s	lit:lemma	gausus
+00014490-a	lit:lemma	gausus
 00107987-r	lit:lemma	palaipsniui
-00312234-s	lit:lemma	atsainus
+00312234-a	lit:lemma	atsainus
 09849012-n	lit:lemma	gražuolė
 03649909-n	lit:lemma	vejapjovė
 14858637-n	lit:lemma	nuodingosios atliekos
-02573443-s	lit:lemma	apaugęs krūmais
+02573443-a	lit:lemma	apaugęs krūmais
 07990824-n	lit:lemma	vada
 00874067-n	lit:lemma	sprendimas
 03744840-n	lit:lemma	atminties įtaisas
 07570720-n	lit:lemma	maisto produktai
 11433140-n	lit:lemma	Brauno judėjimas
 04644512-n	lit:lemma	noras
-00978199-s	lit:lemma	miklus
+00978199-a	lit:lemma	miklus
 00798539-v	lit:lemma	atstumti
 09541919-n	lit:lemma	pikta dvasia
 13400334-n	lit:lemma	hipotekos paskola
 07294423-n	lit:lemma	nuopelnas
 07377682-n	lit:lemma	griaudimas
-02316992-s	lit:lemma	vingiuotas
+02316992-a	lit:lemma	vingiuotas
 06647206-n	lit:lemma	įrašas
 14449405-n	lit:lemma	stygius
 04956594-n	lit:lemma	spalva
@@ -12020,32 +12020,32 @@
 00522145-n	lit:lemma	demonstravimas
 04096066-n	lit:lemma	kelias
 06832248-n	lit:lemma	K
-01647983-s	lit:lemma	paaugliškas
+01647983-a	lit:lemma	paaugliškas
 00043195-n	lit:lemma	atradimas
 00047056-r	lit:lemma	nepalyginamai
 14364802-n	lit:lemma	trynė
 13300555-n	lit:lemma	bauda
 00589769-n	lit:lemma	kapitono laipsnis
 00054950-r	lit:lemma	baisiai
-01450178-s	lit:lemma	trūkstamas
+01450178-a	lit:lemma	trūkstamas
 02775934-a	lit:lemma	piniginis
 03145384-n	lit:lemma	vėzdas
 10280130-n	lit:lemma	maestro
 07223450-n	lit:lemma	nuogirdos
 01940403-v	lit:lemma	skraidyti
 11630489-n	lit:lemma	kiparisas
-01461292-s	lit:lemma	mielas
+01461292-a	lit:lemma	mielas
 05589756-n	lit:lemma	stuburgalio slankstelis
-00890874-s	lit:lemma	to paties laipsnio
+00890874-a	lit:lemma	to paties laipsnio
 05289861-n	lit:lemma	griaučių raumuo
 10391653-n	lit:lemma	tapytojas
-01314537-s	lit:lemma	paveldimas
+01314537-a	lit:lemma	paveldimas
 05726596-n	lit:lemma	tvarka
 02961099-a	lit:lemma	Austrijos
 03931044-n	lit:lemma	atvaizdas
-00604978-s	lit:lemma	tinkamas
+00604978-a	lit:lemma	tinkamas
 03265479-n	lit:lemma	apvadas
-00796715-s	lit:lemma	nenatūralus
+00796715-a	lit:lemma	nenatūralus
 10602985-n	lit:lemma	sesuo
 04074963-n	lit:lemma	nuotolinio valdymo pultelis
 00340239-a	lit:lemma	tikras
@@ -12062,12 +12062,12 @@
 00255710-n	lit:lemma	skalbimas
 04909414-n	lit:lemma	nepaklusnumas
 13769033-n	lit:lemma	puodas
-02087178-s	lit:lemma	atviras
+02087178-a	lit:lemma	atviras
 13250930-n	lit:lemma	nuosavybė
 03481172-n	lit:lemma	plaktukas
 09714264-n	lit:lemma	indonezietė
 02821030-n	lit:lemma	lovos baltiniai
-00758800-s	lit:lemma	mandagus
+00758800-a	lit:lemma	mandagus
 00067038-a	lit:lemma	rekomenduotinas
 00029378-n	lit:lemma	įvykis
 03899328-n	lit:lemma	takas
@@ -12083,7 +12083,7 @@
 03420440-n	lit:lemma	papuošimas
 05993622-n	lit:lemma	pozityvizmas
 13250930-n	lit:lemma	turtas
-01149358-s	lit:lemma	linksmas
+01149358-a	lit:lemma	linksmas
 10403876-n	lit:lemma	keleivis
 07207273-n	lit:lemma	atmetimas
 13991346-n	lit:lemma	nusikalstamumas
@@ -12094,8 +12094,8 @@
 01029642-v	lit:lemma	pavadinti
 04640176-n	lit:lemma	geraširdiškumas
 10182499-n	lit:lemma	šeimininkas
-02343110-s	lit:lemma	nuostabus
-01961205-s	lit:lemma	nenuolatinis
+02343110-a	lit:lemma	nuostabus
+01961205-a	lit:lemma	nenuolatinis
 00095121-n	lit:lemma	atpirkimas
 01471002-a	lit:lemma	didesnis
 00609953-n	lit:lemma	profesija
@@ -12106,10 +12106,10 @@
 14448333-n	lit:lemma	vargas
 14514805-n	lit:lemma	viešpatija
 00049220-r	lit:lemma	dabar
-00130518-s	lit:lemma	iki pietų
-01038332-s	lit:lemma	vidinis
+00130518-a	lit:lemma	iki pietų
+01038332-a	lit:lemma	vidinis
 11642430-n	lit:lemma	gvatemalinis taksodis
-00961908-s	lit:lemma	šuniškas
+00961908-a	lit:lemma	šuniškas
 05819644-n	lit:lemma	karti teisybė
 00355919-n	lit:lemma	minimalizavimas
 03617594-n	lit:lemma	kineskopas
@@ -12128,35 +12128,35 @@
 10409011-n	lit:lemma	skurdžius
 04192858-n	lit:lemma	apsauga
 08300641-n	lit:lemma	TATENA
-01876261-s	lit:lemma	naujoviškas
+01876261-a	lit:lemma	naujoviškas
 05035961-n	lit:lemma	jėga
 03098803-a	lit:lemma	farmacijos
 02964107-a	lit:lemma	Kroatijos
 00523513-n	lit:lemma	atletika
 00898804-n	lit:lemma	modeliavimas
 13609214-n	lit:lemma	masės vienetas
-00119006-s	lit:lemma	gyvybingas
+00119006-a	lit:lemma	gyvybingas
 14759003-n	lit:lemma	avikailis
 05573602-n	lit:lemma	kelio sąnarys
 15205799-n	lit:lemma	penkmetis
-00340827-s	lit:lemma	pasmerktas
+00340827-a	lit:lemma	pasmerktas
 02477755-v	lit:lemma	atšaukti
-01808227-s	lit:lemma	pasakiškas
-02517169-s	lit:lemma	matomas
-02279900-s	lit:lemma	narsus
+01808227-a	lit:lemma	pasakiškas
+02517169-a	lit:lemma	matomas
+02279900-a	lit:lemma	narsus
 14385160-n	lit:lemma	entomofobija
 13711855-n	lit:lemma	baras
 04712735-n	lit:lemma	sutaikomumas
-02418093-s	lit:lemma	suprantamas
+02418093-a	lit:lemma	suprantamas
 01009240-v	lit:lemma	pasakyti
-01487943-s	lit:lemma	pagrindinis
-01333118-s	lit:lemma	protingas
+01487943-a	lit:lemma	pagrindinis
+01333118-a	lit:lemma	protingas
 07054433-n	lit:lemma	šokių muzika
 00161294-r	lit:lemma	akivaizdžiai
 00756898-v	lit:lemma	tvirtinti
-02318728-s	lit:lemma	sąžiningas
+02318728-a	lit:lemma	sąžiningas
 00721889-v	lit:lemma	įkainoti
-02152473-s	lit:lemma	bendras
+02152473-a	lit:lemma	bendras
 07290905-n	lit:lemma	pradžia
 02960338-a	lit:lemma	Danijos
 00009147-v	lit:lemma	šertis
@@ -12169,7 +12169,7 @@
 00753428-v	lit:lemma	paprašyti
 10787470-n	lit:lemma	moteris
 05547508-n	lit:lemma	gerklė
-01536641-s	lit:lemma	labai modernus
+01536641-a	lit:lemma	labai modernus
 11410172-n	lit:lemma	fotoemisija
 07466832-n	lit:lemma	finalinės varžybos
 00173644-r	lit:lemma	kantriai
@@ -12189,7 +12189,7 @@
 01458736-a	lit:lemma	forte
 14758842-n	lit:lemma	gyvūno kailis
 06497459-n	lit:lemma	alfabetas
-00840212-s	lit:lemma	taupus
+00840212-a	lit:lemma	taupus
 01454810-v	lit:lemma	tempti
 12352150-n	lit:lemma	bananas
 07412310-n	lit:lemma	žiežirba
@@ -12203,50 +12203,50 @@
 00023271-n	lit:lemma	žinios
 08299911-n	lit:lemma	UNICEF
 00206144-r	lit:lemma	tamsiai
-01789117-s	lit:lemma	marmuriškas
+01789117-a	lit:lemma	marmuriškas
 05835747-n	lit:lemma	koncepcija
 05349659-n	lit:lemma	ašarų liaukos arterija
 01433294-v	lit:lemma	atgabenti
-00990855-s	lit:lemma	liaunas
+00990855-a	lit:lemma	liaunas
 11872973-n	lit:lemma	krienas
 03544360-n	lit:lemma	namas
 10157744-n	lit:lemma	idiotas
-01761375-s	lit:lemma	draudžiamas
+01761375-a	lit:lemma	draudžiamas
 13576101-n	lit:lemma	apibrėžtas kiekis
 02937876-a	lit:lemma	matematinis
 13668491-n	lit:lemma	Alžyro dinaras
 14546844-n	lit:lemma	tvirtumas
-02077904-s	lit:lemma	paikas
+02077904-a	lit:lemma	paikas
 07051728-n	lit:lemma	daina apie meilę
 07378234-n	lit:lemma	bimbesys
 02914213-a	lit:lemma	terapinis
 09288769-n	lit:lemma	sritis
 03109881-n	lit:lemma	kampas
-00535293-s	lit:lemma	nesuprantamas
+00535293-a	lit:lemma	nesuprantamas
 10243137-n	lit:lemma	ponia
-02370625-s	lit:lemma	nepažįstamas
+02370625-a	lit:lemma	nepažįstamas
 09447666-n	lit:lemma	krantas
 08642517-n	lit:lemma	artumas
 09535809-n	lit:lemma	žemės deivė
 02172888-v	lit:lemma	išleisti garsą
 08740875-n	lit:lemma	Meksikos Jungtinės Valstijos
-01281695-s	lit:lemma	nesvarbus
+01281695-a	lit:lemma	nesvarbus
 03390207-n	lit:lemma	dalis
 05619743-n	lit:lemma	genialumas
 08307589-n	lit:lemma	susitikimas
 03183080-n	lit:lemma	įtaisas
 10580535-n	lit:lemma	baudžiauninkas
 00431005-n	lit:lemma	išdaiga
-01925708-s	lit:lemma	logiškas
+01925708-a	lit:lemma	logiškas
 13669479-n	lit:lemma	Jordanijos piniginis vienetas
-02044860-s	lit:lemma	žiedinis
+02044860-a	lit:lemma	žiedinis
 04626280-n	lit:lemma	emocionalumas
 00685638-a	lit:lemma	ryžtingas
-01991166-s	lit:lemma	žūtbūt siekiantis
+01991166-a	lit:lemma	žūtbūt siekiantis
 09201031-n	lit:lemma	anga
 07295629-n	lit:lemma	atpildas
 00022316-v	lit:lemma	raminti
-01009206-s	lit:lemma	pirmas
+01009206-a	lit:lemma	pirmas
 09701148-n	lit:lemma	anglas
 01731351-a	lit:lemma	nūdienis
 09729530-n	lit:lemma	arabas
@@ -12260,25 +12260,25 @@
 01898731-n	lit:lemma	kailis
 08766988-n	lit:lemma	Vokietijos Federacinė Respublika
 01066163-n	lit:lemma	vilkinimas
-00488857-s	lit:lemma	neįprastas
+00488857-a	lit:lemma	neįprastas
 07945657-n	lit:lemma	negyvėliai
 00519492-n	lit:lemma	šunų paroda
 03400798-n	lit:lemma	kuro elementas
 13860548-n	lit:lemma	antagonizmas
-01143855-s	lit:lemma	skubus
+01143855-a	lit:lemma	skubus
 02928347-a	lit:lemma	indų
 02848523-n	lit:lemma	mentė
 14892138-n	lit:lemma	guaninas
-01857956-s	lit:lemma	antrinis
+01857956-a	lit:lemma	antrinis
 04891333-n	lit:lemma	neprotingumas
 02373093-n	lit:lemma	neporanagiai
 07499615-n	lit:lemma	bičiuliškumas
-01154030-s	lit:lemma	minkštas
+01154030-a	lit:lemma	minkštas
 01779986-a	lit:lemma	protinis
 00406243-v	lit:lemma	pasirengti
 09956387-n	lit:lemma	mokovas
 03104594-n	lit:lemma	kopija
-00402855-s	lit:lemma	ryškus
+00402855-a	lit:lemma	ryškus
 02971940-n	lit:lemma	gramofono galvutė
 13273154-n	lit:lemma	premija
 14049711-n	lit:lemma	sveikumas
@@ -12289,10 +12289,10 @@
 00085811-r	lit:lemma	vikriai
 09348055-n	lit:lemma	beformė medžiaga
 00978413-n	lit:lemma	bombardavimas
-00194357-s	lit:lemma	gąsdinantis
+00194357-a	lit:lemma	gąsdinantis
 09609232-n	lit:lemma	kapitalistas
-02218314-s	lit:lemma	daugialypis
-00387392-s	lit:lemma	sidabrinis
+02218314-a	lit:lemma	daugialypis
+00387392-a	lit:lemma	sidabrinis
 13954253-n	lit:lemma	egzistavimas
 05784242-n	lit:lemma	apmąstymas
 00057388-r	lit:lemma	visiškai
@@ -12303,11 +12303,11 @@
 10261624-n	lit:lemma	pussunkio svorio boksininkas
 00027384-r	lit:lemma	nepaisant to
 09366017-n	lit:lemma	depresija
-00574884-s	lit:lemma	pasenęs
-01141595-s	lit:lemma	sustingęs
+00574884-a	lit:lemma	pasenęs
+01141595-a	lit:lemma	sustingęs
 04930632-n	lit:lemma	gyvenimo būdas
-02568884-s	lit:lemma	sujungtas
-01742715-s	lit:lemma	karinis
+02568884-a	lit:lemma	sujungtas
+01742715-a	lit:lemma	karinis
 03894379-n	lit:lemma	sienelė
 00011093-r	lit:lemma	gerai
 14381416-n	lit:lemma	fobinis nerimo sutrikimas
@@ -12325,7 +12325,7 @@
 00136329-n	lit:lemma	spyris
 05761559-n	lit:lemma	atsiminimas
 04898437-n	lit:lemma	prideramumas
-01781076-s	lit:lemma	dvasinis
+01781076-a	lit:lemma	dvasinis
 01114458-n	lit:lemma	mažmeninė prekyba
 14325335-n	lit:lemma	nugaros skausmas
 08050678-n	lit:lemma	politinis režimas
@@ -12334,10 +12334,10 @@
 03264542-n	lit:lemma	pakraštys
 06615561-n	lit:lemma	pramoga
 05967977-n	lit:lemma	būrimas
-01464700-s	lit:lemma	meilingas
+01464700-a	lit:lemma	meilingas
 00243918-n	lit:lemma	maisto gaminimas
 15152817-n	lit:lemma	pilnametystė
-01304802-s	lit:lemma	patariamasis
+01304802-a	lit:lemma	patariamasis
 08227214-n	lit:lemma	visuomeninė organizacija
 05675601-n	lit:lemma	ego
 00882523-v	lit:lemma	pasveikinti
@@ -12345,56 +12345,56 @@
 10612210-n	lit:lemma	tinginys
 00520257-n	lit:lemma	šou
 02504562-v	lit:lemma	prispirti
-00974697-s	lit:lemma	atsilikęs
+00974697-a	lit:lemma	atsilikęs
 00043609-n	lit:lemma	pašalinimas
 00874806-n	lit:lemma	įvertinimas
 00340192-n	lit:lemma	aplenkimas
 14492373-n	lit:lemma	prabanga
 00056087-n	lit:lemma	emigracija
-00922051-s	lit:lemma	žavingas
+00922051-a	lit:lemma	žavingas
 10657444-n	lit:lemma	tarpininkas
 12583401-n	lit:lemma	sabalpalmė
 00081591-r	lit:lemma	kiekvieną savaitę
 06600684-n	lit:lemma	nutolimas
 15223750-n	lit:lemma	rudens lygiadienis
-00529657-s	lit:lemma	tylus
+00529657-a	lit:lemma	tylus
 14001031-n	lit:lemma	savarankiškumas
 00066781-r	lit:lemma	priešakyje
-01313004-s	lit:lemma	paliktas
+01313004-a	lit:lemma	paliktas
 06961853-n	lit:lemma	italikų kalba
 13757249-n	lit:lemma	žingsnis
 00112090-r	lit:lemma	tyliai
-02057226-s	lit:lemma	pasaulietiškas
+02057226-a	lit:lemma	pasaulietiškas
 03790512-n	lit:lemma	motociklas
 05509889-n	lit:lemma	kvėpavimo sistema
 02759367-a	lit:lemma	iš motinos pusės
-00526062-s	lit:lemma	visuotinis
+00526062-a	lit:lemma	visuotinis
 03547658-n	lit:lemma	įvorė
 00044861-r	lit:lemma	priešais
 08965598-n	lit:lemma	Malis
 02743391-a	lit:lemma	žmogiškas
-00122844-s	lit:lemma	lydintis
+00122844-a	lit:lemma	lydintis
 03833564-n	lit:lemma	antgalis
 00009650-r	lit:lemma	tobulai
 01761871-a	lit:lemma	priimtinas
 04197391-n	lit:lemma	marškiniai
-00019505-s	lit:lemma	prieinamas
+00019505-a	lit:lemma	prieinamas
 02866578-n	lit:lemma	bomba
 00607780-v	lit:lemma	atsiminti
 13972797-n	lit:lemma	neramumai
-00354934-s	lit:lemma	pertvarkytas
+00354934-a	lit:lemma	pertvarkytas
 09989045-n	lit:lemma	merga
 00501140-r	lit:lemma	teoriškai
 03961939-n	lit:lemma	pakyla
 00307631-n	lit:lemma	pasivažinėjimas
 14499262-n	lit:lemma	jovalas
 06269396-n	lit:lemma	kūrinys
-00517554-s	lit:lemma	pusinis
+00517554-a	lit:lemma	pusinis
 05647015-n	lit:lemma	vidutinio sunkumo silpnaprotystė
-02100968-s	lit:lemma	antrinis
+02100968-a	lit:lemma	antrinis
 06691684-n	lit:lemma	audringas pritarimas
 03045750-a	lit:lemma	australiškas
-01461292-s	lit:lemma	malonus
+01461292-a	lit:lemma	malonus
 01041968-n	lit:lemma	meldimasis
 00018584-a	lit:lemma	nepriimtinas
 01661091-n	lit:lemma	roplys
@@ -12409,27 +12409,27 @@
 04458843-n	lit:lemma	jutiklinis ekranas
 00194969-n	lit:lemma	nukrypimas
 03484487-n	lit:lemma	rankų kremas
-02403505-s	lit:lemma	įtemptas
+02403505-a	lit:lemma	įtemptas
 00423471-r	lit:lemma	tiesiai šviesiai
 03541091-n	lit:lemma	kabinetas
 11463073-n	lit:lemma	gama spinduliuotė
 09492123-n	lit:lemma	mitinė būtybė
 04486445-n	lit:lemma	mažmožis
 10071332-n	lit:lemma	emigrantas
-01629681-s	lit:lemma	grobikiškas
-00493012-s	lit:lemma	bendras
+01629681-a	lit:lemma	grobikiškas
+00493012-a	lit:lemma	bendras
 00405645-r	lit:lemma	abipusiai
 00745005-n	lit:lemma	prasižengimas
-00627004-s	lit:lemma	materialus
+00627004-a	lit:lemma	materialus
 06607339-n	lit:lemma	niekai
 00289860-r	lit:lemma	trumpai
 00020926-v	lit:lemma	sukelti transą
 08378698-n	lit:lemma	kastų sistema
-00542359-s	lit:lemma	retas
+00542359-a	lit:lemma	retas
 03862676-n	lit:lemma	orkaitė
 02832272-a	lit:lemma	žinduolių
 01221611-n	lit:lemma	agresija
-02024928-s	lit:lemma	liuksusinis
+02024928-a	lit:lemma	liuksusinis
 01884539-a	lit:lemma	praeities
 03053474-n	lit:lemma	lazda
 08246613-n	lit:lemma	ansamblis
@@ -12439,7 +12439,7 @@
 15238472-n	lit:lemma	atostogų laikotarpis
 03895293-n	lit:lemma	kelias
 03224893-n	lit:lemma	bendrabutis
-01784217-s	lit:lemma	ateistinis
+01784217-a	lit:lemma	ateistinis
 10247358-n	lit:lemma	mergina
 09481036-n	lit:lemma	kirmėlės išėsta skylutė
 08102402-n	lit:lemma	genealogija
@@ -12461,15 +12461,15 @@
 08058098-n	lit:lemma	bendrovė
 02770170-v	lit:lemma	audroti
 04618781-n	lit:lemma	asmenybė
-02018649-s	lit:lemma	sausas
+02018649-a	lit:lemma	sausas
 13976322-n	lit:lemma	sumaištis
 06876309-n	lit:lemma	gestas
-01136248-s	lit:lemma	niurzgus
+01136248-a	lit:lemma	niurzgus
 09984659-n	lit:lemma	pirkėjas
 03124590-n	lit:lemma	galvijų aptvaras
 03077741-n	lit:lemma	ryšių palydovas
 00020926-v	lit:lemma	sukelti ekstazę
-00124685-s	lit:lemma	povandeninis
+00124685-a	lit:lemma	povandeninis
 01639765-n	lit:lemma	rupūžė
 09201031-n	lit:lemma	kiaurymė
 00018813-v	lit:lemma	žadinti
@@ -12484,14 +12484,14 @@
 00236989-a	lit:lemma	vienašališkas
 03079230-n	lit:lemma	kompaktinė plokštelė
 07571324-n	lit:lemma	kulinarija
-00477661-s	lit:lemma	jaukus
+00477661-a	lit:lemma	jaukus
 13999206-n	lit:lemma	nelaisvė
 14686352-n	lit:lemma	iškastinis kuras
 09885145-n	lit:lemma	pirkėjas
 03510072-n	lit:lemma	šiluminė apsauga
-01952643-s	lit:lemma	natūralus
+01952643-a	lit:lemma	natūralus
 15244650-n	lit:lemma	akimirka
-02506922-s	lit:lemma	įvairus
+02506922-a	lit:lemma	įvairus
 08061042-n	lit:lemma	koncernas
 00827010-n	lit:lemma	izoliacijos darymas
 05860639-n	lit:lemma	mažiausias bendrasis kartotinis
@@ -12501,16 +12501,16 @@
 08780881-n	lit:lemma	Graikija
 02806088-n	lit:lemma	bastionas
 07890750-n	lit:lemma	midus
-01769378-s	lit:lemma	privatus
+01769378-a	lit:lemma	privatus
 00123500-r	lit:lemma	taupiai
 09815790-n	lit:lemma	pagalbininkė
-01386538-s	lit:lemma	milžiniškas
+01386538-a	lit:lemma	milžiniškas
 00195194-n	lit:lemma	pokytis
 10104209-n	lit:lemma	šefas
-00602563-s	lit:lemma	polemiškas
+00602563-a	lit:lemma	polemiškas
 14842992-n	lit:lemma	dirva
 02582615-v	lit:lemma	įvykdyti
-00615191-s	lit:lemma	autentiškas
+00615191-a	lit:lemma	autentiškas
 03842012-n	lit:lemma	administracinių patalpų pastatas
 05816622-n	lit:lemma	informacija
 11447851-n	lit:lemma	impulsas
@@ -12520,7 +12520,7 @@
 00163233-n	lit:lemma	užsimojimas
 03065516-a	lit:lemma	fatalus
 07405137-n	lit:lemma	lavina
-00317727-s	lit:lemma	papjaustytas
+00317727-a	lit:lemma	papjaustytas
 14514039-n	lit:lemma	teritorija
 14460565-n	lit:lemma	vienybė
 05815517-n	lit:lemma	sritis
@@ -12530,7 +12530,7 @@
 03740161-n	lit:lemma	medikamentas
 00229260-n	lit:lemma	išjungimas
 12123244-n	lit:lemma	miežis
-00711308-s	lit:lemma	griežtas
+00711308-a	lit:lemma	griežtas
 05554405-n	lit:lemma	krūtis
 09305031-n	lit:lemma	klonis
 09254614-n	lit:lemma	kontinentas
@@ -12539,11 +12539,11 @@
 04205759-n	lit:lemma	strėlė
 06473563-n	lit:lemma	formuliaras
 05772356-n	lit:lemma	abstraktus mąstymas
-01574925-s	lit:lemma	vaiduokliškas
+01574925-a	lit:lemma	vaiduokliškas
 00065791-a	lit:lemma	drąsus
 00454237-n	lit:lemma	meškeriojimas
 02777927-n	lit:lemma	balkonas
-00974697-s	lit:lemma	pasenęs
+00974697-a	lit:lemma	pasenęs
 09864891-n	lit:lemma	baudžiauninkas
 02749904-v	lit:lemma	nutikti
 00895983-n	lit:lemma	dresūra
@@ -12560,11 +12560,11 @@
 07092158-n	lit:lemma	rašymo stilius
 08552138-n	lit:lemma	teritorija
 11807979-n	lit:lemma	gvazdikas
-00413861-s	lit:lemma	klasikinis
+00413861-a	lit:lemma	klasikinis
 06353445-n	lit:lemma	ortografija
-01402763-s	lit:lemma	baudžiamasis
+01402763-a	lit:lemma	baudžiamasis
 02764505-n	lit:lemma	kirvio galva
-02180277-s	lit:lemma	neapsimestinis
+02180277-a	lit:lemma	neapsimestinis
 04649261-n	lit:lemma	žaismingumas
 08191230-n	lit:lemma	kariuomenė
 01306273-a	lit:lemma	žinantis
@@ -12578,9 +12578,9 @@
 05872742-n	lit:lemma	pagrindai
 11409059-n	lit:lemma	cheminis reiškinys
 05119367-n	lit:lemma	perteklius
-02052603-s	lit:lemma	miestietiškas
+02052603-a	lit:lemma	miestietiškas
 03145384-n	lit:lemma	kuoka
-00398978-s	lit:lemma	margas
+00398978-a	lit:lemma	margas
 05262185-n	lit:lemma	ūsai
 07888378-n	lit:lemma	nelegali smuklė
 07316242-n	lit:lemma	bloga lemtis
@@ -12596,37 +12596,37 @@
 13920835-n	lit:lemma	būklė
 10231087-n	lit:lemma	žudikas
 03007130-n	lit:lemma	koplyčia
-01901186-s	lit:lemma	pavėluotas
+01901186-a	lit:lemma	pavėluotas
 00331655-n	lit:lemma	perkėlimas
 13774404-n	lit:lemma	krūva
 02342800-v	lit:lemma	klestėti
 06757891-n	lit:lemma	prasimanymas
-02367319-s	lit:lemma	papildomas
+02367319-a	lit:lemma	papildomas
 02412080-n	lit:lemma	avinas
-02160622-s	lit:lemma	neregintis
+02160622-a	lit:lemma	neregintis
 10338628-n	lit:lemma	nužudytasis
 10612210-n	lit:lemma	apsileidėlis
 00732746-n	lit:lemma	nusikaltimas
 00021766-a	lit:lemma	tikslus
 03209910-n	lit:lemma	diskelis
-00453308-s	lit:lemma	intymus
+00453308-a	lit:lemma	intymus
 00432689-n	lit:lemma	papildoma veikla
 08258523-n	lit:lemma	komunistų partija
 13910384-n	lit:lemma	plotas
-01462324-s	lit:lemma	mielas
+01462324-a	lit:lemma	mielas
 00119940-r	lit:lemma	sėkmingai
-00816160-s	lit:lemma	tarpinis
+00816160-a	lit:lemma	tarpinis
 07593549-n	lit:lemma	maisto pusgaminiai
 05123098-n	lit:lemma	mažumas
 01199751-a	lit:lemma	homogeninis
 00067526-n	lit:lemma	netekimas
-02390724-s	lit:lemma	įaudrintas
+02390724-a	lit:lemma	įaudrintas
 00932367-a	lit:lemma	nenaudingas
 04296562-n	lit:lemma	pakyla
 14011811-n	lit:lemma	neveikimas
 10138767-n	lit:lemma	geras žmogus
 15193908-n	lit:lemma	Žolinė
-01280908-s	lit:lemma	nesvarbus
+01280908-a	lit:lemma	nesvarbus
 00359135-n	lit:lemma	santrumpa
 11425989-n	lit:lemma	branduolinė energija
 00269258-n	lit:lemma	rekonstrukcija
@@ -12637,7 +12637,7 @@
 00348801-n	lit:lemma	virpulys
 05463533-n	lit:lemma	nervinis centras
 00489086-r	lit:lemma	besąlygiškai
-01431112-s	lit:lemma	absurdiškas
+01431112-a	lit:lemma	absurdiškas
 07205573-n	lit:lemma	atsisakymas
 09337048-n	lit:lemma	protėkis
 13417071-n	lit:lemma	vertybinis popierius
@@ -12645,22 +12645,22 @@
 00464513-a	lit:lemma	logiškas
 03127203-n	lit:lemma	karteris
 02788378-a	lit:lemma	respublikonų
-00421590-s	lit:lemma	purvinas
+00421590-a	lit:lemma	purvinas
 06149344-n	lit:lemma	namų ūkis
 15251336-n	lit:lemma	šimtosios metinės
-01262284-s	lit:lemma	humaniškas
+01262284-a	lit:lemma	humaniškas
 00718924-a	lit:lemma	savavališkas
 05835747-n	lit:lemma	nusistatymas
 03479952-n	lit:lemma	koridorius
-01871565-s	lit:lemma	apsimokantis
-01499269-s	lit:lemma	beribis
+01871565-a	lit:lemma	apsimokantis
+01499269-a	lit:lemma	beribis
 09626031-n	lit:lemma	nedirbantis asmuo
 08198398-n	lit:lemma	dalinys (kariuomenės)
 14867858-n	lit:lemma	plaušelis
 00293650-r	lit:lemma	nepatenkintai
 09692250-n	lit:lemma	baskas
-00341655-s	lit:lemma	atsitiktinis
-01628531-s	lit:lemma	šiurkštus
+00341655-a	lit:lemma	atsitiktinis
+01628531-a	lit:lemma	šiurkštus
 03880531-n	lit:lemma	keptuvė
 13599348-n	lit:lemma	norma
 10589785-n	lit:lemma	laivybos kompanijos brokeris
@@ -12669,27 +12669,27 @@
 03892891-n	lit:lemma	dalis
 02050132-v	lit:lemma	pravažiuoti
 03259505-n	lit:lemma	namai
-00711308-s	lit:lemma	reiklus
+00711308-a	lit:lemma	reiklus
 03118661-a	lit:lemma	slavų
 03051307-a	lit:lemma	bulgarų
 07472929-n	lit:lemma	politinė kampanija
-01126841-s	lit:lemma	apgailėtinas
+01126841-a	lit:lemma	apgailėtinas
 00838367-n	lit:lemma	valgymas
-00656132-s	lit:lemma	lemiamas
+00656132-a	lit:lemma	lemiamas
 01158020-a	lit:lemma	beširdis
 09545324-n	lit:lemma	dvasia
 13920835-n	lit:lemma	padėtis
 10253703-n	lit:lemma	legionierius
 03211117-n	lit:lemma	vienetas
-01142196-s	lit:lemma	gailiaširdis
+01142196-a	lit:lemma	gailiaširdis
 05868477-n	lit:lemma	galas
 03656484-n	lit:lemma	lęšis
 07227589-n	lit:lemma	medicininė pažyma
-00793592-s	lit:lemma	antrinis
+00793592-a	lit:lemma	antrinis
 00919542-a	lit:lemma	sužadintas
 13599348-n	lit:lemma	kvota
 14122497-n	lit:lemma	gripas
-01366062-s	lit:lemma	niūrus
+01366062-a	lit:lemma	niūrus
 10389398-n	lit:lemma	savininkas
 00387657-n	lit:lemma	pjovimas
 01871979-v	lit:lemma	nustumti
@@ -12703,18 +12703,18 @@
 10316013-n	lit:lemma	militaristas
 02555126-a	lit:lemma	šlapias
 04640176-n	lit:lemma	geranoriškumas
-00528629-s	lit:lemma	visos šalies
+00528629-a	lit:lemma	visos šalies
 15290337-n	lit:lemma	fazė
-01477077-s	lit:lemma	vyrų
+01477077-a	lit:lemma	vyrų
 07199922-n	lit:lemma	replika
 07976936-n	lit:lemma	dvejetas
-01969150-s	lit:lemma	kasmetinis
+01969150-a	lit:lemma	kasmetinis
 05888929-n	lit:lemma	hipotezė
-00900071-s	lit:lemma	slėpiningas
+00900071-a	lit:lemma	slėpiningas
 04657244-n	lit:lemma	neprieinamumas
-01453809-s	lit:lemma	rėksmingas
+01453809-a	lit:lemma	rėksmingas
 13835899-n	lit:lemma	pietūs
-00682521-s	lit:lemma	kurčias
+00682521-a	lit:lemma	kurčias
 02771756-v	lit:lemma	išdžiūti
 13873917-n	lit:lemma	ratas
 05308310-n	lit:lemma	danties šaknis
@@ -12722,13 +12722,13 @@
 01985923-v	lit:lemma	kristi
 14696793-n	lit:lemma	akmuo
 00761713-v	lit:lemma	derėtis
-02517169-s	lit:lemma	regimas
+02517169-a	lit:lemma	regimas
 08497294-n	lit:lemma	šalis
 06832356-n	lit:lemma	l
 10045713-n	lit:lemma	pedagogas
-01367431-s	lit:lemma	linksmas
+01367431-a	lit:lemma	linksmas
 01459791-n	lit:lemma	gemalas
-00170847-s	lit:lemma	viliojantis
+00170847-a	lit:lemma	viliojantis
 02970849-n	lit:lemma	vežimas
 00258282-r	lit:lemma	žemiau
 14544335-n	lit:lemma	įtempimas
@@ -12742,8 +12742,8 @@
 00753685-n	lit:lemma	apgaulė
 01823092-a	lit:lemma	neįvykdomas
 00499924-n	lit:lemma	biliardas
-02433975-s	lit:lemma	nusikamavęs
-00213610-s	lit:lemma	pūkuotas
+02433975-a	lit:lemma	nusikamavęs
+00213610-a	lit:lemma	pūkuotas
 00490304-r	lit:lemma	šalies gilumoje
 02891236-a	lit:lemma	mašinų
 07800740-n	lit:lemma	pašaras
@@ -12754,18 +12754,18 @@
 00812274-n	lit:lemma	sučiupimas
 09191635-n	lit:lemma	oro burbulas
 00321731-n	lit:lemma	įlašinimas
-01035559-s	lit:lemma	gimęs svetur
+01035559-a	lit:lemma	gimęs svetur
 03739693-n	lit:lemma	medicininis instrumentas
 04453910-n	lit:lemma	dangtelis
-02382396-s	lit:lemma	priešingas
+02382396-a	lit:lemma	priešingas
 02879087-n	lit:lemma	puokštė
-01621424-s	lit:lemma	patekęs į aklavietę
-01442079-s	lit:lemma	vienerių metų
+01621424-a	lit:lemma	patekęs į aklavietę
+01442079-a	lit:lemma	vienerių metų
 00050037-n	lit:lemma	užsirašymas
 13969243-n	lit:lemma	darna
 03933529-n	lit:lemma	molas
 06200344-n	lit:lemma	pomėgis
-02413390-s	lit:lemma	skaidrus
+02413390-a	lit:lemma	skaidrus
 00737188-n	lit:lemma	nenormalumas
 00840189-n	lit:lemma	gurkšnis
 10134178-n	lit:lemma	ožkaganys
@@ -12779,19 +12779,19 @@
 15269513-n	lit:lemma	laiko intervalas
 01764800-v	lit:lemma	numaldyti
 07326557-n	lit:lemma	priežastis
-00724397-s	lit:lemma	tikras
+00724397-a	lit:lemma	tikras
 03135152-n	lit:lemma	kryžiaus simbolis
 00126837-r	lit:lemma	techniškai
 04766059-n	lit:lemma	paprastumas
 01254784-a	lit:lemma	vasariškas
 13989280-n	lit:lemma	gedulas
-01968352-s	lit:lemma	kasnaktinis
+01968352-a	lit:lemma	kasnaktinis
 05553486-n	lit:lemma	krūtinė
-00602563-s	lit:lemma	poleminis
+00602563-a	lit:lemma	poleminis
 02959553-a	lit:lemma	suomiškas
 02913152-n	lit:lemma	statinys
 13244109-n	lit:lemma	nuosavybė
-00475308-s	lit:lemma	degantis
+00475308-a	lit:lemma	degantis
 04670531-n	lit:lemma	nepatikimumas
 02132745-v	lit:lemma	stebeilyti
 07170753-n	lit:lemma	interpretacija
@@ -12799,13 +12799,13 @@
 02698319-v	lit:lemma	nusakyti
 01034457-a	lit:lemma	svetimas
 00033663-r	lit:lemma	šiek tiek
-02023430-s	lit:lemma	vargingas
+02023430-a	lit:lemma	vargingas
 07454452-n	lit:lemma	iškilmės
 05529159-n	lit:lemma	gerklaryklė
-00566835-s	lit:lemma	giminiškas
-01830599-s	lit:lemma	galingas
+00566835-a	lit:lemma	giminiškas
+01830599-a	lit:lemma	galingas
 00061528-r	lit:lemma	staiga
-01948958-s	lit:lemma	per daug subtilus
+01948958-a	lit:lemma	per daug subtilus
 06831391-n	lit:lemma	C
 00270275-n	lit:lemma	restitucija
 10084043-n	lit:lemma	moteriškos lyties palikuonis
@@ -12819,7 +12819,7 @@
 06706676-n	lit:lemma	medalis
 05624700-n	lit:lemma	kūrybiškumas
 13869547-n	lit:lemma	kablys
-00997036-s	lit:lemma	nepalankus
+00997036-a	lit:lemma	nepalankus
 01812337-n	lit:lemma	karvelis
 06272612-n	lit:lemma	balso paštas
 05013642-n	lit:lemma	rasos taško temperatūra
@@ -12830,9 +12830,9 @@
 00144722-r	lit:lemma	tikrai
 01064863-n	lit:lemma	neveikimas
 06798750-n	lit:lemma	žymė
-01126291-s	lit:lemma	bjaurus
+01126291-a	lit:lemma	bjaurus
 06892775-n	lit:lemma	koncertas
-01762257-s	lit:lemma	leistinas
+01762257-a	lit:lemma	leistinas
 05831566-n	lit:lemma	viešosios tvarkos pažeidimas
 02946507-a	lit:lemma	Atlanto
 04999401-n	lit:lemma	nutukimas
@@ -12841,24 +12841,24 @@
 03610270-n	lit:lemma	atminas
 05779923-n	lit:lemma	prielaida
 06051380-n	lit:lemma	higiena
-01516346-s	lit:lemma	susijęs
+01516346-a	lit:lemma	susijęs
 10780632-n	lit:lemma	sutuoktinė
 07537485-n	lit:lemma	depresija
-01975671-s	lit:lemma	adekvatus
+01975671-a	lit:lemma	adekvatus
 01157850-n	lit:lemma	karo prievolė
 03530910-n	lit:lemma	variklio dangtis
-01243102-s	lit:lemma	tuščias
-00566961-s	lit:lemma	besiribojantis
+01243102-a	lit:lemma	tuščias
+00566961-a	lit:lemma	besiribojantis
 03838298-n	lit:lemma	objektyvas
 00796315-n	lit:lemma	avantiūra
 00072808-n	lit:lemma	apsiskaičiavimas
 08512259-n	lit:lemma	kraštas
 14540220-n	lit:lemma	kolektyvinis saugumas
 13932421-n	lit:lemma	priimtinumas
-00032733-s	lit:lemma	mitrus
+00032733-a	lit:lemma	mitrus
 02872752-n	lit:lemma	aulinis
 13658657-n	lit:lemma	milimetras
-00770993-s	lit:lemma	netiesioginis
+00770993-a	lit:lemma	netiesioginis
 07331210-n	lit:lemma	nusilpimas
 03225988-n	lit:lemma	dvigulė lova
 09545976-n	lit:lemma	šmėkla
@@ -12869,7 +12869,7 @@
 04063373-n	lit:lemma	įrašymo įrenginys
 05144079-n	lit:lemma	blogis
 03990474-n	lit:lemma	puodas
-01636205-s	lit:lemma	doras
+01636205-a	lit:lemma	doras
 00003316-v	lit:lemma	ištraukti
 00159396-n	lit:lemma	kyšininkavimas
 06212839-n	lit:lemma	ideologija
@@ -12878,7 +12878,7 @@
 08750334-n	lit:lemma	Kuba
 13125117-n	lit:lemma	šaknis
 00388494-r	lit:lemma	lento
-01367431-s	lit:lemma	smagus
+01367431-a	lit:lemma	smagus
 03600806-n	lit:lemma	cigaretė su marihuana
 06497459-n	lit:lemma	raidynas
 06765044-n	lit:lemma	komentaras
@@ -12893,7 +12893,7 @@
 00147091-n	lit:lemma	suėjimas
 02153709-v	lit:lemma	ieškoti
 11479058-n	lit:lemma	magnetinė jėga
-01755024-s	lit:lemma	amžinas
+01755024-a	lit:lemma	amžinas
 00590761-v	lit:lemma	nujausti
 00204439-n	lit:lemma	palikimas
 15063108-n	lit:lemma	konstrukcinis plienas
@@ -12902,14 +12902,14 @@
 09305031-n	lit:lemma	slėnis
 04021798-n	lit:lemma	siurblys
 07456188-n	lit:lemma	rungtynės
-01440159-s	lit:lemma	iki mirties
+01440159-a	lit:lemma	iki mirties
 09763784-n	lit:lemma	pažįstamas
 07212190-n	lit:lemma	informavimas
 03272383-n	lit:lemma	elektros lempa
 00863513-n	lit:lemma	refleksas
 03791235-n	lit:lemma	motorinė transporto priemonė
-01664015-s	lit:lemma	optimistiškas
-01723543-s	lit:lemma	nesavanaudis
+01664015-a	lit:lemma	optimistiškas
+01723543-a	lit:lemma	nesavanaudis
 13998014-n	lit:lemma	katorga
 07950920-n	lit:lemma	socialinė grupė
 06279326-n	lit:lemma	elektroninis paštas
@@ -12918,55 +12918,55 @@
 03519981-n	lit:lemma	kelias
 03094503-n	lit:lemma	talpykla
 09822955-n	lit:lemma	auditorius
-02182562-s	lit:lemma	veidmainiškas
+02182562-a	lit:lemma	veidmainiškas
 09964805-n	lit:lemma	perrašinėtojas
-00973677-s	lit:lemma	madingas
+00973677-a	lit:lemma	madingas
 02608902-a	lit:lemma	žemdirbystės
-00520892-s	lit:lemma	visiškas
+00520892-a	lit:lemma	visiškas
 02920769-a	lit:lemma	fašistinis
 01038808-a	lit:lemma	namų
 08627919-n	lit:lemma	rajonas
 00759944-v	lit:lemma	melsti
-01384730-s	lit:lemma	milžiniškas
+01384730-a	lit:lemma	milžiniškas
 01581115-a	lit:lemma	atliekamas
 09181557-n	lit:lemma	potraukis
 03094503-n	lit:lemma	dėžė
 07314838-n	lit:lemma	nelaimė
-01509066-s	lit:lemma	švelnus
+01509066-a	lit:lemma	švelnus
 01813385-n	lit:lemma	paprastasis purplelis
 00962447-v	lit:lemma	pasakoti
 13954818-n	lit:lemma	tikrovė
-01376355-s	lit:lemma	legendinis
+01376355-a	lit:lemma	legendinis
 05827684-n	lit:lemma	akstinas
 02472293-n	lit:lemma	žmogiška būtybė
 00123170-v	lit:lemma	mainytis
 05328867-n	lit:lemma	egzokrininė liauka
-01903160-s	lit:lemma	baudžiamasis
+01903160-a	lit:lemma	baudžiamasis
 00020476-r	lit:lemma	nuolat
-01990653-s	lit:lemma	užsispyręs
-01704420-s	lit:lemma	lūpinis
+01990653-a	lit:lemma	užsispyręs
+01704420-a	lit:lemma	lūpinis
 00266806-n	lit:lemma	remontas
 00092366-n	lit:lemma	aukcionas
 09429387-n	lit:lemma	dalis
 05534333-n	lit:lemma	žarna
-02415294-s	lit:lemma	plonytis
-01977669-s	lit:lemma	primenantis
+02415294-a	lit:lemma	plonytis
+01977669-a	lit:lemma	primenantis
 00785959-n	lit:lemma	eksperimentas
-01320705-s	lit:lemma	nepriekaištingas
+01320705-a	lit:lemma	nepriekaištingas
 09811852-n	lit:lemma	kulkosvaidininkas
 00163704-r	lit:lemma	kūliavirsčia
 07140978-n	lit:lemma	diskusija
 08499057-n	lit:lemma	atmosfera
-01044730-s	lit:lemma	nevaržomas
+01044730-a	lit:lemma	nevaržomas
 04148936-n	lit:lemma	priedanga
 15140405-n	lit:lemma	gyvenimo trukmė
 04558347-n	lit:lemma	vandens laikrodis
 03306385-n	lit:lemma	ekspresas
 03368878-n	lit:lemma	dūmtakis
-01742537-s	lit:lemma	kariaujantis
+01742537-a	lit:lemma	kariaujantis
 15232406-n	lit:lemma	senasis akmens amžius
 07200813-n	lit:lemma	gynyba
-00067379-s	lit:lemma	geresnis
+00067379-a	lit:lemma	geresnis
 06831605-n	lit:lemma	e
 01129920-n	lit:lemma	priedermė
 02696920-a	lit:lemma	pilietinis
@@ -12981,9 +12981,9 @@
 05119367-n	lit:lemma	perviršis
 06193203-n	lit:lemma	nuostata
 10153414-n	lit:lemma	vyrukas
-00179190-s	lit:lemma	kanonizuotas
+00179190-a	lit:lemma	kanonizuotas
 05627785-n	lit:lemma	rojus
-00566342-s	lit:lemma	gretutinis
+00566342-a	lit:lemma	gretutinis
 02169702-v	lit:lemma	girdėti
 10187130-n	lit:lemma	šeimininkas
 06474030-n	lit:lemma	užsakymo blankas
@@ -12993,11 +12993,11 @@
 02204692-v	lit:lemma	valdyti
 10093818-n	lit:lemma	prekiautojas žuvimi
 05648459-n	lit:lemma	nemiklumas
-00398978-s	lit:lemma	daugiaspalvis
-02295098-s	lit:lemma	klasikinis
-01274945-s	lit:lemma	sumažėjęs
-00084022-s	lit:lemma	grobuoniškas
-01917594-s	lit:lemma	įtartinas
+00398978-a	lit:lemma	daugiaspalvis
+02295098-a	lit:lemma	klasikinis
+01274945-a	lit:lemma	sumažėjęs
+00084022-a	lit:lemma	grobuoniškas
+01917594-a	lit:lemma	įtartinas
 03207743-n	lit:lemma	mazgotė
 06513366-n	lit:lemma	peticija
 05793000-n	lit:lemma	paaiškinimas
@@ -13008,10 +13008,10 @@
 06757891-n	lit:lemma	fikcija
 00265119-n	lit:lemma	renovacija
 01580050-a	lit:lemma	būtinas
-01637371-s	lit:lemma	naivus
+01637371-a	lit:lemma	naivus
 08591269-n	lit:lemma	karalystė
 02946348-n	lit:lemma	namelis ant ratų
-02587936-s	lit:lemma	vertas
+02587936-a	lit:lemma	vertas
 00586183-a	lit:lemma	destruktyvus
 00250258-r	lit:lemma	nepaprastai
 12992464-n	lit:lemma	grybai
@@ -13025,15 +13025,15 @@
 14781631-n	lit:lemma	heliotropas
 03098806-n	lit:lemma	valdymo sistema
 10171219-n	lit:lemma	heroldas
-00449332-s	lit:lemma	apimantis
+00449332-a	lit:lemma	apimantis
 14491271-n	lit:lemma	gerovė
 00758459-a	lit:lemma	diplomatiškas
-00566342-s	lit:lemma	gretimas
+00566342-a	lit:lemma	gretimas
 13800539-n	lit:lemma	sujungimas
 05015117-n	lit:lemma	žema temperatūra
-01402763-s	lit:lemma	kriminalinis
+01402763-a	lit:lemma	kriminalinis
 01391351-a	lit:lemma	mažas
-01263971-s	lit:lemma	šaltakraujiškas
+01263971-a	lit:lemma	šaltakraujiškas
 00555325-a	lit:lemma	sąlyginis
 03297735-n	lit:lemma	įstaiga
 08409617-n	lit:lemma	gimnazija
@@ -13043,8 +13043,8 @@
 05869584-n	lit:lemma	visuma
 08231184-n	lit:lemma	lyga
 01237080-n	lit:lemma	akis už akį
-01403760-s	lit:lemma	nelegalus
-01998730-s	lit:lemma	nesugebantis
+01403760-a	lit:lemma	nelegalus
+01998730-a	lit:lemma	nesugebantis
 00112279-r	lit:lemma	tarptautiniu mastu
 00318035-n	lit:lemma	perdavimas
 00231161-n	lit:lemma	abortas
@@ -13061,13 +13061,13 @@
 08118260-n	lit:lemma	reklamos padalinys
 07291794-n	lit:lemma	pabaiga
 02978781-a	lit:lemma	nosies
-00657804-s	lit:lemma	kubinis
+00657804-a	lit:lemma	kubinis
 01835496-v	lit:lemma	judėti
 02324045-n	lit:lemma	kiškis
 03113835-n	lit:lemma	kostiumas
 04299370-n	lit:lemma	perdarynė
 02012344-v	lit:lemma	perkelti
-01038332-s	lit:lemma	nacionalinis
+01038332-a	lit:lemma	nacionalinis
 01898731-n	lit:lemma	vilna
 00033663-r	lit:lemma	truputį
 02431441-n	lit:lemma	stirna
@@ -13080,23 +13080,23 @@
 02806907-a	lit:lemma	simbolinis
 02152740-n	lit:lemma	plėšrūnas
 00274941-n	lit:lemma	dažymas
-01126291-s	lit:lemma	kraupus
-01085167-s	lit:lemma	perpildytas
-00361125-s	lit:lemma	skaistus
-01878870-s	lit:lemma	prideramas
-01518694-s	lit:lemma	kareiviškas
+01126291-a	lit:lemma	kraupus
+01085167-a	lit:lemma	perpildytas
+00361125-a	lit:lemma	skaistus
+01878870-a	lit:lemma	prideramas
+01518694-a	lit:lemma	kareiviškas
 00088120-v	lit:lemma	persišaldyti
 05332802-n	lit:lemma	inkstas
 00827010-n	lit:lemma	izoliavimas
 00018813-v	lit:lemma	pabudinti
-01466775-s	lit:lemma	frigidiškas
+01466775-a	lit:lemma	frigidiškas
 10222353-n	lit:lemma	meistras
 06196584-n	lit:lemma	tendencija
 00057042-r	lit:lemma	visiškai ne
-02083908-s	lit:lemma	smulkmeniškas
-01532586-s	lit:lemma	ribotas
+02083908-a	lit:lemma	smulkmeniškas
+01532586-a	lit:lemma	ribotas
 00499066-n	lit:lemma	stalo žaidimas
-01865967-s	lit:lemma	vaisingas
+01865967-a	lit:lemma	vaisingas
 01975138-a	lit:lemma	svarbus
 00490035-a	lit:lemma	nepaprastas
 14527171-n	lit:lemma	atsparumas
@@ -13116,30 +13116,30 @@
 06584891-n	lit:lemma	komanda
 10092098-n	lit:lemma	girininkas
 06427240-n	lit:lemma	tarmių atlasas
-01856802-s	lit:lemma	esminis
+01856802-a	lit:lemma	esminis
 00264775-n	lit:lemma	humanizavimas
 02875930-a	lit:lemma	odos
-01866812-s	lit:lemma	bergždžias
+01866812-a	lit:lemma	bergždžias
 04233405-n	lit:lemma	lenta
 10638734-n	lit:lemma	atstovė
 03049326-n	lit:lemma	uždarasis valdymas
 00061203-r	lit:lemma	vėliau
 01415605-a	lit:lemma	neapibrėžtas
-01441000-s	lit:lemma	ilgalaikis
+01441000-a	lit:lemma	ilgalaikis
 11418460-n	lit:lemma	laimė
 13978033-n	lit:lemma	įvykis
 09620794-n	lit:lemma	vietinis gyventojas
 02632838-v	lit:lemma	trūkti
-01501821-s	lit:lemma	skambus
+01501821-a	lit:lemma	skambus
 09394646-n	lit:lemma	planeta
 06613686-n	lit:lemma	filmas
 03797390-n	lit:lemma	puodukas
-01031602-s	lit:lemma	greitakojis
+01031602-a	lit:lemma	greitakojis
 00387897-n	lit:lemma	įranta
-00907400-s	lit:lemma	išdidus
+00907400-a	lit:lemma	išdidus
 01867295-a	lit:lemma	našus
-02180277-s	lit:lemma	tikras
-01855086-s	lit:lemma	rezervinis
+02180277-a	lit:lemma	tikras
+01855086-a	lit:lemma	rezervinis
 01600333-a	lit:lemma	šiaurinis
 08794798-n	lit:lemma	Jeruzalė
 01716491-a	lit:lemma	nemalonus
@@ -13149,7 +13149,7 @@
 02078399-a	lit:lemma	nepasotinamas
 09627906-n	lit:lemma	adresatas
 09454642-n	lit:lemma	kalnų ežeras
-00653617-s	lit:lemma	žvairas
+00653617-a	lit:lemma	žvairas
 15212455-n	lit:lemma	rugpjūtis
 04219424-n	lit:lemma	šilkas
 05760202-n	lit:lemma	atsiminimas
@@ -13165,34 +13165,34 @@
 06656741-n	lit:lemma	ekonominė politika
 04493381-n	lit:lemma	kubilas
 00464894-n	lit:lemma	golfas
-00595299-s	lit:lemma	nuolatinis
+00595299-a	lit:lemma	nuolatinis
 00150351-r	lit:lemma	tinka!
 02085374-n	lit:lemma	kambarinis šuniukas
 08101410-n	lit:lemma	veislė
 02929184-n	lit:lemma	kabliukas
 00326324-r	lit:lemma	veiksmingai
 00780148-n	lit:lemma	sukčiavimas
-01779558-s	lit:lemma	fiziologinis
+01779558-a	lit:lemma	fiziologinis
 03051307-a	lit:lemma	Bulgarijos
 03637787-n	lit:lemma	smailioji arka
 00231761-a	lit:lemma	geresnis
 05722427-n	lit:lemma	prisilietimas
 07911677-n	lit:lemma	kokteilis
-01400961-s	lit:lemma	teisminis
+01400961-a	lit:lemma	teisminis
 05309392-n	lit:lemma	minkštasis gomurys
 03471473-n	lit:lemma	nutekamasis latakas
 00715140-a	lit:lemma	demokratinis
 02725286-v	lit:lemma	sustingti
-00922051-s	lit:lemma	užburiantis
+00922051-a	lit:lemma	užburiantis
 09700964-n	lit:lemma	britas
 05434927-n	lit:lemma	ląstelės branduolys
-02071782-s	lit:lemma	giminiškas
+02071782-a	lit:lemma	giminiškas
 00823750-n	lit:lemma	apsauga
 00067526-n	lit:lemma	pralaimėjimas
 02106006-v	lit:lemma	jausti
-02074673-s	lit:lemma	apsėstas
+02074673-a	lit:lemma	apsėstas
 00273601-n	lit:lemma	nuosmukis
-01660444-s	lit:lemma	pasiruošęs
+01660444-a	lit:lemma	pasiruošęs
 00318735-n	lit:lemma	gabenimas
 13353156-n	lit:lemma	materialiniai ištekliai
 07721456-n	lit:lemma	aitrioji paprika
@@ -13204,41 +13204,41 @@
 01047937-n	lit:lemma	regeneracija
 02200686-v	lit:lemma	dovanoti
 00024264-n	lit:lemma	atributas
-02132224-s	lit:lemma	begėdiškas
+02132224-a	lit:lemma	begėdiškas
 13867641-n	lit:lemma	vingis
 01220984-n	lit:lemma	veiksmas
 01236296-n	lit:lemma	kova
 07500414-n	lit:lemma	palankumas
 05207130-n	lit:lemma	negalėjimas
-01277097-s	lit:lemma	centrinis
+01277097-a	lit:lemma	centrinis
 11630890-n	lit:lemma	kipariso mediena
 09777012-n	lit:lemma	tarpininkas
 09945905-n	lit:lemma	kompanionas
-01025212-s	lit:lemma	kietakaktis
+01025212-a	lit:lemma	kietakaktis
 14450339-n	lit:lemma	stoka
 04802403-n	lit:lemma	klaidingumas
 00823532-n	lit:lemma	gynyba
 00598954-v	lit:lemma	sužinoti
-01640482-s	lit:lemma	naudotas
+01640482-a	lit:lemma	naudotas
 05943300-n	lit:lemma	filosofija
 01497736-a	lit:lemma	bereikšmis
-01084297-s	lit:lemma	kimšte prikimštas
+01084297-a	lit:lemma	kimšte prikimštas
 06278136-n	lit:lemma	garsas
-01673946-s	lit:lemma	kasdienis
+01673946-a	lit:lemma	kasdienis
 02760344-v	lit:lemma	įpūsti
 06786629-n	lit:lemma	nurodymas
 10676877-n	lit:lemma	prižiūrėtojas
 02324587-n	lit:lemma	triušiukas
 04005630-n	lit:lemma	kalėjimas
-01214430-s	lit:lemma	šaižus
+01214430-a	lit:lemma	šaižus
 09482330-n	lit:lemma	Jenisėjus
 02665617-v	lit:lemma	atrodyti
-00250739-s	lit:lemma	nutrūktgalviškas
+00250739-a	lit:lemma	nutrūktgalviškas
 09366017-n	lit:lemma	įdubimas
 09967555-n	lit:lemma	kazokas
 02380745-n	lit:lemma	mustangas
 00021065-v	lit:lemma	anestezuoti
-00926505-s	lit:lemma	likęs
+00926505-a	lit:lemma	likęs
 07120524-n	lit:lemma	šauksmas
 00635850-n	lit:lemma	patikrinimas
 08187033-n	lit:lemma	trupė
@@ -13251,19 +13251,19 @@
 00285557-n	lit:lemma	žingsnis
 02144835-v	lit:lemma	paslėpti
 00024682-r	lit:lemma	jokiu būdu
-01941814-s	lit:lemma	beveik visiškas
+01941814-a	lit:lemma	beveik visiškas
 03112177-a	lit:lemma	čigonų
 01578341-n	lit:lemma	varniniai
 08246613-n	lit:lemma	muzikantų kolektyvas
 00159396-n	lit:lemma	kyšis
 00834198-a	lit:lemma	veiksmingas
 02089984-v	lit:lemma	pasukti
-01287808-s	lit:lemma	žymus
+01287808-a	lit:lemma	žymus
 06400271-n	lit:lemma	ištrauka
 03725035-n	lit:lemma	apsauginė kaukė
 00027807-n	lit:lemma	forma
 14758842-n	lit:lemma	gyvūno oda
-02400628-s	lit:lemma	apmuitinamas
+02400628-a	lit:lemma	apmuitinamas
 05164353-n	lit:lemma	žuvusiųjų skaičius
 02414290-n	lit:lemma	merinosai
 13931889-n	lit:lemma	meilės intriga
@@ -13282,12 +13282,12 @@
 06756831-n	lit:lemma	netiesa
 08651247-n	lit:lemma	sklypas
 09337048-n	lit:lemma	skylė
-00150505-s	lit:lemma	iškalbingas
+00150505-a	lit:lemma	iškalbingas
 08401248-n	lit:lemma	dalis
 00870912-n	lit:lemma	dalyba
 15056938-n	lit:lemma	stearino rūgštis
-01788048-s	lit:lemma	languotas
-02101757-s	lit:lemma	šokiruojantis
+01788048-a	lit:lemma	languotas
+02101757-a	lit:lemma	šokiruojantis
 08823968-n	lit:lemma	Manitoba
 04335435-n	lit:lemma	tramvajus
 03907654-n	lit:lemma	pataisos darbų įstaiga
@@ -13297,7 +13297,7 @@
 07378234-n	lit:lemma	gaudesys
 00283568-n	lit:lemma	vaikščiojimas
 07291312-n	lit:lemma	galas
-02499301-s	lit:lemma	logiškas
+02499301-a	lit:lemma	logiškas
 01645601-v	lit:lemma	sukelti
 07457126-n	lit:lemma	olimpiada
 01754421-a	lit:lemma	nuolatinis
@@ -13312,8 +13312,8 @@
 00488225-n	lit:lemma	kortų žaidimas
 01742296-a	lit:lemma	neramus
 04685396-n	lit:lemma	žavumas
-00378782-s	lit:lemma	gelsvai žalias
-01752953-s	lit:lemma	defektinis
+00378782-a	lit:lemma	gelsvai žalias
+01752953-a	lit:lemma	defektinis
 02755352-n	lit:lemma	jungtis
 09477890-n	lit:lemma	pelkynas
 02771020-v	lit:lemma	apniaukti
@@ -13324,7 +13324,7 @@
 07651454-n	lit:lemma	subproduktai
 01654628-v	lit:lemma	sukonstruoti
 14418395-n	lit:lemma	susivienijimas
-00966753-s	lit:lemma	svetimas
+00966753-a	lit:lemma	svetimas
 02776505-n	lit:lemma	gelumbė
 13375891-n	lit:lemma	avansas
 01113867-n	lit:lemma	prekyba
@@ -13335,7 +13335,7 @@
 04157320-n	lit:lemma	skulptūra
 00387666-r	lit:lemma	kairėje
 00725274-v	lit:lemma	nustebinti
-01383394-s	lit:lemma	didokas
+01383394-a	lit:lemma	didokas
 00262792-a	lit:lemma	drąsus
 06828389-n	lit:lemma	asteriskas
 02897237-n	lit:lemma	alaus darykla
@@ -13354,14 +13354,14 @@
 14489113-n	lit:lemma	ekonominė krizė
 10128909-n	lit:lemma	gigantas
 00415000-n	lit:lemma	įpratimas
-00476663-s	lit:lemma	ankštas
+00476663-a	lit:lemma	ankštas
 13758296-n	lit:lemma	limitas
 10628222-n	lit:lemma	pietietis
 09339810-n	lit:lemma	litosfera
 04477091-n	lit:lemma	protektorius
 13886133-n	lit:lemma	arka
 00382109-n	lit:lemma	susijungimas
-02550333-s	lit:lemma	darganotas
+02550333-a	lit:lemma	darganotas
 07500042-n	lit:lemma	broliškumas
 00431396-r	lit:lemma	gražiai
 09225943-n	lit:lemma	durpynas
@@ -13390,12 +13390,12 @@
 07887967-n	lit:lemma	šviesus alus
 04522168-n	lit:lemma	vaza
 04829282-n	lit:lemma	maloningumas
-00968010-s	lit:lemma	neįprastas
-02329864-s	lit:lemma	pavaldus
+00968010-a	lit:lemma	neįprastas
+02329864-a	lit:lemma	pavaldus
 00378479-n	lit:lemma	uždegimas
 01137597-n	lit:lemma	ne pelno organizacija
-01784401-s	lit:lemma	stabmeldiškas
-01384212-s	lit:lemma	platus
+01784401-a	lit:lemma	stabmeldiškas
+01384212-a	lit:lemma	platus
 00244787-r	lit:lemma	neįtikėtinai
 00151105-a	lit:lemma	nerišlus
 06380726-n	lit:lemma	lyrinis eilėraštis
@@ -13404,22 +13404,22 @@
 00036935-r	lit:lemma	neabejotinai
 06756831-n	lit:lemma	melas
 09903153-n	lit:lemma	garsenybė
-00583842-s	lit:lemma	nuolatinis
-01042491-s	lit:lemma	formalus
+00583842-a	lit:lemma	nuolatinis
+01042491-a	lit:lemma	formalus
 04033425-n	lit:lemma	dama (kortų)
 14724436-n	lit:lemma	lėtiklis
 02774630-n	lit:lemma	bagažas
-02280333-s	lit:lemma	energingas
+02280333-a	lit:lemma	energingas
 00312403-n	lit:lemma	ekskursija
 00035718-r	lit:lemma	gana
-00068180-s	lit:lemma	pasvertas
+00068180-a	lit:lemma	pasvertas
 05766984-n	lit:lemma	atvaizdas
 07928696-n	lit:lemma	Coca Cola
 05221895-n	lit:lemma	šaka (mokslo)
 00123170-v	lit:lemma	pasikeisti
 05426243-n	lit:lemma	apvalkalas
 08565506-n	lit:lemma	dangus
-01940651-s	lit:lemma	praktiškas
+01940651-a	lit:lemma	praktiškas
 09839022-n	lit:lemma	bardas
 10200781-n	lit:lemma	asmenybė
 06070503-n	lit:lemma	citologija
@@ -13432,7 +13432,7 @@
 03455033-n	lit:lemma	kapas
 04536866-n	lit:lemma	smuikas
 08406619-n	lit:lemma	labdaros organizacija
-01616157-s	lit:lemma	asmeniškas
+01616157-a	lit:lemma	asmeniškas
 01119192-a	lit:lemma	gabus
 02050132-v	lit:lemma	praeiti
 00411570-r	lit:lemma	niekaip
@@ -13441,10 +13441,10 @@
 01998432-v	lit:lemma	sekti
 05370918-n	lit:lemma	jungo vena
 05621439-n	lit:lemma	nuovokumas
-00579622-s	lit:lemma	svarbus
+00579622-a	lit:lemma	svarbus
 14720692-n	lit:lemma	feritas
 02795925-a	lit:lemma	sėklinis
-02161136-s	lit:lemma	pasirašytas
+02161136-a	lit:lemma	pasirašytas
 13125003-n	lit:lemma	šaknų sistema
 10577284-n	lit:lemma	prekybininkas
 06798750-n	lit:lemma	ženklas
@@ -13459,9 +13459,9 @@
 00400083-n	lit:lemma	vertimas
 02790322-n	lit:lemma	dantelis
 05580416-n	lit:lemma	skridininis sąnarys
-01028163-s	lit:lemma	prisitaikantis
+01028163-a	lit:lemma	prisitaikantis
 02965043-a	lit:lemma	Japonijos
-00712877-s	lit:lemma	neatidėliotinas
+00712877-a	lit:lemma	neatidėliotinas
 06149484-n	lit:lemma	politinė ekonomika
 03870546-n	lit:lemma	pėdas
 00024264-n	lit:lemma	buožas
@@ -13469,13 +13469,13 @@
 00803617-n	lit:lemma	valdymas
 00418394-n	lit:lemma	nervinimas
 01595596-a	lit:lemma	nenormalus
-00010726-s	lit:lemma	valgus
+00010726-a	lit:lemma	valgus
 07577374-n	lit:lemma	užkandis
 00336065-r	lit:lemma	neteisingai
 07121157-n	lit:lemma	šūksmas
 04837232-n	lit:lemma	agresyvumas
 12998815-n	lit:lemma	lakštabudinis grybas
-00459330-s	lit:lemma	nuogas
+00459330-a	lit:lemma	nuogas
 14813560-n	lit:lemma	baltasis molis
 02524171-v	lit:lemma	pasisekti
 05013204-n	lit:lemma	absoliutus nulis
@@ -13487,7 +13487,7 @@
 09542339-n	lit:lemma	nelabasis
 13668751-n	lit:lemma	Bahreino piniginis vienetas
 04188643-n	lit:lemma	plokštė
-01350225-s	lit:lemma	išorinis
+01350225-a	lit:lemma	išorinis
 05217859-n	lit:lemma	palaikai
 00974111-n	lit:lemma	aviacijos antskrydis
 04941453-n	lit:lemma	tankis
@@ -13496,10 +13496,10 @@
 03429288-n	lit:lemma	matuoklis
 00073897-r	lit:lemma	daugiausia
 13776971-n	lit:lemma	aibė
-02503216-s	lit:lemma	negaliojantis
+02503216-a	lit:lemma	negaliojantis
 13515251-n	lit:lemma	metafazė
 10648696-n	lit:lemma	pagrindinio vaidmens atlikėjas
-00640660-s	lit:lemma	atžarus
+00640660-a	lit:lemma	atžarus
 03285912-n	lit:lemma	aptvertas plotas
 05827684-n	lit:lemma	stimulas
 09853645-n	lit:lemma	fanatikas
@@ -13507,7 +13507,7 @@
 08049401-n	lit:lemma	sąjunga
 10130686-n	lit:lemma	mergina
 00005205-a	lit:lemma	visiškas
-01067415-s	lit:lemma	atsitiktinis
+01067415-a	lit:lemma	atsitiktinis
 10088390-n	lit:lemma	kino filmo kūrėjas
 09213565-n	lit:lemma	šlaitas
 01488038-n	lit:lemma	bangininis ryklys
@@ -13527,15 +13527,15 @@
 00153261-r	lit:lemma	iškart
 04328329-n	lit:lemma	baterija
 07205946-n	lit:lemma	išsižadėjimas
-01046226-s	lit:lemma	buitinis
+01046226-a	lit:lemma	buitinis
 14452151-n	lit:lemma	pilnumas
 06025172-n	lit:lemma	standartinis nuokrypis
 00076193-r	lit:lemma	pirmyn ir atgal
 00550777-a	lit:lemma	negalutinis
 01112420-n	lit:lemma	rinkodara
-01159119-s	lit:lemma	svaiginantis
+01159119-a	lit:lemma	svaiginantis
 11447851-n	lit:lemma	postūmis
-01644847-s	lit:lemma	senas
+01644847-a	lit:lemma	senas
 03015254-n	lit:lemma	spinta
 00021702-r	lit:lemma	kada nors
 03848729-n	lit:lemma	anga
@@ -13549,7 +13549,7 @@
 07123552-n	lit:lemma	šaukimas
 07199191-n	lit:lemma	žinių patikrinimas
 02094755-a	lit:lemma	abejotinas
-00858558-s	lit:lemma	stoiškas
+00858558-a	lit:lemma	stoiškas
 08751494-n	lit:lemma	Haitis
 14376188-n	lit:lemma	įtampa
 00250259-n	lit:lemma	gerinimas
@@ -13570,7 +13570,7 @@
 04737934-n	lit:lemma	pastovumas
 02899486-a	lit:lemma	bažnytinis
 01128193-v	lit:lemma	saugoti
-02372520-s	lit:lemma	simetriškas
+02372520-a	lit:lemma	simetriškas
 04777852-n	lit:lemma	stabilumas
 07566340-n	lit:lemma	maisto produktas
 09815790-n	lit:lemma	padėjėjas
@@ -13584,7 +13584,7 @@
 00011516-r	lit:lemma	silpnai
 00418615-n	lit:lemma	nepriežiūra
 09614684-n	lit:lemma	gynėjas
-02340458-s	lit:lemma	žemas
+02340458-a	lit:lemma	žemas
 03380867-n	lit:lemma	apavas
 02651014-a	lit:lemma	autorinis
 14496193-n	lit:lemma	švarumas
@@ -13605,16 +13605,16 @@
 13356112-n	lit:lemma	lėšos
 13392786-n	lit:lemma	fartingas
 05924519-n	lit:lemma	tobulybė
-00768397-s	lit:lemma	padrikas
+00768397-a	lit:lemma	padrikas
 07575076-n	lit:lemma	pietūs
 10648696-n	lit:lemma	filmo žvaigždė
-01937390-s	lit:lemma	netikras
+01937390-a	lit:lemma	netikras
 07745940-n	lit:lemma	braškė
 06024936-n	lit:lemma	dispersija
 00614829-v	lit:lemma	pamiršti
 02828482-a	lit:lemma	laikinas
 14940100-n	lit:lemma	skystis
-02282651-s	lit:lemma	spontaniškas
+02282651-a	lit:lemma	spontaniškas
 08440630-n	lit:lemma	autoritarizmas
 09923673-n	lit:lemma	pilietis
 00180611-r	lit:lemma	nepriklausomai
@@ -13624,36 +13624,36 @@
 04507155-n	lit:lemma	skėtis
 02945820-a	lit:lemma	raidos
 01108148-v	lit:lemma	įveikti
-01822563-s	lit:lemma	įgyvendinamas
+01822563-a	lit:lemma	įgyvendinamas
 06758225-n	lit:lemma	klaidinimas
 01391351-a	lit:lemma	mažytis
 08539717-n	lit:lemma	konurbacija
 13955461-n	lit:lemma	realumas
 00171135-r	lit:lemma	staiga
-02164913-s	lit:lemma	nerimtas
+02164913-a	lit:lemma	nerimtas
 14686913-n	lit:lemma	benzinas
 10153414-n	lit:lemma	vaikinas
 00327824-n	lit:lemma	supimasis
 13668380-n	lit:lemma	Alžyro piniginis vienetas
 03200701-n	lit:lemma	valgomasis
-00959244-s	lit:lemma	tvirtas
+00959244-a	lit:lemma	tvirtas
 15191827-n	lit:lemma	Didysis penktadienis
 00206867-r	lit:lemma	greitai
 02870092-n	lit:lemma	tomas
 02838805-a	lit:lemma	apšvietos
-00390539-s	lit:lemma	pieno baltumo
+00390539-a	lit:lemma	pieno baltumo
 03725968-n	lit:lemma	MIT
-00169056-s	lit:lemma	patrauklus
+00169056-a	lit:lemma	patrauklus
 08630039-n	lit:lemma	sritis
-00848375-s	lit:lemma	privalomas
+00848375-a	lit:lemma	privalomas
 06177450-n	lit:lemma	fonologija
 08849549-n	lit:lemma	Flandrija
 07003119-n	lit:lemma	paveiksliukas
-00195684-s	lit:lemma	klaikus
+00195684-a	lit:lemma	klaikus
 02886090-a	lit:lemma	kontinentinis
 05832745-n	lit:lemma	atsakomybė
-02110778-s	lit:lemma	atskiras
-02229584-s	lit:lemma	grubus
+02110778-a	lit:lemma	atskiras
+02229584-a	lit:lemma	grubus
 00356926-a	lit:lemma	tipiškas
 02801938-n	lit:lemma	krepšys
 08756884-n	lit:lemma	Kipras
@@ -13667,7 +13667,7 @@
 10130686-n	lit:lemma	partnerė
 13867133-n	lit:lemma	taisyklingas daugiakampis
 08274565-n	lit:lemma	pulkas
-01977669-s	lit:lemma	žadinantis prisiminimus
+01977669-a	lit:lemma	žadinantis prisiminimus
 04935528-n	lit:lemma	kibumas
 14732472-n	lit:lemma	keratinas
 05084201-n	lit:lemma	ilguma (geografija)
@@ -13677,7 +13677,7 @@
 00022131-r	lit:lemma	vienodai
 05125377-n	lit:lemma	diapazonas
 00059413-r	lit:lemma	dažnai
-01037022-s	lit:lemma	čiagimis
+01037022-a	lit:lemma	čiagimis
 02502085-n	lit:lemma	kaguanai
 07223170-n	lit:lemma	paskala
 04616059-n	lit:lemma	buožas
@@ -13687,42 +13687,42 @@
 10466918-n	lit:lemma	globėjas
 03419014-n	lit:lemma	apdaras
 13828075-n	lit:lemma	padėtis
-00792202-s	lit:lemma	stipriausias
+00792202-a	lit:lemma	stipriausias
 05328867-n	lit:lemma	išorės sekrecijos liauka
 14488813-n	lit:lemma	(ekonominis) pakilimas
 07863229-n	lit:lemma	virtų kopūstų ir bulvių apkepas
 08567235-n	lit:lemma	aplinka
 03279508-n	lit:lemma	elektroninis mikroskopas
 02734217-n	lit:lemma	arka
-01755024-s	lit:lemma	nuolatinis
+01755024-a	lit:lemma	nuolatinis
 00833702-v	lit:lemma	treniruoti
 08151490-n	lit:lemma	kulto pasekėjai
 09857852-n	lit:lemma	kandikas
 10450303-n	lit:lemma	politikas
-00595299-s	lit:lemma	pastovus
-02570046-s	lit:lemma	pamokomas
+00595299-a	lit:lemma	pastovus
+02570046-a	lit:lemma	pamokomas
 13971901-n	lit:lemma	konsensas
 00057042-r	lit:lemma	visai ne
 00216723-n	lit:lemma	pašalinimas
 09805151-n	lit:lemma	arkivyskupas
 07318476-n	lit:lemma	veikimo sutrikimas
-00650900-s	lit:lemma	neatidėliotinas
-02114746-s	lit:lemma	infekcinis
-00402855-s	lit:lemma	skaistus
+00650900-a	lit:lemma	neatidėliotinas
+02114746-a	lit:lemma	infekcinis
+00402855-a	lit:lemma	skaistus
 01410363-a	lit:lemma	nepanašus
 01120448-n	lit:lemma	mokėjimas
 01497736-a	lit:lemma	beprasmis
 00376400-n	lit:lemma	sulaužymas
 00681429-v	lit:lemma	apgalvoti
-01898722-s	lit:lemma	protingas
-02032617-s	lit:lemma	pats dešinysis
+01898722-a	lit:lemma	protingas
+02032617-a	lit:lemma	pats dešinysis
 00250570-r	lit:lemma	kasmet
 02935891-n	lit:lemma	bufetas
-00119006-s	lit:lemma	energingas
+00119006-a	lit:lemma	energingas
 14533796-n	lit:lemma	padidėjęs jautrumas
 11519253-n	lit:lemma	vėtra
 04771890-n	lit:lemma	nevienodumas
-01676026-s	lit:lemma	nepaprastas
+01676026-a	lit:lemma	nepaprastas
 02137710-v	lit:lemma	atidengti
 04436185-n	lit:lemma	rąstas
 00305570-r	lit:lemma	gilyn
@@ -13737,16 +13737,16 @@
 03909406-n	lit:lemma	švytuoklinis laikrodis
 00157624-r	lit:lemma	visiškai
 00363463-r	lit:lemma	logiškai
-01827766-s	lit:lemma	silpnas
+01827766-a	lit:lemma	silpnas
 05098099-n	lit:lemma	kraštutinumas
 00993014-v	lit:lemma	parašyti
 06000644-n	lit:lemma	matematika
-02372520-s	lit:lemma	proporcingas
+02372520-a	lit:lemma	proporcingas
 14857497-n	lit:lemma	šlamštas
 07269916-n	lit:lemma	piktograma
 00512843-n	lit:lemma	kvailiojimas
 00429048-n	lit:lemma	pramoga
-00219389-s	lit:lemma	didingas
+00219389-a	lit:lemma	didingas
 05000913-n	lit:lemma	apvalumas
 05644922-n	lit:lemma	nesugebėjimas
 14529524-n	lit:lemma	priešais
@@ -13764,13 +13764,13 @@
 04935239-n	lit:lemma	lipnumas
 01767329-a	lit:lemma	privatus
 05001482-n	lit:lemma	laibumas
-02406370-s	lit:lemma	sudirgęs
+02406370-a	lit:lemma	sudirgęs
 05579436-n	lit:lemma	dvigalvis raumuo
 00282050-n	lit:lemma	judėjimas į priekį
 02154508-v	lit:lemma	aptikti
 00059127-n	lit:lemma	vengimas
 03523633-n	lit:lemma	supamasis arkliukas
-00792202-s	lit:lemma	svarbiausias
+00792202-a	lit:lemma	svarbiausias
 05824739-n	lit:lemma	įrodymas
 03082807-n	lit:lemma	kompresorius
 08059412-n	lit:lemma	bendrovė
@@ -13778,19 +13778,19 @@
 04723816-n	lit:lemma	būdingas bruožas
 13333237-n	lit:lemma	investicija
 07901587-n	lit:lemma	stiprus alkoholinis gėrimas
-01735346-s	lit:lemma	motiniškas
+01735346-a	lit:lemma	motiniškas
 00887081-n	lit:lemma	mokymas
 07707451-n	lit:lemma	daržovės
 09453008-n	lit:lemma	plokščiakalnis
 06831712-n	lit:lemma	ef
 06217944-n	lit:lemma	fašizmas
 10421016-n	lit:lemma	faraonas
-02421364-s	lit:lemma	ūkiškas
+02421364-a	lit:lemma	ūkiškas
 00007015-r	lit:lemma	apytiksliai
-01968811-s	lit:lemma	valandinis
+01968811-a	lit:lemma	valandinis
 00761713-v	lit:lemma	tartis
 07858978-n	lit:lemma	medus
-02514380-s	lit:lemma	šlykštus
+02514380-a	lit:lemma	šlykštus
 07203696-n	lit:lemma	pritarimas
 14523090-n	lit:lemma	blogi orai
 02443049-v	lit:lemma	prižiūrėti
@@ -13801,7 +13801,7 @@
 09033936-n	lit:lemma	Damaskas
 07175241-n	lit:lemma	susitarimas
 13903738-n	lit:lemma	slenkstis
-02013758-s	lit:lemma	atnaujintas
+02013758-a	lit:lemma	atnaujintas
 00804802-v	lit:lemma	nesutarti
 00363218-r	lit:lemma	teisėtai
 10148165-n	lit:lemma	pabrolys
@@ -13817,37 +13817,37 @@
 01104637-n	lit:lemma	statymas
 05000342-n	lit:lemma	kūningumas
 09761403-n	lit:lemma	sąskaitininkas
-01264913-s	lit:lemma	pajuokiamas
+01264913-a	lit:lemma	pajuokiamas
 04024862-n	lit:lemma	pintinėlė
 10202363-n	lit:lemma	nekompetentingas asmuo
-00763272-s	lit:lemma	apgaulingas
+00763272-a	lit:lemma	apgaulingas
 09178999-n	lit:lemma	priežastis
 01679459-a	lit:lemma	organinis
 05690916-n	lit:lemma	barjeras
-01969707-s	lit:lemma	mėnesinis
+01969707-a	lit:lemma	mėnesinis
 00124880-n	lit:lemma	susijungimas
 02843495-a	lit:lemma	vestuvinis
 00280853-n	lit:lemma	priartėjimas
 05514905-n	lit:lemma	vyrų išoriniai lyties organai
 08928193-n	lit:lemma	Kenija
-00329034-s	lit:lemma	suskaidytas
+00329034-a	lit:lemma	suskaidytas
 00005526-v	lit:lemma	šnopuoti
 13393762-n	lit:lemma	popierinis pinigas
 04607869-n	lit:lemma	rankinis laikrodis
 14122053-n	lit:lemma	užkrečiama liga
 00987863-n	lit:lemma	ugnies ruožas
-00170847-s	lit:lemma	patrauklus
+00170847-a	lit:lemma	patrauklus
 13774404-n	lit:lemma	kalnas
 07294423-n	lit:lemma	atpildas
 03610270-n	lit:lemma	suvenyras
-01961205-s	lit:lemma	atsitiktinis
+01961205-a	lit:lemma	atsitiktinis
 09090825-n	lit:lemma	Luiziana
 08967868-n	lit:lemma	Monakas
 02380745-n	lit:lemma	pusiau laukinis arklys
 06526291-n	lit:lemma	partnerystė
 01494273-a	lit:lemma	sezoninis
 02403325-n	lit:lemma	jautis
-00076127-s	lit:lemma	palankus
+00076127-a	lit:lemma	palankus
 14006945-n	lit:lemma	veiksmas
 08956760-n	lit:lemma	Laoso Liaudies Demokratinė Respublika
 02479323-v	lit:lemma	aprūpinti
@@ -13873,14 +13873,14 @@
 09767197-n	lit:lemma	atlikėjas
 10352299-n	lit:lemma	kaimynas
 01056236-n	lit:lemma	lankymasis
-01276150-s	lit:lemma	svarbiausias
+01276150-a	lit:lemma	svarbiausias
 02771564-v	lit:lemma	užlieti
 08613000-n	lit:lemma	pakrantė
 14033185-n	lit:lemma	lemiamas momentas
 14539268-n	lit:lemma	apsauga
-01794995-s	lit:lemma	barokinis
+01794995-a	lit:lemma	barokinis
 02157041-a	lit:lemma	basas
-01518860-s	lit:lemma	karo
+01518860-a	lit:lemma	karo
 10450303-n	lit:lemma	politikos veikėjas
 00258677-r	lit:lemma	laukan
 03633091-n	lit:lemma	samtis
@@ -13889,7 +13889,7 @@
 07987380-n	lit:lemma	ketvertas
 00112231-a	lit:lemma	analitinis
 00259894-n	lit:lemma	atlyginimas
-00370869-s	lit:lemma	melsvas
+00370869-a	lit:lemma	melsvas
 01614343-n	lit:lemma	kilnusis erelis
 05722427-n	lit:lemma	lytėjimo pojūtis
 00022829-r	lit:lemma	kone
@@ -13904,20 +13904,20 @@
 07143137-n	lit:lemma	pasitarimas
 02387581-n	lit:lemma	ieninis arklys
 04753455-n	lit:lemma	neabejotinas dalykas
-02418692-s	lit:lemma	neįmanomas
+02418692-a	lit:lemma	neįmanomas
 01245813-n	lit:lemma	metimas
-01987646-s	lit:lemma	nutolęs
+01987646-a	lit:lemma	nutolęs
 00476819-a	lit:lemma	patogus
 00079951-v	lit:lemma	plauti
 07330007-n	lit:lemma	likimas
 07470110-n	lit:lemma	kūjo metimas
 00065822-r	lit:lemma	pabaigoje
-01987646-s	lit:lemma	santūrus
+01987646-a	lit:lemma	santūrus
 02636708-a	lit:lemma	vandeningas
 01378556-v	lit:lemma	platinti
 03379204-n	lit:lemma	futbolo aikštė
 03327234-n	lit:lemma	tvora
-01131454-s	lit:lemma	brutalus
+01131454-a	lit:lemma	brutalus
 00311809-n	lit:lemma	iškyla
 08954611-n	lit:lemma	Korėjos pusiasalis
 06671484-n	lit:lemma	patarimai
@@ -13925,7 +13925,7 @@
 13779374-n	lit:lemma	talpa
 03882058-n	lit:lemma	plokštė
 15295045-n	lit:lemma	suklestėjimas
-00599005-s	lit:lemma	suvaldytas
+00599005-a	lit:lemma	suvaldytas
 06885083-n	lit:lemma	tapatybės nustatymas
 00948071-v	lit:lemma	suskaičiuoti
 03047071-a	lit:lemma	krikšto
@@ -13934,13 +13934,13 @@
 02976641-n	lit:lemma	kartečė
 00004819-v	lit:lemma	čiaudėti
 02716605-a	lit:lemma	ekonominis
-01378429-s	lit:lemma	suprastas
+01378429-a	lit:lemma	suprastas
 00076196-n	lit:lemma	etiketo pažeidimas
 02993702-a	lit:lemma	humanitarinis
 08388207-n	lit:lemma	diduomenė
 00179112-r	lit:lemma	tiktai
 13878306-n	lit:lemma	ovalas
-00793592-s	lit:lemma	antraeilis
+00793592-a	lit:lemma	antraeilis
 00325343-r	lit:lemma	kraštu
 05118251-n	lit:lemma	nesusivaldymas
 11475279-n	lit:lemma	žaibas
@@ -13948,7 +13948,7 @@
 09324118-n	lit:lemma	Karos jūra
 06376572-n	lit:lemma	proza
 15140190-n	lit:lemma	nedarbingumo pažymėjimo turėjimas
-00440292-s	lit:lemma	kvailas
+00440292-a	lit:lemma	kvailas
 01180351-v	lit:lemma	patiekti
 00015303-v	lit:lemma	snūduriuoti
 00210797-n	lit:lemma	pabaiga
@@ -13957,20 +13957,20 @@
 00274022-r	lit:lemma	neįprastai
 08512259-n	lit:lemma	riba
 09575548-n	lit:lemma	Atlantas
-00839225-s	lit:lemma	veiksmingas
+00839225-a	lit:lemma	veiksmingas
 00455599-n	lit:lemma	rungtynės
 02920951-a	lit:lemma	katalikiškas
 05910940-n	lit:lemma	darbotvarkė
 00357680-n	lit:lemma	tirštinimas
 08198398-n	lit:lemma	būrys
-00370869-s	lit:lemma	žydras
+00370869-a	lit:lemma	žydras
 00139508-r	lit:lemma	deramai
 01031256-v	lit:lemma	išsiųsti
-00719442-s	lit:lemma	kaprizingas
+00719442-a	lit:lemma	kaprizingas
 00778958-a	lit:lemma	medialinis
-02275412-s	lit:lemma	stiprus
+02275412-a	lit:lemma	stiprus
 14997529-n	lit:lemma	konservantas
-01280908-s	lit:lemma	bereikšmis
+01280908-a	lit:lemma	bereikšmis
 06308304-n	lit:lemma	priešdėlis
 03074922-a	lit:lemma	genties
 04849759-n	lit:lemma	skaistybė
@@ -13978,17 +13978,17 @@
 02873811-a	lit:lemma	gyslų
 02331046-n	lit:lemma	žiurkė
 01573515-v	lit:lemma	plyšti
-01593079-s	lit:lemma	įprastas
+01593079-a	lit:lemma	įprastas
 15266164-n	lit:lemma	pradžia
-02059381-s	lit:lemma	netikras
+02059381-a	lit:lemma	netikras
 01573515-v	lit:lemma	trūkti
 08438223-n	lit:lemma	krūmynas
 01099592-v	lit:lemma	pralaimėti
 05241072-n	lit:lemma	odos ląstelė
-02522938-s	lit:lemma	autonominis
+02522938-a	lit:lemma	autonominis
 02396088-n	lit:lemma	kiaulė
 04071102-n	lit:lemma	prieglobstis
-02449952-s	lit:lemma	nuodingas
+02449952-a	lit:lemma	nuodingas
 01269073-a	lit:lemma	alkanas
 13306870-n	lit:lemma	mokestis
 00019613-n	lit:lemma	medžiaga
@@ -14010,13 +14010,13 @@
 14074041-n	lit:lemma	ligos komplikacija
 08053905-n	lit:lemma	gydymo įstaiga
 00084223-r	lit:lemma	ypatingai
-00937341-s	lit:lemma	neįpratęs
+00937341-a	lit:lemma	neįpratęs
 00625393-a	lit:lemma	realus
 14424517-n	lit:lemma	renovacija
 00199707-n	lit:lemma	modifikacija
 04589745-n	lit:lemma	langas
-01618376-s	lit:lemma	matomas
-00126830-s	lit:lemma	paruošiamasis
+01618376-a	lit:lemma	matomas
+00126830-a	lit:lemma	paruošiamasis
 00015713-v	lit:lemma	pramiegoti
 07516756-n	lit:lemma	pasipiktinimas
 03416329-n	lit:lemma	plyšys
@@ -14024,8 +14024,8 @@
 00048739-r	lit:lemma	nedelsiant
 02891188-n	lit:lemma	stabdžių sistema
 01517081-a	lit:lemma	kariuomenės
-01973311-s	lit:lemma	prijungtas
-00405879-s	lit:lemma	blyškus
+01973311-a	lit:lemma	prijungtas
+00405879-a	lit:lemma	blyškus
 05300231-n	lit:lemma	cheminis receptorius
 00180611-r	lit:lemma	savarankiškai
 00081572-n	lit:lemma	pirkimas
@@ -14054,8 +14054,8 @@
 13996719-n	lit:lemma	priespauda
 08219226-n	lit:lemma	divizionas
 00967129-a	lit:lemma	neįprastas
-02144436-s	lit:lemma	elastingas
-00816160-s	lit:lemma	įsiterpiantis
+02144436-a	lit:lemma	elastingas
+00816160-a	lit:lemma	įsiterpiantis
 02053941-v	lit:lemma	priartėti
 07460546-n	lit:lemma	maratonas
 14524849-n	lit:lemma	atmosfera
@@ -14069,20 +14069,20 @@
 05872742-n	lit:lemma	principai
 01904930-v	lit:lemma	vaikščioti
 00236989-a	lit:lemma	vienpusis
-01780343-s	lit:lemma	protinis
+01780343-a	lit:lemma	protinis
 05891572-n	lit:lemma	planas
-01930004-s	lit:lemma	nesąveikaujantis
+01930004-a	lit:lemma	nesąveikaujantis
 06642138-n	lit:lemma	žinios
 08981244-n	lit:lemma	Filipinų Respublika
 03405265-n	lit:lemma	apstatymas
 03800933-n	lit:lemma	muzikos instrumentas
 10162991-n	lit:lemma	vadovas
-01464700-s	lit:lemma	meilus
+01464700-a	lit:lemma	meilus
 00681429-v	lit:lemma	išmatuoti
 13809920-n	lit:lemma	detalė
 07578363-n	lit:lemma	porcija
 00431552-n	lit:lemma	hobis
-02130821-s	lit:lemma	atviras
+02130821-a	lit:lemma	atviras
 07204911-n	lit:lemma	paneigimas
 14420464-n	lit:lemma	sankiba
 14788332-n	lit:lemma	butano rūgštis
@@ -14127,7 +14127,7 @@
 02589245-v	lit:lemma	susidėti
 08226978-n	lit:lemma	kaimelis
 06722453-n	lit:lemma	pareiškimas
-01122595-s	lit:lemma	nepažįstamas
+01122595-a	lit:lemma	nepažįstamas
 02666624-n	lit:lemma	baterija
 13303315-n	lit:lemma	kaina
 15224486-n	lit:lemma	terminas
@@ -14137,14 +14137,14 @@
 13623636-n	lit:lemma	kubinis centimetras
 04697267-n	lit:lemma	nepretenzingumas
 00670741-a	lit:lemma	palaimintas
-01439496-s	lit:lemma	nuolatinis
+01439496-a	lit:lemma	nuolatinis
 03541091-n	lit:lemma	palata
 03247620-n	lit:lemma	vaistas
 14328290-n	lit:lemma	kryžmens skausmas
-01059711-s	lit:lemma	tvirtas
+01059711-a	lit:lemma	tvirtas
 05361123-n	lit:lemma	poodinė vena
 04164989-n	lit:lemma	atkarpa
-00750296-s	lit:lemma	elementarus
+00750296-a	lit:lemma	elementarus
 02746897-a	lit:lemma	imperijos
 10378026-n	lit:lemma	žiūrovas
 14501726-n	lit:lemma	išsigimimas
@@ -14156,7 +14156,7 @@
 09279161-n	lit:lemma	fermionas
 01301624-a	lit:lemma	industrinis
 01215392-n	lit:lemma	pritarimas
-01385773-s	lit:lemma	milžiniškas
+01385773-a	lit:lemma	milžiniškas
 07403300-n	lit:lemma	kvadratūrinis potvynis ir atoslūgis
 00035718-r	lit:lemma	pakankamai
 00123170-v	lit:lemma	pakeisti
@@ -14172,19 +14172,19 @@
 08795974-n	lit:lemma	Gomora
 03718458-n	lit:lemma	dvaras
 00077981-n	lit:lemma	užsikrėtimas
-01464700-s	lit:lemma	lipšnus
+01464700-a	lit:lemma	lipšnus
 15163797-n	lit:lemma	sekmadienis
-02119716-s	lit:lemma	tikras
-00228645-s	lit:lemma	optimalus
+02119716-a	lit:lemma	tikras
+00228645-a	lit:lemma	optimalus
 05808557-n	lit:lemma	lingvistinis procesas
 00963570-v	lit:lemma	šnekėti
-00714763-s	lit:lemma	prašomas
+00714763-a	lit:lemma	prašomas
 14526764-n	lit:lemma	neimlumas
 04649051-n	lit:lemma	linksmumas
-00505853-s	lit:lemma	neprilygstamas
-01038580-s	lit:lemma	komunalinis
+00505853-a	lit:lemma	neprilygstamas
+01038580-a	lit:lemma	komunalinis
 00315390-n	lit:lemma	buriavimas
-01731786-s	lit:lemma	esamas
+01731786-a	lit:lemma	esamas
 03716327-n	lit:lemma	figūrėlė
 10464178-n	lit:lemma	pamokslininkas
 00409597-r	lit:lemma	niekada daugiau
@@ -14196,21 +14196,21 @@
 06545843-n	lit:lemma	vienašalis įsipareigojimas
 03177349-n	lit:lemma	saugykla
 02961099-a	lit:lemma	austriškas
-01644847-s	lit:lemma	senovinis
+01644847-a	lit:lemma	senovinis
 02325884-n	lit:lemma	vandeninis triušis
 05699770-n	lit:lemma	netikrumas
-01333118-s	lit:lemma	racionalus
+01333118-a	lit:lemma	racionalus
 07677982-n	lit:lemma	kiaulienos dešrelė
 06607809-n	lit:lemma	nesąmonė
-00592880-s	lit:lemma	pasikartojantis
+00592880-a	lit:lemma	pasikartojantis
 13742573-n	lit:lemma	vienas
 14585519-n	lit:lemma	gabaliukas
 00254059-r	lit:lemma	prieš laikrodžio rodyklę
-00888200-s	lit:lemma	trokštantis
+00888200-a	lit:lemma	trokštantis
 07456906-n	lit:lemma	raundas
 09625401-n	lit:lemma	pilietis
 07573696-n	lit:lemma	valgis
-00590271-s	lit:lemma	nerimastingas
+00590271-a	lit:lemma	nerimastingas
 14493716-n	lit:lemma	nepriteklius
 04881369-n	lit:lemma	paprastumas
 10612210-n	lit:lemma	suskretėlis
@@ -14224,7 +14224,7 @@
 02376277-a	lit:lemma	simpatiškas
 00770543-n	lit:lemma	peržengimas
 00402308-n	lit:lemma	metamorfozė
-01320705-s	lit:lemma	nepeiktinas
+01320705-a	lit:lemma	nepeiktinas
 00086809-n	lit:lemma	užėmimas
 03259505-n	lit:lemma	butas
 01240210-n	lit:lemma	intervencija
@@ -14235,14 +14235,14 @@
 00356339-a	lit:lemma	kintamas
 03081021-n	lit:lemma	elementas
 00475845-r	lit:lemma	meiliai
-01936184-s	lit:lemma	mitologinis
+01936184-a	lit:lemma	mitologinis
 13306870-n	lit:lemma	rinkliava
 00139508-r	lit:lemma	tinkamai
 06808720-n	lit:lemma	matematinė ženklų sistema
 03682487-n	lit:lemma	spyna
 01997910-a	lit:lemma	neatsakingas
 00408205-r	lit:lemma	būtinai
-00070111-s	lit:lemma	kosmetinis
+00070111-a	lit:lemma	kosmetinis
 00017531-v	lit:lemma	eiti miegoti
 07884567-n	lit:lemma	alkoholis
 00476819-a	lit:lemma	jaukus
@@ -14253,10 +14253,10 @@
 00135148-n	lit:lemma	smūgis
 13623455-n	lit:lemma	kubinis milimetras
 02814774-n	lit:lemma	paplūdimio drabužiai
-00554098-s	lit:lemma	neatitinkantis
+00554098-a	lit:lemma	neatitinkantis
 13624509-n	lit:lemma	dekalitras
 05602548-n	lit:lemma	kakta
-01143138-s	lit:lemma	laipsniškas
+01143138-a	lit:lemma	laipsniškas
 00203922-r	lit:lemma	tiksliai
 00987071-v	lit:lemma	nupasakoti
 06828389-n	lit:lemma	žvaigždutė
@@ -14273,32 +14273,32 @@
 00356926-a	lit:lemma	būdingas
 00044353-a	lit:lemma	galimas
 13783581-n	lit:lemma	matematinis santykis
-02067491-s	lit:lemma	skirtingas
-00157268-s	lit:lemma	užsidaręs
+02067491-a	lit:lemma	skirtingas
+00157268-a	lit:lemma	užsidaręs
 00033615-n	lit:lemma	kiekis
 02867783-a	lit:lemma	muzikinis
 02905794-a	lit:lemma	psichologinis
 13809207-n	lit:lemma	sandas
-02110447-s	lit:lemma	pavienis
+02110447-a	lit:lemma	pavienis
 07409592-n	lit:lemma	sąlytis
 04857738-n	lit:lemma	didvyriškumas
 02904518-a	lit:lemma	nervų
 07945490-n	lit:lemma	pasmerktasis
-00910101-s	lit:lemma	lygus
-01707733-s	lit:lemma	slaptas
+00910101-a	lit:lemma	lygus
+01707733-a	lit:lemma	slaptas
 09857200-n	lit:lemma	vyskupas
 09573966-n	lit:lemma	Jupiteris
 06637824-n	lit:lemma	pagrindas
-01698103-s	lit:lemma	išklotas plytelėmis
-00432453-s	lit:lemma	vaiskus
+01698103-a	lit:lemma	išklotas plytelėmis
+00432453-a	lit:lemma	vaiskus
 05644527-n	lit:lemma	našumas
 05711084-n	lit:lemma	kontrastas
 08374049-n	lit:lemma	kolonija
 10306181-n	lit:lemma	medicinos studentas
 04606574-n	lit:lemma	veržliaraktis
-00130518-s	lit:lemma	rytinis
+00130518-a	lit:lemma	rytinis
 09287968-n	lit:lemma	formacija
-01284212-s	lit:lemma	jaudinantis
+01284212-a	lit:lemma	jaudinantis
 00850425-n	lit:lemma	kryžminimas
 06400510-n	lit:lemma	fragmentas
 00754767-n	lit:lemma	iliuzija
@@ -14310,12 +14310,12 @@
 02513269-a	lit:lemma	skaistus
 03211117-n	lit:lemma	vaizduoklis
 08613472-n	lit:lemma	išorinė pusė
-00516231-s	lit:lemma	ištisas
+00516231-a	lit:lemma	ištisas
 06378627-n	lit:lemma	humoristinis ketureilis eilėraštukas
 02807731-n	lit:lemma	vonios kambarys
 06078327-n	lit:lemma	morfologija
 06773434-n	lit:lemma	sutartis
-02074673-s	lit:lemma	velniškas
+02074673-a	lit:lemma	velniškas
 04766275-n	lit:lemma	painumas
 00180413-n	lit:lemma	priėmimas
 07035420-n	lit:lemma	religinė giesmė
@@ -14324,26 +14324,26 @@
 00282103-r	lit:lemma	apdairiai
 10613996-n	lit:lemma	gražuolė
 14832193-n	lit:lemma	RNR
-01706465-s	lit:lemma	slaptas
+01706465-a	lit:lemma	slaptas
 00367427-n	lit:lemma	didinimas
 06930427-n	lit:lemma	Kantono tarmė
-00847715-s	lit:lemma	nemokamas
+00847715-a	lit:lemma	nemokamas
 00543233-n	lit:lemma	muzikavimas
 00431552-n	lit:lemma	užsiėmimas
-00032733-s	lit:lemma	vikrus
-01764895-s	lit:lemma	apsauginis
-00195383-s	lit:lemma	baisus
+00032733-a	lit:lemma	vikrus
+01764895-a	lit:lemma	apsauginis
+00195383-a	lit:lemma	baisus
 00442361-a	lit:lemma	tolimas
 02207206-v	lit:lemma	pirkti
-00461609-s	lit:lemma	miglotas
+00461609-a	lit:lemma	miglotas
 00004184-r	lit:lemma	neigiamai
 03117939-n	lit:lemma	kopija
 08968677-n	lit:lemma	Mongolija
-02332845-s	lit:lemma	garantuotas
+02332845-a	lit:lemma	garantuotas
 01509527-a	lit:lemma	smarkus
 01619929-v	lit:lemma	sunaikinti
 08715110-n	lit:lemma	Pietryčių Azija
-00148852-s	lit:lemma	gudrus
+00148852-a	lit:lemma	gudrus
 00975171-a	lit:lemma	skoningas
 00011982-v	lit:lemma	šundaktariauti
 07927197-n	lit:lemma	gaivusis gėrimas
@@ -14352,7 +14352,7 @@
 00022717-r	lit:lemma	beveik
 00053097-n	lit:lemma	atsisveikinimas
 07520612-n	lit:lemma	siaubas
-01158180-s	lit:lemma	negailestingas
+01158180-a	lit:lemma	negailestingas
 11424400-n	lit:lemma	alternatyvioji energija
 00475845-r	lit:lemma	švelniai
 05838765-n	lit:lemma	kategorija
@@ -14362,21 +14362,21 @@
 10030277-n	lit:lemma	dramaturgas
 09795010-n	lit:lemma	autorius
 02541509-v	lit:lemma	atstovauti
-01263013-s	lit:lemma	nuožmus
-02388921-s	lit:lemma	naminis
+01263013-a	lit:lemma	nuožmus
+02388921-a	lit:lemma	naminis
 05647643-n	lit:lemma	nemokėjimas
 00167447-r	lit:lemma	galų gale
 00874806-n	lit:lemma	įkainojimas
-01318741-s	lit:lemma	sužeistas
+01318741-a	lit:lemma	sužeistas
 12709688-n	lit:lemma	greipfrutinis citrinmedis
-00798103-s	lit:lemma	labai girtas
+00798103-a	lit:lemma	labai girtas
 08960987-n	lit:lemma	Liuksemburgas
-00505853-s	lit:lemma	vienintelis
+00505853-a	lit:lemma	vienintelis
 09069862-n	lit:lemma	Delaveras
 11688750-n	lit:lemma	motininė ląstelė
 03077419-a	lit:lemma	žurnalistinis
-01789481-s	lit:lemma	dėmėtas
-00326608-s	lit:lemma	impulsyvus
+01789481-a	lit:lemma	dėmėtas
+00326608-a	lit:lemma	impulsyvus
 14464675-n	lit:lemma	klaida
 05625465-n	lit:lemma	fantazija
 09326662-n	lit:lemma	kalnelis
@@ -14386,29 +14386,29 @@
 00897746-v	lit:lemma	klausti
 02978781-a	lit:lemma	nosinis
 00418394-n	lit:lemma	pykdymas
-00331167-s	lit:lemma	vidurinis
+00331167-a	lit:lemma	vidurinis
 14010148-n	lit:lemma	neveikimas
 09085593-n	lit:lemma	Indianapolis
 05621439-n	lit:lemma	sumanumas
-01573238-s	lit:lemma	netikras
+01573238-a	lit:lemma	netikras
 03605722-n	lit:lemma	susidūrimo vieta
 04688246-n	lit:lemma	patrauklumas
 00823532-n	lit:lemma	apgynimas
 07941945-n	lit:lemma	biomas
 02959912-a	lit:lemma	norvegiškas
 02912065-n	lit:lemma	bufetas
-01041209-s	lit:lemma	malonus
+01041209-a	lit:lemma	malonus
 04664778-n	lit:lemma	budrumas
 09028062-n	lit:lemma	Katalonija
 00293650-r	lit:lemma	piktai
 00050693-n	lit:lemma	pasirodymas
-01941604-s	lit:lemma	realus
+01941604-a	lit:lemma	realus
 07051975-n	lit:lemma	tekstas
-02418093-s	lit:lemma	įmanomas
+02418093-a	lit:lemma	įmanomas
 05367341-n	lit:lemma	veido vena
 03114359-a	lit:lemma	uolinis
 03557141-n	lit:lemma	ledo kubelis
-01443097-s	lit:lemma	trumpalaikis
+01443097-a	lit:lemma	trumpalaikis
 00001740-n	lit:lemma	egzistuojantis daiktas
 03876519-n	lit:lemma	piešinys
 03871083-n	lit:lemma	ryšulys
@@ -14420,7 +14420,7 @@
 02710402-v	lit:lemma	sueiti
 10569744-n	lit:lemma	asistentas
 00835609-a	lit:lemma	neveiksmingas
-01516346-s	lit:lemma	įsipainiojęs
+01516346-a	lit:lemma	įsipainiojęs
 01975138-a	lit:lemma	susijęs
 07802417-n	lit:lemma	grūdai
 10676018-n	lit:lemma	vyresnysis
@@ -14434,7 +14434,7 @@
 00908492-n	lit:lemma	kūryba
 00074095-r	lit:lemma	prieš tai
 03551084-n	lit:lemma	hidraulinis stabdys
-02418692-s	lit:lemma	negalimas
+02418692-a	lit:lemma	negalimas
 00263000-n	lit:lemma	puošimas
 06070929-n	lit:lemma	ekologija
 14127211-n	lit:lemma	užkrečiamoji liga
@@ -14445,13 +14445,13 @@
 03128519-n	lit:lemma	kremas
 05311054-n	lit:lemma	akis
 08587828-n	lit:lemma	grafystė
-01159907-s	lit:lemma	nepavojingas
-01423851-s	lit:lemma	gyvenamas
-01010271-s	lit:lemma	galutinis
+01159907-a	lit:lemma	nepavojingas
+01423851-a	lit:lemma	gyvenamas
+01010271-a	lit:lemma	galutinis
 03997027-n	lit:lemma	energetinė sistema
 02064745-a	lit:lemma	įvairus
 14519366-n	lit:lemma	klimatas
-00310433-s	lit:lemma	smulkus
+00310433-a	lit:lemma	smulkus
 01504130-v	lit:lemma	išdėlioti
 00021212-r	lit:lemma	retkarčiais
 02773838-n	lit:lemma	lagaminas
@@ -14459,12 +14459,12 @@
 03225238-n	lit:lemma	dozė
 01078086-n	lit:lemma	diskvalifikacija
 05273822-n	lit:lemma	skruostakaulis
-00445169-s	lit:lemma	gretimas
-00852754-s	lit:lemma	teisėtas
+00445169-a	lit:lemma	gretimas
+00852754-a	lit:lemma	teisėtas
 10011902-n	lit:lemma	diktatorius
 03138128-n	lit:lemma	kabliukas
 00029343-a	lit:lemma	godus
-00115777-s	lit:lemma	įtūžęs
+00115777-a	lit:lemma	įtūžęs
 00893955-n	lit:lemma	ruošimas
 02991555-n	lit:lemma	vienutė
 01117541-n	lit:lemma	pardavimas
@@ -14477,57 +14477,57 @@
 02411999-n	lit:lemma	avis
 08464601-n	lit:lemma	visuomeninis judėjimas
 05025413-n	lit:lemma	mastas
-02164913-s	lit:lemma	silpnas
+02164913-a	lit:lemma	silpnas
 06733227-n	lit:lemma	tvirtinimas
-01038580-s	lit:lemma	savivaldybės
-02446931-s	lit:lemma	trapus
+01038580-a	lit:lemma	savivaldybės
+02446931-a	lit:lemma	trapus
 07377682-n	lit:lemma	dundesys
 03025590-a	lit:lemma	Alpių
 07484547-n	lit:lemma	svajonė
 02839351-n	lit:lemma	biliardo rutulys
 03870546-n	lit:lemma	ryšulys
 07849336-n	lit:lemma	jogurtas
-00182225-s	lit:lemma	automatinis
+00182225-a	lit:lemma	automatinis
 00635850-n	lit:lemma	tyrimas
-01178458-s	lit:lemma	išsiplėtęs
+01178458-a	lit:lemma	išsiplėtęs
 03287178-n	lit:lemma	išdirbis
 10346015-n	lit:lemma	nacionalistas
-01131454-s	lit:lemma	žvėriškas
+01131454-a	lit:lemma	žvėriškas
 03592773-n	lit:lemma	stakta
 08927836-n	lit:lemma	Jerichas
-00979366-s	lit:lemma	greitas
+00979366-a	lit:lemma	greitas
 08820121-n	lit:lemma	Kanada
 05462674-n	lit:lemma	nervų sistemos dalis
 13758296-n	lit:lemma	apribojimas
 02687423-n	lit:lemma	aviacinis variklis
 15210870-n	lit:lemma	kovas
 00566099-a	lit:lemma	sujungtas
-01880918-s	lit:lemma	netinkamas
+01880918-a	lit:lemma	netinkamas
 01482228-a	lit:lemma	nesusituokęs
 01177703-n	lit:lemma	manifestacija
-02280333-s	lit:lemma	gyvas
+02280333-a	lit:lemma	gyvas
 09895701-n	lit:lemma	prižiūrėtojas
 15238895-n	lit:lemma	lietaus sezonas
-00115777-s	lit:lemma	rūstus
+00115777-a	lit:lemma	rūstus
 15142167-n	lit:lemma	kilimas
 09025863-n	lit:lemma	Granada
 03008565-n	lit:lemma	herbas
 06366391-n	lit:lemma	dialogas
 10140314-n	lit:lemma	gubernatorius
-02347086-s	lit:lemma	vargingas
+02347086-a	lit:lemma	vargingas
 00039297-n	lit:lemma	ryšys
-01779428-s	lit:lemma	asmeninis
+01779428-a	lit:lemma	asmeninis
 00305283-r	lit:lemma	noromis
 00425451-n	lit:lemma	pykdymas
 14066203-n	lit:lemma	kolapsas
 02540347-v	lit:lemma	suaugti
 10230736-n	lit:lemma	kūdikis
 00420477-n	lit:lemma	persekiojimas
-00978754-s	lit:lemma	tiesioginis
+00978754-a	lit:lemma	tiesioginis
 00044353-a	lit:lemma	potencialus
 02963942-a	lit:lemma	serbų
 02020590-v	lit:lemma	pasiekti
-01362387-s	lit:lemma	graudus
+01362387-a	lit:lemma	graudus
 00039592-a	lit:lemma	neveiklus
 00110533-r	lit:lemma	viduje
 02528380-v	lit:lemma	nepasisekti
@@ -14546,16 +14546,16 @@
 00235208-n	lit:lemma	atžanga
 00987071-v	lit:lemma	apibūdinti
 05820620-n	lit:lemma	pavyzdys
-01081340-s	lit:lemma	vaisingas
+01081340-a	lit:lemma	vaisingas
 10667187-n	lit:lemma	bukagalvis
 01041061-v	lit:lemma	užsičiaupti
-01462324-s	lit:lemma	brangus
+01462324-a	lit:lemma	brangus
 03073977-n	lit:lemma	kolona
 07412092-n	lit:lemma	žaibas
 08630039-n	lit:lemma	teritorija
 00297404-n	lit:lemma	klajojimas
 00233573-r	lit:lemma	dėl
-00915420-s	lit:lemma	fotografiškas
+00915420-a	lit:lemma	fotografiškas
 03346455-n	lit:lemma	židinys
 01415605-a	lit:lemma	beribis
 05568767-n	lit:lemma	alkūninis nervas
@@ -14568,13 +14568,13 @@
 05618056-n	lit:lemma	protiniai sugebėjimai
 00228724-r	lit:lemma	mintyse
 00187120-r	lit:lemma	maloniai
-02502578-s	lit:lemma	nevykęs
+02502578-a	lit:lemma	nevykęs
 05026312-n	lit:lemma	molekulinė masė
 04508949-n	lit:lemma	apatiniai
 06592991-n	lit:lemma	archyvas
 14820180-n	lit:lemma	betonas
 13781348-n	lit:lemma	bendradarbiavimas
-00748359-s	lit:lemma	svarbus
+00748359-a	lit:lemma	svarbus
 13920835-n	lit:lemma	būvis
 00540235-v	lit:lemma	plėstis
 03567066-n	lit:lemma	perėtuvas
@@ -14583,7 +14583,7 @@
 02918112-n	lit:lemma	arena (koridos)
 10102800-n	lit:lemma	šeimos pradininkas
 13746512-n	lit:lemma	dešimtis
-02369027-s	lit:lemma	kartus
+02369027-a	lit:lemma	kartus
 09889539-n	lit:lemma	operatorius
 00643250-a	lit:lemma	kūrybingas
 04916342-n	lit:lemma	savybė
@@ -14593,14 +14593,14 @@
 14448333-n	lit:lemma	neganda
 14452151-n	lit:lemma	prisisotinimas
 06758225-n	lit:lemma	apgaulė
-00431004-s	lit:lemma	nesuprantamas
+00431004-a	lit:lemma	nesuprantamas
 08301525-n	lit:lemma	Tarptautinė darbo organizacija
 00470988-r	lit:lemma	neatidėliotinai
-00160768-s	lit:lemma	atskiras
+00160768-a	lit:lemma	atskiras
 03278248-n	lit:lemma	elektroninė įranga
 10371450-n	lit:lemma	pareigūnas
 05856217-n	lit:lemma	nulinis taškas
-02114613-s	lit:lemma	pūlinis
+02114613-a	lit:lemma	pūlinis
 05949726-n	lit:lemma	viešoji nuomonė
 10078131-n	lit:lemma	mėgėjas
 03478907-n	lit:lemma	salė
@@ -14608,35 +14608,35 @@
 03443912-n	lit:lemma	apsauginiai akiniai
 10182499-n	lit:lemma	namo savininkas
 02917694-a	lit:lemma	gimdymo
-00886253-s	lit:lemma	užsidegęs
+00886253-a	lit:lemma	užsidegęs
 00802238-n	lit:lemma	pavojingas žygis
 00014201-v	lit:lemma	drebėti
 11481334-n	lit:lemma	trajektorija
 00237636-r	lit:lemma	sąmoningai
-00974519-s	lit:lemma	pasenęs
+00974519-a	lit:lemma	pasenęs
 08008017-n	lit:lemma	ryšulys
 11450566-n	lit:lemma	elektra
 11419404-n	lit:lemma	fizinis reiškinys
 05261566-n	lit:lemma	barzda
-00935103-s	lit:lemma	įperkamas
+00935103-a	lit:lemma	įperkamas
 09633969-n	lit:lemma	nusikaltėlis
 08428756-n	lit:lemma	greta
 01317541-n	lit:lemma	naminis gyvūnas
 02924554-n	lit:lemma	senas apiręs automobilis
 00789391-n	lit:lemma	peštynės
 02711846-a	lit:lemma	skersmeninis
-00021110-s	lit:lemma	paslaugus
+00021110-a	lit:lemma	paslaugus
 07649854-n	lit:lemma	mėsa
 10757193-n	lit:lemma	svečias
-01880918-s	lit:lemma	nepadorus
+01880918-a	lit:lemma	nepadorus
 00071165-r	lit:lemma	netoli
 04830689-n	lit:lemma	brutalumas
 07292694-n	lit:lemma	rezultatas
 02737351-n	lit:lemma	Nojaus arka
-01723543-s	lit:lemma	nešališkas
+01723543-a	lit:lemma	nešališkas
 05698982-n	lit:lemma	skepticizmas
 13580415-n	lit:lemma	pakankamumas
-02090567-s	lit:lemma	krintantis į akis
+02090567-a	lit:lemma	krintantis į akis
 00048475-r	lit:lemma	šiais laikais
 02832678-a	lit:lemma	grybelinis
 08794366-n	lit:lemma	Gazos ruožas
@@ -14668,7 +14668,7 @@
 02285629-v	lit:lemma	rasti
 02267012-a	lit:lemma	išaiškintas
 09288769-n	lit:lemma	šaka (mokslo)
-02418692-s	lit:lemma	neįsivaizduojamas
+02418692-a	lit:lemma	neįsivaizduojamas
 01910965-v	lit:lemma	vaikštinėti
 03851787-n	lit:lemma	optinis diskas
 03038595-n	lit:lemma	klasikinis kūrinys
@@ -14684,7 +14684,7 @@
 07484547-n	lit:lemma	siekis
 04837425-n	lit:lemma	kovingumas
 15159819-n	lit:lemma	diena
-00808822-s	lit:lemma	besikeičiantis
+00808822-a	lit:lemma	besikeičiantis
 11524213-n	lit:lemma	vandens energija
 05556943-n	lit:lemma	pilvas
 00255710-n	lit:lemma	plovimas
@@ -14705,34 +14705,34 @@
 14747338-n	lit:lemma	progestinas
 04164529-n	lit:lemma	antras bėgis
 03953416-n	lit:lemma	maldos namai
-02500179-s	lit:lemma	klaidingas
-01874331-s	lit:lemma	mėgėjiškas
-02502578-s	lit:lemma	netikęs
+02500179-a	lit:lemma	klaidingas
+01874331-a	lit:lemma	mėgėjiškas
+02502578-a	lit:lemma	netikęs
 15211189-n	lit:lemma	balandis
 09307902-n	lit:lemma	hidrosfera
 09629752-n	lit:lemma	keliautojas
 02619424-v	lit:lemma	aplankyti
 00330457-n	lit:lemma	greitinimas
 05172596-n	lit:lemma	nereikšmingumas
-00933599-s	lit:lemma	brangus
-02064127-s	lit:lemma	identiškas
+00933599-a	lit:lemma	brangus
+02064127-a	lit:lemma	identiškas
 04955633-n	lit:lemma	blausumas
 09440400-n	lit:lemma	Pietų Amerika
-00709215-s	lit:lemma	trapus
+00709215-a	lit:lemma	trapus
 02684971-a	lit:lemma	dangiškas
 08717209-n	lit:lemma	Kamerūno Respublika
-02123579-s	lit:lemma	rinktinis
+02123579-a	lit:lemma	rinktinis
 00444519-a	lit:lemma	artimas
 00451866-n	lit:lemma	medžioklė
 02590340-v	lit:lemma	užimti
 03936895-n	lit:lemma	kontraceptinės tabletės
 00106170-r	lit:lemma	vogčia
-01933731-s	lit:lemma	realus
-02071782-s	lit:lemma	panašus
+01933731-a	lit:lemma	realus
+02071782-a	lit:lemma	panašus
 05644727-n	lit:lemma	ekonomija
 01012712-n	lit:lemma	rūšiavimas
-01789481-s	lit:lemma	lopiniuotas
-01689223-s	lit:lemma	lėkštas
+01789481-a	lit:lemma	lopiniuotas
+01689223-a	lit:lemma	lėkštas
 00501140-r	lit:lemma	iš principo
 02644234-v	lit:lemma	vyrauti
 02943241-n	lit:lemma	fotoaparato objektyvas
@@ -14740,9 +14740,9 @@
 15022617-n	lit:lemma	raumenų baltymas
 08440630-n	lit:lemma	diktatūra
 00279523-r	lit:lemma	stačiai
-01647983-s	lit:lemma	paauglių
+01647983-a	lit:lemma	paauglių
 02783324-n	lit:lemma	šokių salė
-02477557-s	lit:lemma	ištisas
+02477557-a	lit:lemma	ištisas
 06080361-n	lit:lemma	zimologija
 13112664-n	lit:lemma	krūmokšnis
 15147713-n	lit:lemma	jaunatvė
@@ -14751,8 +14751,8 @@
 04493505-n	lit:lemma	vamzdis
 00927017-a	lit:lemma	esamas
 04726724-n	lit:lemma	pobūdis
-00649892-s	lit:lemma	vertinantis
-00890351-s	lit:lemma	tolygus
+00649892-a	lit:lemma	vertinantis
+00890351-a	lit:lemma	tolygus
 00223983-n	lit:lemma	žudynės
 08750151-n	lit:lemma	Kuba
 02088086-a	lit:lemma	netinkamas plaukioti
@@ -14776,15 +14776,15 @@
 00258549-r	lit:lemma	gilyn
 05465868-n	lit:lemma	smegenų ląstelė
 04743605-n	lit:lemma	panašumas
-01378429-s	lit:lemma	perprastas
+01378429-a	lit:lemma	perprastas
 03009111-n	lit:lemma	iškilmių vežimas
 10200781-n	lit:lemma	žinomas asmuo
-00440489-s	lit:lemma	kvailas
+00440489-a	lit:lemma	kvailas
 10726786-n	lit:lemma	keliaujantis prekybininkas
-01912858-s	lit:lemma	primityvus
-02507772-s	lit:lemma	visapusiškas
+01912858-a	lit:lemma	primityvus
+02507772-a	lit:lemma	visapusiškas
 02349477-a	lit:lemma	esantis žemiau
-00968730-s	lit:lemma	keistas
+00968730-a	lit:lemma	keistas
 07151380-n	lit:lemma	idioma
 05199286-n	lit:lemma	veiksmingumas
 02863750-n	lit:lemma	garo katilas
@@ -14792,29 +14792,29 @@
 02402559-a	lit:lemma	vidutinis
 00164751-r	lit:lemma	dėl visa ko
 01036996-n	lit:lemma	santuoka
-02502994-s	lit:lemma	menkas
+02502994-a	lit:lemma	menkas
 06353757-n	lit:lemma	kodavimo sistema
-02241988-s	lit:lemma	akmenuotas
+02241988-a	lit:lemma	akmenuotas
 02899808-n	lit:lemma	tiltelio grandinė
-00969556-s	lit:lemma	neįprastas
+00969556-a	lit:lemma	neįprastas
 13872592-n	lit:lemma	kūgis
 08715390-n	lit:lemma	Birma
 01062555-v	lit:lemma	perduoti
 09468604-n	lit:lemma	klonis
 00607780-v	lit:lemma	prisiminti
 10522324-n	lit:lemma	niekšas
-01392249-s	lit:lemma	smulkutis
+01392249-a	lit:lemma	smulkutis
 13397174-n	lit:lemma	skola
 11503968-n	lit:lemma	elektrinė varža
 03722288-n	lit:lemma	turgus
-01709437-s	lit:lemma	apmokėtas iš anksto
+01709437-a	lit:lemma	apmokėtas iš anksto
 00634276-n	lit:lemma	skaidymas
 02965043-a	lit:lemma	japoniškas
-01644225-s	lit:lemma	vyresnis
+01644225-a	lit:lemma	vyresnis
 08440630-n	lit:lemma	absoliutizmas
 08300641-n	lit:lemma	Tarptautinė atominės energetikos agentūra
 03539875-n	lit:lemma	žarna
-01517632-s	lit:lemma	kovos
+01517632-a	lit:lemma	kovos
 13371030-n	lit:lemma	vertybė
 08684294-n	lit:lemma	aikštelė
 06344461-n	lit:lemma	antraštė
@@ -14822,16 +14822,16 @@
 04587648-n	lit:lemma	langas
 03442756-n	lit:lemma	vartai
 06944911-n	lit:lemma	čekų kalba
-01625063-s	lit:lemma	šlykštus
+01625063-a	lit:lemma	šlykštus
 00055101-r	lit:lemma	labai blogai
 03759432-n	lit:lemma	mikrofilmas
-00859632-s	lit:lemma	patirtinis
+00859632-a	lit:lemma	patirtinis
 00932367-a	lit:lemma	netinkamas
-01993693-s	lit:lemma	solidus
+01993693-a	lit:lemma	solidus
 03509025-n	lit:lemma	šildymas
 00363788-n	lit:lemma	pridėjimas
 06196584-n	lit:lemma	polinkis
-01442597-s	lit:lemma	sutrumpintas
+01442597-a	lit:lemma	sutrumpintas
 03051540-n	lit:lemma	apdaras
 08552138-n	lit:lemma	rajonas (administracinis vienetas)
 00024814-v	lit:lemma	atsigaivinti
@@ -14841,7 +14841,7 @@
 00048374-n	lit:lemma	atėjimas
 05708432-n	lit:lemma	suvokimas
 00239064-r	lit:lemma	pėsčiomis
-01539444-s	lit:lemma	paprastas
+01539444-a	lit:lemma	paprastas
 07217782-n	lit:lemma	instruktavimas
 10405694-n	lit:lemma	pacientas
 03206282-n	lit:lemma	diskoteka
@@ -14852,13 +14852,13 @@
 00041361-a	lit:lemma	veikiantis
 02062430-n	lit:lemma	banginių šeimos žinduolis
 01716227-a	lit:lemma	malonus
-01780596-s	lit:lemma	moralinis
-01804728-s	lit:lemma	šiurkštus
+01780596-a	lit:lemma	moralinis
+01804728-a	lit:lemma	šiurkštus
 12434775-n	lit:lemma	česnakas
 08792548-n	lit:lemma	Izraelis
 07679356-n	lit:lemma	duona
-01441271-s	lit:lemma	ilgalaikis
-00798491-s	lit:lemma	girtaujantis
+01441271-a	lit:lemma	ilgalaikis
+00798491-a	lit:lemma	girtaujantis
 08119525-n	lit:lemma	prekybos padalinys
 00713952-n	lit:lemma	krovimas
 00210651-r	lit:lemma	laisvai
@@ -14875,14 +14875,14 @@
 00228910-r	lit:lemma	nedrąsiai
 08907606-n	lit:lemma	Indonezija
 10112591-n	lit:lemma	draugas
-00579498-s	lit:lemma	krintantis į akį
-01243102-s	lit:lemma	baisus
+00579498-a	lit:lemma	krintantis į akį
+01243102-a	lit:lemma	baisus
 00331655-n	lit:lemma	perėjimas
 03412220-n	lit:lemma	laivo virtuvė
 00042614-r	lit:lemma	nelaimingai
 03775199-n	lit:lemma	maišiklis
 07698915-n	lit:lemma	makaronai
-02038994-s	lit:lemma	tvirtas
+02038994-a	lit:lemma	tvirtas
 01778212-a	lit:lemma	kūno
 00213875-r	lit:lemma	produktyviai
 05027529-n	lit:lemma	sunkumas
@@ -14893,17 +14893,17 @@
 02802976-a	lit:lemma	astralinis
 05585383-n	lit:lemma	griaučiai
 09024844-n	lit:lemma	Maljorka
-00860127-s	lit:lemma	bandomasis
+00860127-a	lit:lemma	bandomasis
 04746430-n	lit:lemma	paralelė
 07622708-n	lit:lemma	kepinys
 00009147-v	lit:lemma	mesti plunksnas
 09811852-n	lit:lemma	kanonierius
 00087188-r	lit:lemma	besąlygiškai
-00852197-s	lit:lemma	tinkamas
+00852197-a	lit:lemma	tinkamas
 01220984-n	lit:lemma	veikimas
 00361065-r	lit:lemma	taip pat
 09765278-n	lit:lemma	artistas
-00782216-s	lit:lemma	neaiškus
+00782216-a	lit:lemma	neaiškus
 04387201-n	lit:lemma	būgnas
 00005567-r	lit:lemma	nevalingai
 00036935-r	lit:lemma	aiškiai
@@ -14911,32 +14911,32 @@
 02886629-a	lit:lemma	leksinis
 10409634-n	lit:lemma	mokėjimo gavėjas
 02939185-n	lit:lemma	katilas
-02570643-s	lit:lemma	kvailas
-01282510-s	lit:lemma	baisus
-01144102-s	lit:lemma	žaibiškas
+02570643-a	lit:lemma	kvailas
+01282510-a	lit:lemma	baisus
+01144102-a	lit:lemma	žaibiškas
 00647270-n	lit:lemma	kiekybinė analizė
 10249011-n	lit:lemma	laureatas
-00547317-s	lit:lemma	kompaktiškas
-01390588-s	lit:lemma	milžiniškas
+00547317-a	lit:lemma	kompaktiškas
+01390588-a	lit:lemma	milžiniškas
 00249501-n	lit:lemma	vystymasis
 01508368-v	lit:lemma	mesti
 07122118-n	lit:lemma	triukšmas
 01170962-n	lit:lemma	dvikova
 10036929-n	lit:lemma	būgnininkas
-01535270-s	lit:lemma	radikalus
+01535270-a	lit:lemma	radikalus
 06671484-n	lit:lemma	patarimas
 00146572-n	lit:lemma	suartėjimas
-01084644-s	lit:lemma	pilnas
+01084644-a	lit:lemma	pilnas
 01824532-v	lit:lemma	linkėti
 09807754-n	lit:lemma	didikas
 00294459-r	lit:lemma	todėl
 01151110-v	lit:lemma	nusitaikyti
-00028471-s	lit:lemma	spėjamas
-02558528-s	lit:lemma	apstus
+00028471-a	lit:lemma	spėjamas
+02558528-a	lit:lemma	apstus
 15237044-n	lit:lemma	pavasaris
 01640855-v	lit:lemma	įvykdyti
 03040635-a	lit:lemma	Moravijos
-01870636-s	lit:lemma	neprofesionalus
+01870636-a	lit:lemma	neprofesionalus
 00251780-n	lit:lemma	grandymas
 06722453-n	lit:lemma	informacija
 05168261-n	lit:lemma	svarba
@@ -14947,59 +14947,59 @@
 08318691-n	lit:lemma	kongresas
 02118333-n	lit:lemma	lapė
 05855125-n	lit:lemma	kiekybė
-01568684-s	lit:lemma	visuotinis
-00026168-s	lit:lemma	pagrindinis
+01568684-a	lit:lemma	visuotinis
+00026168-a	lit:lemma	pagrindinis
 01719921-v	lit:lemma	vaidinti
-02018141-s	lit:lemma	poetinis
+02018141-a	lit:lemma	poetinis
 04750164-n	lit:lemma	skirtingumas
 04760024-n	lit:lemma	apčiuopiamumas
 05948264-n	lit:lemma	kultas
 03550153-n	lit:lemma	kareivinės
 11527014-n	lit:lemma	vėtra
-01648491-s	lit:lemma	vaikiškas
+01648491-a	lit:lemma	vaikiškas
 08620061-n	lit:lemma	punktas
 09972157-n	lit:lemma	drabužių dizaineris
 00978173-n	lit:lemma	kontrataka
 04881623-n	lit:lemma	drausmė
 03247620-n	lit:lemma	medikamentas
 01379705-a	lit:lemma	pažymėtas
-01936778-s	lit:lemma	fantastinis
+01936778-a	lit:lemma	fantastinis
 02991690-a	lit:lemma	sakinio
 00048138-r	lit:lemma	po kurio laiko
-01212095-s	lit:lemma	paskutinis
-01977488-s	lit:lemma	dėmesingas
+01212095-a	lit:lemma	paskutinis
+01977488-a	lit:lemma	dėmesingas
 14391660-n	lit:lemma	manija
 14421585-n	lit:lemma	jungtuvės
 00067966-a	lit:lemma	protingas
-00937616-s	lit:lemma	nepatyręs
+00937616-a	lit:lemma	nepatyręs
 08497294-n	lit:lemma	vietovė
 05018542-n	lit:lemma	apšvietimas
 09759311-n	lit:lemma	akademikas
-02557719-s	lit:lemma	maistingas
+02557719-a	lit:lemma	maistingas
 02733524-n	lit:lemma	arka
 01164394-n	lit:lemma	užmėtymas akmenimis
 00266401-n	lit:lemma	krizė
 02639087-n	lit:lemma	dumblažuvė
 09883174-n	lit:lemma	gatvės muzikantas
 03701391-n	lit:lemma	kulkosvaidis
-02573987-s	lit:lemma	užžėlęs
+02573987-a	lit:lemma	užžėlęs
 00018813-v	lit:lemma	budinti
 13902482-n	lit:lemma	smailuma
 00174987-r	lit:lemma	smarkiai
 05849284-n	lit:lemma	ypatybė
 13367070-n	lit:lemma	rezervas
 02935891-n	lit:lemma	savitarnos užkandinė
-01681307-s	lit:lemma	parengtas
+01681307-a	lit:lemma	parengtas
 07962124-n	lit:lemma	aibė
 00958896-n	lit:lemma	grumtynės
 00048828-n	lit:lemma	pasirodymas
 09775663-n	lit:lemma	advokatas
 00919542-a	lit:lemma	susijaudinęs
-01866812-s	lit:lemma	nenaudingas
+01866812-a	lit:lemma	nenaudingas
 07611046-n	lit:lemma	kompotas
-00066146-s	lit:lemma	drąsus
+00066146-a	lit:lemma	drąsus
 10206173-n	lit:lemma	šnipas
-01876261-s	lit:lemma	pažangus
+01876261-a	lit:lemma	pažangus
 00151105-a	lit:lemma	bežadis
 06727758-n	lit:lemma	Teisių bilis
 03690473-n	lit:lemma	krovininis automobilis
@@ -15016,12 +15016,12 @@
 09921409-n	lit:lemma	patiklus asmuo
 10103485-n	lit:lemma	svetimšalis
 00142361-n	lit:lemma	medicininė apžiūra
-00687614-s	lit:lemma	tariamas
+00687614-a	lit:lemma	tariamas
 10261388-n	lit:lemma	baržos škiperis
 05397333-n	lit:lemma	kraujagyslė
-02462089-s	lit:lemma	melagingas
+02462089-a	lit:lemma	melagingas
 13625063-n	lit:lemma	kubinis kilometras
-01517632-s	lit:lemma	kovinis
+01517632-a	lit:lemma	kovinis
 07301543-n	lit:lemma	susidūrimas
 00050693-n	lit:lemma	atsiradimas
 02982473-a	lit:lemma	kanadietiškas
@@ -15029,28 +15029,28 @@
 00066781-r	lit:lemma	priešais
 09041371-n	lit:lemma	Dardanelai
 00099951-n	lit:lemma	triukas
-00633581-s	lit:lemma	teisingas
+00633581-a	lit:lemma	teisingas
 13668864-n	lit:lemma	Bahreino dinaras
 12589841-n	lit:lemma	skėtinė korifa
 04703698-n	lit:lemma	debesuotumas
 13914608-n	lit:lemma	kubas
 02152740-n	lit:lemma	grobuonis
-00876204-s	lit:lemma	neveiklus
+00876204-a	lit:lemma	neveiklus
 09945905-n	lit:lemma	bičiulis
-00521976-s	lit:lemma	visas
+00521976-a	lit:lemma	visas
 05458576-n	lit:lemma	oocitas
 15206943-n	lit:lemma	jaunatis
 10470460-n	lit:lemma	numatyta auka
 06781581-n	lit:lemma	žodžių žaismas
-00798103-s	lit:lemma	pasigėręs
+00798103-a	lit:lemma	pasigėręs
 13396054-n	lit:lemma	skola
 10388924-n	lit:lemma	savininkas
-02342608-s	lit:lemma	nuostabus
+02342608-a	lit:lemma	nuostabus
 06634095-n	lit:lemma	atsisakymas
 15191661-n	lit:lemma	Verbų sekmadienis
 14751417-n	lit:lemma	kortikosteroidas
 08537837-n	lit:lemma	miesto rajonas
-00527188-s	lit:lemma	visuotinis
+00527188-a	lit:lemma	visuotinis
 10410815-n	lit:lemma	barbaras
 00281237-r	lit:lemma	atsargiai
 07974025-n	lit:lemma	socialinė grupė
@@ -15063,7 +15063,7 @@
 14421585-n	lit:lemma	santuoka
 05503705-n	lit:lemma	nugaros smegenys
 04344246-n	lit:lemma	studija
-01243373-s	lit:lemma	nepalankus
+01243373-a	lit:lemma	nepalankus
 00001740-n	lit:lemma	esybė
 07024929-n	lit:lemma	polifonija
 14049711-n	lit:lemma	gera sveikata
@@ -15078,7 +15078,7 @@
 03484083-n	lit:lemma	vežimėlis (rankinis)
 01094725-n	lit:lemma	komercinė veikla
 00117082-r	lit:lemma	kartu
-00696996-s	lit:lemma	švelnus
+00696996-a	lit:lemma	švelnus
 13427078-n	lit:lemma	prisitaikymas
 02287618-v	lit:lemma	pamesti
 05094863-n	lit:lemma	gilumas
@@ -15090,19 +15090,19 @@
 09849598-n	lit:lemma	brangusis
 06272803-n	lit:lemma	skambutis
 00682243-n	lit:lemma	riebalų nusiurbimo operacija
-00998207-s	lit:lemma	plunksninis
+00998207-a	lit:lemma	plunksninis
 00875246-n	lit:lemma	įvertinimas
 10741590-n	lit:lemma	vartotojas
 03148920-n	lit:lemma	bordiūras
 06226057-n	lit:lemma	krikščionių tikėjimas
-01944088-s	lit:lemma	protingas
+01944088-a	lit:lemma	protingas
 00835609-a	lit:lemma	neefektyvus
 11515935-n	lit:lemma	prieblanda
 10522324-n	lit:lemma	pasileidėlis
 00425905-n	lit:lemma	erzinimas
 00697188-a	lit:lemma	apibrėžtas
 00172980-r	lit:lemma	narsiai
-02214736-s	lit:lemma	vienas
+02214736-a	lit:lemma	vienas
 09416076-n	lit:lemma	uola
 09849598-n	lit:lemma	mylimasis
 00190959-r	lit:lemma	intensyviai
@@ -15113,7 +15113,7 @@
 00188779-r	lit:lemma	entuziastingai
 00828779-a	lit:lemma	valgomas
 10138767-n	lit:lemma	geruolis
-00993885-s	lit:lemma	mirtinas
+00993885-a	lit:lemma	mirtinas
 05797597-n	lit:lemma	tyrimas
 05982152-n	lit:lemma	siekis
 00096333-r	lit:lemma	į viršų
@@ -15130,10 +15130,10 @@
 02556126-v	lit:lemma	palaikyti
 04073948-n	lit:lemma	vienuolynas
 05397333-n	lit:lemma	limfagyslė
-00193480-s	lit:lemma	kraupus
+00193480-a	lit:lemma	kraupus
 13911872-n	lit:lemma	taškas
 05833252-n	lit:lemma	našta
-01360962-s	lit:lemma	identiškas
+01360962-a	lit:lemma	identiškas
 00016702-v	lit:lemma	linkčioti
 05124928-n	lit:lemma	didžiausias dydis
 00284183-r	lit:lemma	pigiai
@@ -15154,13 +15154,13 @@
 13875185-n	lit:lemma	skritulys
 04708113-n	lit:lemma	paprastumas
 13267014-n	lit:lemma	dotacija
-01066787-s	lit:lemma	paplitęs
+01066787-a	lit:lemma	paplitęs
 15202806-n	lit:lemma	metai
 00078760-v	lit:lemma	gydyti
 05239680-n	lit:lemma	pagurklis
 07809368-n	lit:lemma	prieskonis
-00672382-s	lit:lemma	pasiūtas pagal užsakymą
-00803432-s	lit:lemma	duriantis
+00672382-a	lit:lemma	pasiūtas pagal užsakymą
+00803432-a	lit:lemma	duriantis
 09183693-n	lit:lemma	etinis įsitikinimas
 14435670-n	lit:lemma	karalius
 03006105-n	lit:lemma	kanalas
@@ -15170,12 +15170,12 @@
 04268799-n	lit:lemma	iškroviklis
 00090228-r	lit:lemma	pavojingai
 10340312-n	lit:lemma	muzikantas
-01591699-s	lit:lemma	karališkas
+01591699-a	lit:lemma	karališkas
 14958405-n	lit:lemma	nafta
 05280831-n	lit:lemma	sąnarinė ertmė
 14057371-n	lit:lemma	širdies ir kraujagyslių liga
-02456157-s	lit:lemma	susirūpinęs
-01804728-s	lit:lemma	grubus
+02456157-a	lit:lemma	susirūpinęs
+01804728-a	lit:lemma	grubus
 06300193-n	lit:lemma	kamienas
 00808182-n	lit:lemma	apribojimas
 00324384-n	lit:lemma	pakilimas
@@ -15185,18 +15185,18 @@
 05641720-n	lit:lemma	nesuderinimas
 05834758-n	lit:lemma	įkvėpimo šaltinis
 11433140-n	lit:lemma	Brauno judesys
-01309657-s	lit:lemma	nesupažindintas
+01309657-a	lit:lemma	nesupažindintas
 00213301-r	lit:lemma	stulbinamai
 08366753-n	lit:lemma	ekonominė sistema
 00303849-n	lit:lemma	parašiutizmas
-02462375-s	lit:lemma	sufabrikuotas
+02462375-a	lit:lemma	sufabrikuotas
 02074915-n	lit:lemma	plėšrieji
 00074038-v	lit:lemma	tuštintis
 00107416-r	lit:lemma	neseniai
 14052046-n	lit:lemma	prasta sveikata
 01910965-v	lit:lemma	pereiti
 13138842-n	lit:lemma	sėklavaisis
-01634736-s	lit:lemma	oficialus
+01634736-a	lit:lemma	oficialus
 10722758-n	lit:lemma	geležinkelininkas
 04617562-n	lit:lemma	asmenybė
 10757193-n	lit:lemma	lankytojas
@@ -15211,19 +15211,19 @@
 00211462-n	lit:lemma	užbaigimas
 07978423-n	lit:lemma	mitologija
 00249501-n	lit:lemma	pažanga
-02104727-s	lit:lemma	fotojautrusis
+02104727-a	lit:lemma	fotojautrusis
 13873849-n	lit:lemma	ratelis
-00425313-s	lit:lemma	vulgarus
+00425313-a	lit:lemma	vulgarus
 00666058-a	lit:lemma	dabartinis
 00733044-v	lit:lemma	išspręsti
 00348110-r	lit:lemma	noriai
 02928299-n	lit:lemma	kulninis lankstas
-00286837-s	lit:lemma	atviras
+00286837-a	lit:lemma	atviras
 00268557-n	lit:lemma	atnaujinimas
 05799212-n	lit:lemma	testavimas
-00126497-s	lit:lemma	pirmesnis
+00126497-a	lit:lemma	pirmesnis
 01071090-n	lit:lemma	toleravimas
-02542148-s	lit:lemma	palaužtas
+02542148-a	lit:lemma	palaužtas
 10185483-n	lit:lemma	valtornininkas
 03862676-n	lit:lemma	krosnis
 15129927-n	lit:lemma	laikas
@@ -15233,19 +15233,19 @@
 03429914-n	lit:lemma	tinkliukas
 06756407-n	lit:lemma	neteisybė
 09403086-n	lit:lemma	triušio landa
-01990653-s	lit:lemma	ryžtingas
-02460964-s	lit:lemma	tikras
+01990653-a	lit:lemma	ryžtingas
+02460964-a	lit:lemma	tikras
 09428293-n	lit:lemma	pakrantė
 04531098-n	lit:lemma	indas
 14330265-n	lit:lemma	išangės skausmas
 09614684-n	lit:lemma	globėjas
 14061805-n	lit:lemma	liga
 00123170-v	lit:lemma	keisti
-00731955-s	lit:lemma	sujungtas
+00731955-a	lit:lemma	sujungtas
 13910019-n	lit:lemma	gniužulas
 00406243-v	lit:lemma	pasiruošti
 04317420-n	lit:lemma	pagaliukas
-00792641-s	lit:lemma	visavaldis
+00792641-a	lit:lemma	visavaldis
 04602044-n	lit:lemma	darbo vieta
 02100709-a	lit:lemma	jaunesnis
 05287090-n	lit:lemma	kolagenas
@@ -15259,18 +15259,18 @@
 08061042-n	lit:lemma	verslas
 00830733-n	lit:lemma	motorika
 13758296-n	lit:lemma	riba
-01450178-s	lit:lemma	dingęs
+01450178-a	lit:lemma	dingęs
 15050011-n	lit:lemma	prieskoniai
 03234306-n	lit:lemma	piešinys
-00856651-s	lit:lemma	jausmingas
+00856651-a	lit:lemma	jausmingas
 00776262-n	lit:lemma	kyšininkavimas
-00714763-s	lit:lemma	maldaujamas
+00714763-a	lit:lemma	maldaujamas
 00036061-n	lit:lemma	taikymas
 09815790-n	lit:lemma	padėjėja
 00207127-r	lit:lemma	finansiškai
-02448324-s	lit:lemma	delikatus
+02448324-a	lit:lemma	delikatus
 09624168-n	lit:lemma	vyras
-00246175-s	lit:lemma	spuoguotas
+00246175-a	lit:lemma	spuoguotas
 08971914-n	lit:lemma	Naujosios Zelandijos salos
 14438788-n	lit:lemma	reputacija
 00053394-r	lit:lemma	atvirai
@@ -15287,7 +15287,7 @@
 07955726-n	lit:lemma	nuomininkai
 00096513-n	lit:lemma	gelbėjimas
 02891188-n	lit:lemma	stabdžiai
-00798491-s	lit:lemma	girtas
+00798491-a	lit:lemma	girtas
 11501649-n	lit:lemma	lietaus lašas
 00737399-n	lit:lemma	nukrypimas
 05948537-n	lit:lemma	sekta
@@ -15309,24 +15309,24 @@
 04514738-n	lit:lemma	viršutinis denis
 07963711-n	lit:lemma	kombinacija
 00383952-n	lit:lemma	pertrūkis
-00719442-s	lit:lemma	užgaidus
+00719442-a	lit:lemma	užgaidus
 12156819-n	lit:lemma	grūdas
 00061203-r	lit:lemma	paskui
-00211564-s	lit:lemma	lygus
+00211564-a	lit:lemma	lygus
 04842993-n	lit:lemma	juslumas
 08428756-n	lit:lemma	eilė
-00523867-s	lit:lemma	savarankiškas
+00523867-a	lit:lemma	savarankiškas
 00060477-v	lit:lemma	kastruoti
 03327234-n	lit:lemma	užtvara
 02906478-a	lit:lemma	ekologinis
 00550771-n	lit:lemma	vaidinimas
 01034457-a	lit:lemma	užsieninis
-01484651-s	lit:lemma	mergiškas
+01484651-a	lit:lemma	mergiškas
 13408023-n	lit:lemma	dividendas
 07597145-n	lit:lemma	uogienė
 07413629-n	lit:lemma	blyksnis
 02827160-a	lit:lemma	galvaninis
-00933415-s	lit:lemma	prabangus
+00933415-a	lit:lemma	prabangus
 08428756-n	lit:lemma	vora
 01105737-n	lit:lemma	navigacija
 03077958-n	lit:lemma	ryšio sistema
@@ -15335,15 +15335,15 @@
 01812950-v	lit:lemma	pradžiugti
 01704761-a	lit:lemma	akivaizdus
 00021265-n	lit:lemma	lesalas
-02332604-s	lit:lemma	produktyvus
+02332604-a	lit:lemma	produktyvus
 13525549-n	lit:lemma	funkcionavimas
 13268842-n	lit:lemma	dovana
-00157268-s	lit:lemma	santūrus
+00157268-a	lit:lemma	santūrus
 00207668-r	lit:lemma	po vieną
 10369317-n	lit:lemma	obojininkas
 04975122-n	lit:lemma	atspalvis
 01170962-n	lit:lemma	konfliktas
-00027599-s	lit:lemma	pripažintas
+00027599-a	lit:lemma	pripažintas
 00360485-n	lit:lemma	mažėjimas
 00180228-n	lit:lemma	sprendimas
 03264136-n	lit:lemma	briauna
@@ -15355,7 +15355,7 @@
 10673451-n	lit:lemma	pasiūlytojas
 11515935-n	lit:lemma	sutema
 02648639-v	lit:lemma	gyventi
-01206318-s	lit:lemma	aukštesnis
+01206318-a	lit:lemma	aukštesnis
 05637558-n	lit:lemma	sugebėjimas
 05263029-n	lit:lemma	smaili barzdelė
 00069295-v	lit:lemma	išskirti
@@ -15370,7 +15370,7 @@
 06399631-n	lit:lemma	priedas
 10500217-n	lit:lemma	pažiba
 00807273-n	lit:lemma	koordinacija
-02186338-s	lit:lemma	vienas
+02186338-a	lit:lemma	vienas
 03707597-n	lit:lemma	magnetinis rašytuvas
 07330007-n	lit:lemma	dalia
 01763813-a	lit:lemma	įspėjamasis
@@ -15382,46 +15382,46 @@
 00037396-n	lit:lemma	veikla
 03003616-a	lit:lemma	angliškas
 06770275-n	lit:lemma	sutartis
-00978199-s	lit:lemma	vikrus
+00978199-a	lit:lemma	vikrus
 00189401-r	lit:lemma	kada nors
 06468403-n	lit:lemma	gyvenimo aprašymas
-01044557-s	lit:lemma	kasdieninis
+01044557-a	lit:lemma	kasdieninis
 08557482-n	lit:lemma	imperija
-00710097-s	lit:lemma	grūdintas
-01925708-s	lit:lemma	rišlus
+00710097-a	lit:lemma	grūdintas
+01925708-a	lit:lemma	rišlus
 01145359-n	lit:lemma	suvaržymas
 08552138-n	lit:lemma	apskritis
-00228485-s	lit:lemma	išeiginis
+00228485-a	lit:lemma	išeiginis
 01560320-a	lit:lemma	abejingas
 10582746-n	lit:lemma	kariškis
-02316992-s	lit:lemma	besirangantis
+02316992-a	lit:lemma	besirangantis
 07500741-n	lit:lemma	susižavėjimas
 00063630-r	lit:lemma	iš viso
 02015598-v	lit:lemma	išvykti
 10453357-n	lit:lemma	beturtis
 00289082-a	lit:lemma	sulaužytas
-00975487-s	lit:lemma	stilingas
-02119716-s	lit:lemma	realus
+00975487-a	lit:lemma	stilingas
+02119716-a	lit:lemma	realus
 00042484-r	lit:lemma	laimei
 06125041-n	lit:lemma	inžinerija
-02229584-s	lit:lemma	neišdirbtas
+02229584-a	lit:lemma	neišdirbtas
 00016702-v	lit:lemma	knapsėti
 01763813-a	lit:lemma	prevencinis
 02960686-a	lit:lemma	olandų
 06760722-n	lit:lemma	gudrybė
 00102029-r	lit:lemma	visur
 06726158-n	lit:lemma	deklaracija
-01161635-s	lit:lemma	katastrofiškas
+01161635-a	lit:lemma	katastrofiškas
 00812860-a	lit:lemma	beausis
 00877345-a	lit:lemma	žvalgomasis
 00581401-a	lit:lemma	nepastebimas
-02111095-s	lit:lemma	atjungtas
+02111095-a	lit:lemma	atjungtas
 05261566-n	lit:lemma	žandenos
 01548193-a	lit:lemma	dorovingas
 08227214-n	lit:lemma	draugija
 04111190-n	lit:lemma	velenas
 07516756-n	lit:lemma	pyktis
-01763159-s	lit:lemma	atlaidus
+01763159-a	lit:lemma	atlaidus
 06152460-n	lit:lemma	penologija
 09777012-n	lit:lemma	makleris
 00059552-n	lit:lemma	išsisukimas
@@ -15430,21 +15430,21 @@
 14441498-n	lit:lemma	gėda
 13670281-n	lit:lemma	Libijos dinaras
 15278281-n	lit:lemma	dažnumas
-01401413-s	lit:lemma	patvirtintas
+01401413-a	lit:lemma	patvirtintas
 10200781-n	lit:lemma	autoritetas
 03302121-n	lit:lemma	duobė
 00259096-r	lit:lemma	anksčiau
-02071782-s	lit:lemma	giminingas
+02071782-a	lit:lemma	giminingas
 00279523-r	lit:lemma	tiesiai
 15273241-n	lit:lemma	atsako laikas
-01629681-s	lit:lemma	agresyvus
+01629681-a	lit:lemma	agresyvus
 02807731-n	lit:lemma	vonia
 07881800-n	lit:lemma	gėrimas
 07776866-n	lit:lemma	jūros gėrybės
-01523724-s	lit:lemma	judamas
-00552089-s	lit:lemma	išpildytas
+01523724-a	lit:lemma	judamas
+00552089-a	lit:lemma	išpildytas
 01006056-v	lit:lemma	užsirašyti
-02271052-s	lit:lemma	išsilavinęs
+02271052-a	lit:lemma	išsilavinęs
 13869547-n	lit:lemma	kabliukas
 03391770-n	lit:lemma	rėminė konstrukcija
 00453803-v	lit:lemma	pripildyti
@@ -15453,12 +15453,12 @@
 13985818-n	lit:lemma	nuotaika
 00177686-r	lit:lemma	atvirkščiai
 09955015-n	lit:lemma	aferistas
-02032850-s	lit:lemma	dešinysis
+02032850-a	lit:lemma	dešinysis
 14285662-n	lit:lemma	trauma
-01389170-s	lit:lemma	didžiulis
+01389170-a	lit:lemma	didžiulis
 04070727-n	lit:lemma	šaldytuvas
 00254769-n	lit:lemma	skutimasis
-00070427-s	lit:lemma	jausmingas
+00070427-a	lit:lemma	jausmingas
 13836841-n	lit:lemma	verslo ryšys
 13600822-n	lit:lemma	tūrio matas
 05525628-n	lit:lemma	sėklidės prielipas
@@ -15472,19 +15472,19 @@
 01916229-a	lit:lemma	ginčytinas
 00930290-a	lit:lemma	nelauktas
 00076196-n	lit:lemma	netaktas
-01019713-s	lit:lemma	suglebęs
+01019713-a	lit:lemma	suglebęs
 07502669-n	lit:lemma	antipatija
 00404501-r	lit:lemma	liūdnai
-01768466-s	lit:lemma	asmeniškas
+01768466-a	lit:lemma	asmeniškas
 05827684-n	lit:lemma	postūmis
-00627004-s	lit:lemma	fizinis
-00195684-s	lit:lemma	siaubingas
+00627004-a	lit:lemma	fizinis
+00195684-a	lit:lemma	siaubingas
 07747055-n	lit:lemma	citrusai
 00067526-n	lit:lemma	praradimas
 04634161-n	lit:lemma	energingumas
 00781685-n	lit:lemma	apiplėšimas
 00339934-v	lit:lemma	vykti
-02558528-s	lit:lemma	gausus
+02558528-a	lit:lemma	gausus
 06209101-n	lit:lemma	vaizdas iš viršaus
 00868196-n	lit:lemma	raudojimas
 09957013-n	lit:lemma	pacifistas
@@ -15492,7 +15492,7 @@
 02753044-n	lit:lemma	branduolinė bomba
 05986395-n	lit:lemma	švietimas
 13725457-n	lit:lemma	kvintalas
-01439155-s	lit:lemma	užsitęsęs
+01439155-a	lit:lemma	užsitęsęs
 05122850-n	lit:lemma	mažuma
 07238455-n	lit:lemma	juodinančios užuominos
 00031899-r	lit:lemma	labai
@@ -15509,13 +15509,13 @@
 07738353-n	lit:lemma	odelė
 01217043-v	lit:lemma	laikyti
 05093890-n	lit:lemma	laipsnis
-01277426-s	lit:lemma	svarbiausias
+01277426-a	lit:lemma	svarbiausias
 00035465-a	lit:lemma	veikiantis
 13258362-n	lit:lemma	grynas pelnas
 05593476-n	lit:lemma	alkūnkaulis
 03240140-n	lit:lemma	elektrinis grąžtas
 08620061-n	lit:lemma	pozicija
-01358534-s	lit:lemma	kviečiantis
+01358534-a	lit:lemma	kviečiantis
 10002760-n	lit:lemma	demonstrantas
 00340239-a	lit:lemma	neabejotinas
 01484850-n	lit:lemma	baltasis ryklys
@@ -15524,18 +15524,18 @@
 06394865-n	lit:lemma	knyga
 09752795-n	lit:lemma	Liūtas
 05512337-n	lit:lemma	šlapimo pūslė
-02074929-s	lit:lemma	pakvaišęs
-01401224-s	lit:lemma	teisėtas
+02074929-a	lit:lemma	pakvaišęs
+01401224-a	lit:lemma	teisėtas
 06362953-n	lit:lemma	raštija
 06803845-n	lit:lemma	tarptautinis nelaimės signalas
 05211044-n	lit:lemma	komiškumas
-01234527-s	lit:lemma	palinkęs
+01234527-a	lit:lemma	palinkęs
 00270275-n	lit:lemma	atstatymas
-02477211-s	lit:lemma	suporuotas
+02477211-a	lit:lemma	suporuotas
 04782116-n	lit:lemma	klaikumas
 09536058-n	lit:lemma	Dievas
 00298161-n	lit:lemma	turizmas
-00666610-s	lit:lemma	dabartinis
+00666610-a	lit:lemma	dabartinis
 15119536-n	lit:lemma	nūdiena
 13457378-n	lit:lemma	mažėjimas
 08737041-n	lit:lemma	Gvatemala
@@ -15544,7 +15544,7 @@
 04025350-n	lit:lemma	marionetė
 14539268-n	lit:lemma	sauga
 03072201-n	lit:lemma	spalvotoji televizija
-02318728-s	lit:lemma	tiesus
+02318728-a	lit:lemma	tiesus
 06713752-n	lit:lemma	priekaištas
 10276942-n	lit:lemma	pamišėlis
 04933544-n	lit:lemma	konstitucija
@@ -15560,29 +15560,29 @@
 09718092-n	lit:lemma	Jamaikos gyventojas
 00002452-n	lit:lemma	dalykas
 00537682-n	lit:lemma	liaudies šokiai
-01871565-s	lit:lemma	rentabilus
+01871565-a	lit:lemma	rentabilus
 02753724-a	lit:lemma	juridinis
 07387509-n	lit:lemma	triukšmas
 00040365-r	lit:lemma	iš naujo
-00699521-s	lit:lemma	pradinis
-01880918-s	lit:lemma	nederamas
-01300661-s	lit:lemma	drausminis
+00699521-a	lit:lemma	pradinis
+01880918-a	lit:lemma	nederamas
+01300661-a	lit:lemma	drausminis
 01919391-v	lit:lemma	žygiuoti
 01774426-v	lit:lemma	neapkęsti
 07314838-n	lit:lemma	tragedija
 08240633-n	lit:lemma	uždaras išrinktųjų ratas
 05035961-n	lit:lemma	energija
-00488998-s	lit:lemma	nepaprastas
+00488998-a	lit:lemma	nepaprastas
 05648459-n	lit:lemma	nerangumas
 01887474-n	lit:lemma	gyvulys
 01215392-n	lit:lemma	palaiminimas
 07221094-n	lit:lemma	pasakojimas
 05599203-n	lit:lemma	viršunosė
 10127273-n	lit:lemma	džentelmenas
-01936184-s	lit:lemma	mitinis
+01936184-a	lit:lemma	mitinis
 01813088-n	lit:lemma	karvelis keršulis
 09504915-n	lit:lemma	lemties deivė
-02074929-s	lit:lemma	išprotėjęs
+02074929-a	lit:lemma	išprotėjęs
 09696585-n	lit:lemma	kanadietis
 02267060-v	lit:lemma	sunaudoti
 03706415-n	lit:lemma	magnetinė šerdinė atmintinė
@@ -15591,29 +15591,29 @@
 10541229-n	lit:lemma	valdovas
 03274796-n	lit:lemma	elektrodas
 00249501-n	lit:lemma	progresas
-01769378-s	lit:lemma	asmeniškas
+01769378-a	lit:lemma	asmeniškas
 03959936-n	lit:lemma	lakštas
 14033185-n	lit:lemma	kritiškas momentas
 00507819-r	lit:lemma	neseniai
 07503430-n	lit:lemma	neapkentimas
-01176973-s	lit:lemma	gangrenos
-02144436-s	lit:lemma	tąsus
+01176973-a	lit:lemma	gangrenos
+02144436-a	lit:lemma	tąsus
 13447361-n	lit:lemma	cheminė reakcija
 00002684-n	lit:lemma	materialus objektas
 04411966-n	lit:lemma	rėmų kabliukas
 10415638-n	lit:lemma	artistas
 04846770-n	lit:lemma	etika
 02727825-n	lit:lemma	prietaisas
-00505086-s	lit:lemma	rekordinis
-00012689-s	lit:lemma	nerealus
+00505086-a	lit:lemma	rekordinis
+00012689-a	lit:lemma	nerealus
 00032414-v	lit:lemma	kvatoti
 07208338-n	lit:lemma	prieštaravimas
-01539444-s	lit:lemma	nepretenzingas
+01539444-a	lit:lemma	nepretenzingas
 13779374-n	lit:lemma	tūris
 02384686-v	lit:lemma	pakviesti
 05995576-n	lit:lemma	liberalizmas
-01046226-s	lit:lemma	kasdienis
-00027599-s	lit:lemma	priimtinas
+01046226-a	lit:lemma	kasdienis
+00027599-a	lit:lemma	priimtinas
 00192511-r	lit:lemma	įtikinamai
 06518719-n	lit:lemma	bilietas
 00024257-r	lit:lemma	visai ne
@@ -15623,13 +15623,13 @@
 02782093-n	lit:lemma	oro balionas
 00429048-n	lit:lemma	pasilinksminimas
 07123552-n	lit:lemma	rėkimas
-00425313-s	lit:lemma	nešvankus
+00425313-a	lit:lemma	nešvankus
 09767700-n	lit:lemma	aktorė
 01654628-v	lit:lemma	statyti
 04620216-n	lit:lemma	charakteris
 01849288-a	lit:lemma	manieringas
-00579622-s	lit:lemma	žymus
-00144510-s	lit:lemma	šarvuotas
+00579622-a	lit:lemma	žymus
+00144510-a	lit:lemma	šarvuotas
 07587023-n	lit:lemma	viralas
 03452741-n	lit:lemma	fortepijonas
 05204637-n	lit:lemma	bejėgiškumas
@@ -15646,9 +15646,9 @@
 07511238-n	lit:lemma	nežinia
 10231515-n	lit:lemma	valdovas
 15275598-n	lit:lemma	sulėtinimas
-01601069-s	lit:lemma	šiaurinis
-01383582-s	lit:lemma	astronominis
-01211296-s	lit:lemma	sudėtingesnis
+01601069-a	lit:lemma	šiaurinis
+01383582-a	lit:lemma	astronominis
+01211296-a	lit:lemma	sudėtingesnis
 00342755-n	lit:lemma	sukimasis
 13331778-n	lit:lemma	ištekliai
 03173929-n	lit:lemma	krovininis automobilis
@@ -15659,26 +15659,26 @@
 00255214-n	lit:lemma	maudymas
 05546040-n	lit:lemma	žandikaulis
 01249315-n	lit:lemma	atleidimas
-00528167-s	lit:lemma	plenarinis
+00528167-a	lit:lemma	plenarinis
 03953416-n	lit:lemma	maldykla
-01362387-s	lit:lemma	liūdnas
-00750054-s	lit:lemma	lengvas
+01362387-a	lit:lemma	liūdnas
+00750054-a	lit:lemma	lengvas
 02083863-n	lit:lemma	šunys
 10801697-n	lit:lemma	ksilofonininkas
 08253640-n	lit:lemma	banketas
 07702193-n	lit:lemma	kukulis
 01663049-a	lit:lemma	nesutinkantis pasipriešinimo
 04664058-n	lit:lemma	atsargumas
-01040752-s	lit:lemma	neužmirštinas
+01040752-a	lit:lemma	neužmirštinas
 03379719-n	lit:lemma	stabdžio pedalas
-01797633-s	lit:lemma	iš anksto nuspręstas
+01797633-a	lit:lemma	iš anksto nuspręstas
 15207556-n	lit:lemma	pilnatis
 00249300-r	lit:lemma	iš išorės
 11515935-n	lit:lemma	prietema
 03220802-n	lit:lemma	domino kauliukas
 05321664-n	lit:lemma	vidinė ausis
-01127147-s	lit:lemma	siaubingas
-01926229-s	lit:lemma	protingas
+01127147-a	lit:lemma	siaubingas
+01926229-a	lit:lemma	protingas
 02417914-n	lit:lemma	alpinis ožys
 00030358-n	lit:lemma	veiksmas
 08428383-n	lit:lemma	automobilių kortežas
@@ -15690,24 +15690,24 @@
 10186578-n	lit:lemma	prekiautojas trikotažu
 01059900-n	lit:lemma	sveikatos priežiūra
 00231916-r	lit:lemma	ne savo noru
-02339577-s	lit:lemma	aukštas
+02339577-a	lit:lemma	aukštas
 14796073-n	lit:lemma	karbolio rūgštis
 00328502-n	lit:lemma	slydimas
 00071178-v	lit:lemma	kamuoti
-00418364-s	lit:lemma	švarus
+00418364-a	lit:lemma	švarus
 06733476-n	lit:lemma	grasinimas
-00570322-s	lit:lemma	neįveikiamas
+00570322-a	lit:lemma	neįveikiamas
 00415333-n	lit:lemma	lobizmas
-00656132-s	lit:lemma	sprendžiamasis
+00656132-a	lit:lemma	sprendžiamasis
 10129133-n	lit:lemma	gigantas
 07137733-n	lit:lemma	oficialus pokalbis
 03797390-n	lit:lemma	bokalas
 13488110-n	lit:lemma	globalizacija
-00304144-s	lit:lemma	audringas
+00304144-a	lit:lemma	audringas
 00150134-r	lit:lemma	be abejo
 09356080-n	lit:lemma	Misisipė
 06781383-n	lit:lemma	komedija
-00625055-s	lit:lemma	ženklus
+00625055-a	lit:lemma	ženklus
 13283764-n	lit:lemma	atlygis
 03386011-n	lit:lemma	tvirtovė
 00887081-n	lit:lemma	pedagogika
@@ -15715,7 +15715,7 @@
 03716327-n	lit:lemma	figūra
 00308370-n	lit:lemma	iškyla
 04576002-n	lit:lemma	invalidų vežimėlis
-00194357-s	lit:lemma	bauginantis
+00194357-a	lit:lemma	bauginantis
 06252138-n	lit:lemma	bendravimas
 02793495-n	lit:lemma	daržinė
 06756407-n	lit:lemma	melas
@@ -15723,12 +15723,12 @@
 13954253-n	lit:lemma	egzistencia
 00031974-a	lit:lemma	gyvas
 05088804-n	lit:lemma	tankumas
-01386234-s	lit:lemma	platus
+01386234-a	lit:lemma	platus
 11435871-n	lit:lemma	teigiamas krūvis
 13992514-n	lit:lemma	autonomija
 13364984-n	lit:lemma	pinigų ekvivalentai
 02381089-a	lit:lemma	jungtukinis
-01921466-s	lit:lemma	triukšmingas
+01921466-a	lit:lemma	triukšmingas
 09375085-n	lit:lemma	branduolys
 02614387-v	lit:lemma	gyventi
 00957176-a	lit:lemma	šališkas
@@ -15736,13 +15736,13 @@
 09308398-n	lit:lemma	ledas
 10092098-n	lit:lemma	eigulys
 07928367-n	lit:lemma	imbierinis limonadas
-00635244-s	lit:lemma	pagerinamas
-01141468-s	lit:lemma	dirbtinis
+00635244-a	lit:lemma	pagerinamas
+01141468-a	lit:lemma	dirbtinis
 13959818-n	lit:lemma	neegzistavimas
 15143012-n	lit:lemma	pradžia
 00174987-r	lit:lemma	nekontroliuojamai
 14984973-n	lit:lemma	dažai
-00848466-s	lit:lemma	privalomas
+00848466-a	lit:lemma	privalomas
 01034925-n	lit:lemma	sakramentas
 09889691-n	lit:lemma	kandidatė
 00491438-r	lit:lemma	be naudos
@@ -15761,13 +15761,13 @@
 08642037-n	lit:lemma	vietovė
 03605722-n	lit:lemma	sandūra
 13766733-n	lit:lemma	puodelis
-00927832-s	lit:lemma	trūkstamas
+00927832-a	lit:lemma	trūkstamas
 00084759-r	lit:lemma	ypač
 09345932-n	lit:lemma	jūra
 00975171-a	lit:lemma	stilingas
 06009537-n	lit:lemma	ilgoji ašis
 11466701-n	lit:lemma	karšti orai
-02542148-s	lit:lemma	ištiktas
+02542148-a	lit:lemma	ištiktas
 14074041-n	lit:lemma	komplikacija
 03181293-n	lit:lemma	detektorius
 07702642-n	lit:lemma	pusryčiai
@@ -15780,72 +15780,72 @@
 14806838-n	lit:lemma	cheminė medžiaga
 02416030-v	lit:lemma	mėgėjiškai dirbti
 00758795-n	lit:lemma	tinginystė
-00280463-s	lit:lemma	švytintis
+00280463-a	lit:lemma	švytintis
 03093076-a	lit:lemma	olimpinis
-01300187-s	lit:lemma	griežtas
+01300187-a	lit:lemma	griežtas
 07526182-n	lit:lemma	drąsa
 13266892-n	lit:lemma	dotacija, subsidija, pašalpa
 00069012-v	lit:lemma	plūsti
 09490825-n	lit:lemma	žmogėdra milžinas
 04493381-n	lit:lemma	puskubilis
-00048858-s	lit:lemma	papildomas
+00048858-a	lit:lemma	papildomas
 03417345-n	lit:lemma	sodas (vaismedžių)
 14716997-n	lit:lemma	žalvaris
 14364802-n	lit:lemma	nuospauda
-01208738-s	lit:lemma	sudėtingas
-01492907-s	lit:lemma	kūdikiškas
+01208738-a	lit:lemma	sudėtingas
+01492907-a	lit:lemma	kūdikiškas
 00051696-a	lit:lemma	nepakankamas
 03411544-n	lit:lemma	balkonas
 14488594-n	lit:lemma	ekonominė būklė
 05540513-n	lit:lemma	kiaušas
-00631798-s	lit:lemma	tikslus
+00631798-a	lit:lemma	tikslus
 07584938-n	lit:lemma	buljonas
 05119223-n	lit:lemma	prabangos dalykas
-01388062-s	lit:lemma	milžiniškas
+01388062-a	lit:lemma	milžiniškas
 01527420-a	lit:lemma	metalinis
 00022131-r	lit:lemma	lygiai
 06688522-n	lit:lemma	paminėjimas
-01728919-s	lit:lemma	praėjęs
+01728919-a	lit:lemma	praėjęs
 08006989-n	lit:lemma	nominalinė vertė
 00279835-n	lit:lemma	kraustymasis
 06515662-n	lit:lemma	kronika
-01752953-s	lit:lemma	sugadintas
-00440579-s	lit:lemma	bukas
+01752953-a	lit:lemma	sugadintas
+00440579-a	lit:lemma	bukas
 07497473-n	lit:lemma	pomėgis
-01625893-s	lit:lemma	šlykštus
+01625893-a	lit:lemma	šlykštus
 00020280-r	lit:lemma	visą laiką
 08213205-n	lit:lemma	divizija
 09792237-n	lit:lemma	anatomijos žinovas
 13997253-n	lit:lemma	priklausomybė
 05850624-n	lit:lemma	atžvilgis
-01076145-s	lit:lemma	malonus
+01076145-a	lit:lemma	malonus
 10118844-n	lit:lemma	lošikas
 07185870-n	lit:lemma	noras
 00900961-v	lit:lemma	atsisveikinti
 07567707-n	lit:lemma	rupūs miltai
-01207546-s	lit:lemma	apatinis
+01207546-a	lit:lemma	apatinis
 14491625-n	lit:lemma	perteklius
 00911048-n	lit:lemma	konstravimas
 01277974-v	lit:lemma	atlenkti
-02250430-s	lit:lemma	vienišas
+02250430-a	lit:lemma	vienišas
 02194913-v	lit:lemma	kelti pasibjaurėjimą
 14529524-n	lit:lemma	prieš
-02344070-s	lit:lemma	tikras
+02344070-a	lit:lemma	tikras
 10195487-n	lit:lemma	hipochondrikas
 10719267-n	lit:lemma	miestelėnas
 00612160-n	lit:lemma	medicina
 03420935-n	lit:lemma	garota
 01219111-a	lit:lemma	kalnuotas
 13352138-n	lit:lemma	įkeitimas
-02023430-s	lit:lemma	skurdus
+02023430-a	lit:lemma	skurdus
 08630039-n	lit:lemma	regionas
-00969264-s	lit:lemma	savotiškas
+00969264-a	lit:lemma	savotiškas
 13972797-n	lit:lemma	bruzdėjimas
 01032040-n	lit:lemma	pamaldos
 06357304-n	lit:lemma	dvejetainis kodas
 08411170-n	lit:lemma	privati mokykla
 00660957-n	lit:lemma	pedikiūras
-00865007-s	lit:lemma	neturintis darbo
+00865007-a	lit:lemma	neturintis darbo
 00060185-v	lit:lemma	perėti
 15213406-n	lit:lemma	lapkritis
 00061598-n	lit:lemma	užbaigimas
@@ -15859,7 +15859,7 @@
 01631072-v	lit:lemma	atsinaujinti
 00981818-a	lit:lemma	greitas
 05131283-n	lit:lemma	pakiluma
-00724397-s	lit:lemma	saugus
+00724397-a	lit:lemma	saugus
 14706889-n	lit:lemma	adeninas
 00166608-r	lit:lemma	slapta
 02862444-a	lit:lemma	branduolinis
@@ -15873,11 +15873,11 @@
 07990824-n	lit:lemma	jaunikliai
 00014742-v	lit:lemma	miegoti
 03032811-n	lit:lemma	ratas
-00505853-s	lit:lemma	unikalus
+00505853-a	lit:lemma	unikalus
 00415963-r	lit:lemma	pernelyg
 00164751-r	lit:lemma	tokiu atveju
 14942223-n	lit:lemma	priemolis
-00533221-s	lit:lemma	suprantamas
+00533221-a	lit:lemma	suprantamas
 12651611-n	lit:lemma	kriaušė
 10599354-n	lit:lemma	žioplys
 10677713-n	lit:lemma	rėmėjas
@@ -15888,12 +15888,12 @@
 02764614-n	lit:lemma	sukimosi ašis
 08957381-n	lit:lemma	Libano Respublika
 07505676-n	lit:lemma	nesidomėjimas
-01993408-s	lit:lemma	geras
+01993408-a	lit:lemma	geras
 05273822-n	lit:lemma	skruostikaulis
 04569520-n	lit:lemma	pleištas
 09631463-n	lit:lemma	sunkiai sugyvenamas asmuo
 02738031-n	lit:lemma	ginklai
-00850053-s	lit:lemma	prabangus
+00850053-a	lit:lemma	prabangus
 10197525-n	lit:lemma	kvaiša
 13600822-n	lit:lemma	tūrio vienetas
 03863923-n	lit:lemma	viršutinis drabužis
@@ -15906,33 +15906,33 @@
 01012561-v	lit:lemma	pagrįsti
 03111690-n	lit:lemma	pataisos įstaiga
 00414619-r	lit:lemma	pasirinktinai
-00182961-s	lit:lemma	rankinio valdymo
+00182961-a	lit:lemma	rankinio valdymo
 14618253-n	lit:lemma	šarmas
-00127948-s	lit:lemma	artimiausias
+00127948-a	lit:lemma	artimiausias
 02884225-n	lit:lemma	ložė
 09799461-n	lit:lemma	apaštalas
 12432808-n	lit:lemma	svogūnas
 00876989-a	lit:lemma	eksportuojamas
 00512487-a	lit:lemma	konkursinis
-02038994-s	lit:lemma	ištvermingas
-00861216-s	lit:lemma	spėjamas
+02038994-a	lit:lemma	ištvermingas
+00861216-a	lit:lemma	spėjamas
 00754767-n	lit:lemma	apgaulė
-00708738-s	lit:lemma	trapus
-01740358-s	lit:lemma	nacionalistinis
+00708738-a	lit:lemma	trapus
+01740358-a	lit:lemma	nacionalistinis
 05643190-n	lit:lemma	patyrimas
 00007884-r	lit:lemma	ligi pusės
 02934168-n	lit:lemma	laidas
-01375831-s	lit:lemma	žinomas
+01375831-a	lit:lemma	žinomas
 00883139-n	lit:lemma	uodimas
 02019574-v	lit:lemma	peržengti
-02251212-s	lit:lemma	atsiskyręs
-00324481-s	lit:lemma	judinamasis
+02251212-a	lit:lemma	atsiskyręs
+00324481-a	lit:lemma	judinamasis
 01528069-v	lit:lemma	įkišti
 02779774-a	lit:lemma	fizikinis
 00182213-n	lit:lemma	balsavimas
 10363913-n	lit:lemma	pradedantysis
-01951197-s	lit:lemma	šiurkštus
-00491511-s	lit:lemma	išskirtinis
+01951197-a	lit:lemma	šiurkštus
+00491511-a	lit:lemma	išskirtinis
 00288970-n	lit:lemma	išvyka pėsčiomis
 00258854-n	lit:lemma	korekcija
 09505153-n	lit:lemma	dvasinis vadovas
@@ -15944,12 +15944,12 @@
 08337324-n	lit:lemma	agentūra
 00080304-r	lit:lemma	be to
 00365668-r	lit:lemma	pastebimai
-00580684-s	lit:lemma	paženklintas
+00580684-a	lit:lemma	paženklintas
 00326324-r	lit:lemma	efektyviai
 06361770-n	lit:lemma	skiemenų abėcėlė
 05024931-n	lit:lemma	rimties masė
 00598679-a	lit:lemma	valdomas
-00858558-s	lit:lemma	ramus
+00858558-a	lit:lemma	ramus
 00039318-r	lit:lemma	akivaizdžiai
 15203017-n	lit:lemma	mėnulio metai
 09859152-n	lit:lemma	kalvis
@@ -15958,33 +15958,33 @@
 00088725-n	lit:lemma	areštas
 02062744-n	lit:lemma	banginis
 02556126-v	lit:lemma	paremti
-02177584-s	lit:lemma	komplikuotas
+02177584-a	lit:lemma	komplikuotas
 13763384-n	lit:lemma	mažiausias dydis
 06623614-n	lit:lemma	susirašinėjimas laiškais
 03775199-n	lit:lemma	maišytuvas
 07473441-n	lit:lemma	pergalė
 02776505-n	lit:lemma	bajus
 08418631-n	lit:lemma	nacionalinis bankas
-00398978-s	lit:lemma	margaspalvis
+00398978-a	lit:lemma	margaspalvis
 02169352-v	lit:lemma	sekti
 00232386-n	lit:lemma	atšaukimas
 06071426-n	lit:lemma	embriologija
 05026843-n	lit:lemma	svoris
 00151497-n	lit:lemma	apibrėžimas
 09614684-n	lit:lemma	prižiūrėtojas
-00309740-s	lit:lemma	įsitikinęs
+00309740-a	lit:lemma	įsitikinęs
 13896100-n	lit:lemma	arka
 01439190-v	lit:lemma	gaudyti
 00228283-n	lit:lemma	panaikinimas
 05098311-n	lit:lemma	amplitudė
 04075160-n	lit:lemma	nuotolinio valdymo bomba
-01756292-s	lit:lemma	efemeriškas
+01756292-a	lit:lemma	efemeriškas
 00666058-a	lit:lemma	šiuometinis
 08179689-n	lit:lemma	liaudis
 00028651-n	lit:lemma	erdvė
 00029677-n	lit:lemma	procesas
 00334790-r	lit:lemma	skubiai
-01750386-s	lit:lemma	visiškas
+01750386-a	lit:lemma	visiškas
 00358089-n	lit:lemma	suspaudimas
 02856463-n	lit:lemma	lenta
 10332385-n	lit:lemma	motina
@@ -15992,12 +15992,12 @@
 07122118-n	lit:lemma	šauksmas
 03100897-n	lit:lemma	juostinis transporteris
 05697135-n	lit:lemma	tikrumas
-00728431-s	lit:lemma	savarankiškas
+00728431-a	lit:lemma	savarankiškas
 00022686-v	lit:lemma	sužadinti
 10639925-n	lit:lemma	aistruolis
 10415638-n	lit:lemma	atlikėjas
 05750163-n	lit:lemma	tendencija
-01037885-s	lit:lemma	užsieninis
+01037885-a	lit:lemma	užsieninis
 08050678-n	lit:lemma	valdžia
 10060621-n	lit:lemma	aplinkosaugininkas
 06072145-n	lit:lemma	miškininkystė
@@ -16011,18 +16011,18 @@
 05808218-n	lit:lemma	įžvalga
 01113867-n	lit:lemma	prekiavimas
 13670521-n	lit:lemma	Tuniso piniginis vienetas
-01893510-s	lit:lemma	nuolankus
+01893510-a	lit:lemma	nuolankus
 13688033-n	lit:lemma	Vokietijos markė
-01166413-s	lit:lemma	sveikas
+01166413-a	lit:lemma	sveikas
 00780148-n	lit:lemma	klastojimas
 05118251-n	lit:lemma	nesaikingumas
 11460829-n	lit:lemma	šaltasis frontas
-01024228-s	lit:lemma	prisitaikantis
+01024228-a	lit:lemma	prisitaikantis
 05752544-n	lit:lemma	išmokimas
 02629535-v	lit:lemma	įtraukti
 01182709-v	lit:lemma	parūpinti
 04079933-n	lit:lemma	varžas
-00852754-s	lit:lemma	legalus
+00852754-a	lit:lemma	legalus
 11524662-n	lit:lemma	atmosferos sąlygos
 01705494-v	lit:lemma	rašyti
 10631941-n	lit:lemma	specialistas

--- a/wns/slk/wn-data-slk.tab
+++ b/wns/slk/wn-data-slk.tab
@@ -5,10 +5,10 @@
 10125786-n	slk:lemma	generál
 08065234-n	slk:lemma	systém
 04089152-n	slk:lemma	hrebeňová väznica strechy
-01601297-s	slk:lemma	severský
+01601297-a	slk:lemma	severský
 01170962-n	slk:lemma	konflikt
 00075966-r	slk:lemma	opačne
-00874226-s	slk:lemma	živý
+00874226-a	slk:lemma	živý
 01130169-v	slk:lemma	ochraňovať
 05804793-n	slk:lemma	uvedomovanie si
 06447763-n	slk:lemma	Júdov list
@@ -36,7 +36,7 @@
 13875571-n	slk:lemma	očko
 04061969-n	slk:lemma	nika
 02269143-v	slk:lemma	ušetriť si
-00341655-s	slk:lemma	nestály
+00341655-a	slk:lemma	nestály
 01888511-v	slk:lemma	triasť sa
 01003050-a	slk:lemma	finálny
 13508183-n	slk:lemma	posun o riadok
@@ -45,9 +45,9 @@
 07445265-n	slk:lemma	postup
 04951373-n	slk:lemma	svetlosť
 10339966-n	slk:lemma	hudobník
-01258264-s	slk:lemma	mrazivý
+01258264-a	slk:lemma	mrazivý
 01002297-v	slk:lemma	zaznamenávať
-01640124-s	slk:lemma	starodávny
+01640124-a	slk:lemma	starodávny
 00900726-n	slk:lemma	maľovanie
 02541302-a	slk:lemma	nemocný
 00531489-v	slk:lemma	znižovať sa
@@ -58,7 +58,7 @@
 03551084-n	slk:lemma	kvapalinová brzda
 00592199-n	slk:lemma	úrad starešinu
 08415127-n	slk:lemma	zablokovaná porota
-00370267-s	slk:lemma	bledomodrý
+00370267-a	slk:lemma	bledomodrý
 01601234-v	slk:lemma	nosiť sa
 02122164-v	slk:lemma	bolieť
 00746718-v	slk:lemma	zaveliť
@@ -68,17 +68,17 @@
 00033852-v	slk:lemma	mračiť sa
 00943563-v	slk:lemma	rozprávať o
 02642814-v	slk:lemma	presúvať
-01475160-s	slk:lemma	schopný riadiť
+01475160-a	slk:lemma	schopný riadiť
 03832673-n	slk:lemma	laptop
 00990719-n	slk:lemma	priama paľba
 02464461-n	slk:lemma	zadná končatina
 00356954-v	slk:lemma	zdvihnúť sa
 00017282-v	slk:lemma	zosypať sa (od vyčerpania)
-00331167-s	slk:lemma	ležiaci presne uprostred
-02090567-s	slk:lemma	nápadný
+00331167-a	slk:lemma	ležiaci presne uprostred
+02090567-a	slk:lemma	nápadný
 00252019-v	slk:lemma	vyvinúť
 04975122-n	slk:lemma	nuansa
-00431004-s	slk:lemma	neurčitý
+00431004-a	slk:lemma	neurčitý
 02136271-v	slk:lemma	odrážať
 06492811-n	slk:lemma	zoznam adresátov
 13354154-n	slk:lemma	nevyhnutné finančné prostriedky
@@ -102,10 +102,10 @@
 00673766-v	slk:lemma	podhodnotiť
 14899152-n	slk:lemma	médium
 03129123-n	slk:lemma	kreácia
-01177899-s	slk:lemma	mentálny
+01177899-a	slk:lemma	mentálny
 13780719-n	slk:lemma	vzťah
 13403025-n	slk:lemma	bremeno
-00522463-s	slk:lemma	úplný
+00522463-a	slk:lemma	úplný
 01115916-v	slk:lemma	odolávať
 06218459-n	slk:lemma	ľavicová politika
 08240169-n	slk:lemma	zostava
@@ -127,7 +127,7 @@
 00621627-n	slk:lemma	úsilie
 01580467-v	slk:lemma	obkolesiť
 00259177-n	slk:lemma	naprávať
-00169692-s	slk:lemma	tmavý
+00169692-a	slk:lemma	tmavý
 13461162-n	slk:lemma	dopyt
 00088303-r	slk:lemma	dočasne
 05702726-n	slk:lemma	zreteľ
@@ -137,16 +137,16 @@
 01642924-v	slk:lemma	predvádzať
 01880113-v	slk:lemma	udierať
 01441100-v	slk:lemma	prebodávať
-01388062-s	slk:lemma	ohromný
+01388062-a	slk:lemma	ohromný
 04358381-n	slk:lemma	povrch
 14036203-n	slk:lemma	emotívny prejav
-01451768-s	slk:lemma	požehnaný
-00535293-s	slk:lemma	nepresný
+01451768-a	slk:lemma	požehnaný
+00535293-a	slk:lemma	nepresný
 10010632-n	slk:lemma	dedič
 08081403-n	slk:lemma	obrana
 02768864-n	slk:lemma	kulisy
 01805982-v	slk:lemma	uznať
-01011753-s	slk:lemma	úvodný
+01011753-a	slk:lemma	úvodný
 04697267-n	slk:lemma	nenápadnosť
 03649909-n	slk:lemma	kosačka na trávu
 04904352-n	slk:lemma	pokoj
@@ -168,7 +168,7 @@
 01323958-v	slk:lemma	zabiť
 04574999-n	slk:lemma	koleso
 00752493-v	slk:lemma	prosiť
-02344070-s	slk:lemma	pravý
+02344070-a	slk:lemma	pravý
 06750804-n	slk:lemma	výrok
 10402086-n	slk:lemma	horlivec
 00998399-v	slk:lemma	nahrať
@@ -178,12 +178,12 @@
 06429590-n	slk:lemma	posvätný text
 01874568-v	slk:lemma	spustiť na vodu
 07289014-n	slk:lemma	problém
-00028471-s	slk:lemma	zdanlivý
-02031473-s	slk:lemma	liberálny
+00028471-a	slk:lemma	zdanlivý
+02031473-a	slk:lemma	liberálny
 07837362-n	slk:lemma	biela omáčka
 06082136-n	slk:lemma	poznávacia neuroveda
 01960911-v	slk:lemma	plávať
-01038580-s	slk:lemma	obecný
+01038580-a	slk:lemma	obecný
 06184270-n	slk:lemma	kresťanská teológia
 02564674-v	slk:lemma	brať ohľad (na niekoho)
 01874875-v	slk:lemma	uniesť, odniesť po vode
@@ -231,13 +231,13 @@
 03276179-n	slk:lemma	elektromagnet
 00447221-n	slk:lemma	sánkovanie
 11911274-n	slk:lemma	Campanulales
-01647983-s	slk:lemma	dospievajúci
+01647983-a	slk:lemma	dospievajúci
 00221583-r	slk:lemma	vo všeobecnosti
 02549211-v	slk:lemma	poštvať
 00084759-r	slk:lemma	zvlášť
 02262752-v	slk:lemma	predkladať
 02959942-n	slk:lemma	vagón
-02405805-s	slk:lemma	dobrodružný
+02405805-a	slk:lemma	dobrodružný
 07672914-n	slk:lemma	margarín
 00835609-a	slk:lemma	neúčinný
 15137890-n	slk:lemma	prázdniny
@@ -246,13 +246,13 @@
 03209666-n	slk:lemma	mechanika diskovej pamäte
 08521267-n	slk:lemma	nebo
 15143477-n	slk:lemma	koniec
-00995647-s	slk:lemma	nepriaznivý
-02163602-s	slk:lemma	pozoruhodný
+00995647-a	slk:lemma	nepriaznivý
+02163602-a	slk:lemma	pozoruhodný
 01635432-v	slk:lemma	zviditeľňovať
 05000537-n	slk:lemma	obezita
-00422168-s	slk:lemma	olejový
+00422168-a	slk:lemma	olejový
 03961070-n	slk:lemma	kus skla
-00674732-s	slk:lemma	domáci
+00674732-a	slk:lemma	domáci
 09967063-n	slk:lemma	kozmetik
 15141059-n	slk:lemma	dni (života)
 06142861-n	slk:lemma	poznávacia veda
@@ -265,18 +265,18 @@
 06314144-n	slk:lemma	veta
 00268112-n	slk:lemma	kontrola
 00064504-n	slk:lemma	trhák
-02516148-s	slk:lemma	očný
+02516148-a	slk:lemma	očný
 06814870-n	slk:lemma	hudobný záznam
 02677231-a	slk:lemma	podobný krabovi
 01434278-v	slk:lemma	odviesť
 00622384-v	slk:lemma	popliesť
-02465519-s	slk:lemma	čestný
+02465519-a	slk:lemma	čestný
 02663141-v	slk:lemma	vyvrátiť
 00231567-n	slk:lemma	anulovať
 04635104-n	slk:lemma	energickosť
 00027167-n	slk:lemma	lokalita
 09619824-n	slk:lemma	individualista
-02071782-s	slk:lemma	spriaznený
+02071782-a	slk:lemma	spriaznený
 14058934-n	slk:lemma	porucha hmatu
 00397010-n	slk:lemma	cenzurovanie
 12708654-n	slk:lemma	horký pomaranč
@@ -292,7 +292,7 @@
 00089324-v	slk:lemma	dezinfikovať
 00220869-v	slk:lemma	zosilniť
 00138611-r	slk:lemma	možno
-01948958-s	slk:lemma	krehký
+01948958-a	slk:lemma	krehký
 01041968-n	slk:lemma	modlitba
 01108627-v	slk:lemma	potláčať
 00252019-v	slk:lemma	vyvinúť sa
@@ -300,7 +300,7 @@
 00155298-n	slk:lemma	vyvrátenie
 14802450-n	slk:lemma	oceľ
 09712448-n	slk:lemma	Haiťan
-00066146-s	slk:lemma	odvážny
+00066146-a	slk:lemma	odvážny
 13509196-n	slk:lemma	zmenšenie
 00601822-v	slk:lemma	venovať sa
 07753592-n	slk:lemma	banán
@@ -316,7 +316,7 @@
 13451204-n	slk:lemma	súbežná operácia
 02131942-n	slk:lemma	rod Ursus
 14473222-n	slk:lemma	šťastie
-00719442-s	slk:lemma	rozmarný
+00719442-a	slk:lemma	rozmarný
 03834604-n	slk:lemma	nukleárna zbraň
 00112843-r	slk:lemma	od základu
 00311809-n	slk:lemma	vychádzka
@@ -325,7 +325,7 @@
 00229605-v	slk:lemma	pozdvihovať
 00348247-r	slk:lemma	veselo
 05554405-n	slk:lemma	prsník
-02526124-s	slk:lemma	nezdolateľný
+02526124-a	slk:lemma	nezdolateľný
 09029457-n	slk:lemma	Sudánska republika
 05517578-n	slk:lemma	cysta
 15238570-n	slk:lemma	hlavná sezóna
@@ -335,7 +335,7 @@
 00753973-n	slk:lemma	podvod
 07969695-n	slk:lemma	klan
 09418059-n	slk:lemma	Russian River
-00538891-s	slk:lemma	rastúci v strapcoch
+00538891-a	slk:lemma	rastúci v strapcoch
 00658052-v	slk:lemma	stanoviť
 00552815-v	slk:lemma	rozpadávať sa
 00157528-r	slk:lemma	celkom
@@ -349,7 +349,7 @@
 00746718-v	slk:lemma	veliť
 03264136-n	slk:lemma	hrana
 03017428-n	slk:lemma	komín
-02081114-s	slk:lemma	OK
+02081114-a	slk:lemma	OK
 06526619-n	slk:lemma	výsada
 08121301-n	slk:lemma	hasiči
 00552815-v	slk:lemma	rozložiť sa
@@ -363,9 +363,9 @@
 01111028-v	slk:lemma	prebojovávať sa
 02295550-v	slk:lemma	zdieľať
 02477135-v	slk:lemma	oslobodiť z otroctva
-02165432-s	slk:lemma	plytký
+02165432-a	slk:lemma	plytký
 09377315-n	slk:lemma	Ohio
-01901186-s	slk:lemma	meškajúci
+01901186-a	slk:lemma	meškajúci
 09856401-n	slk:lemma	milovník vtáctva
 02066939-v	slk:lemma	vliať sa
 08593924-n	slk:lemma	čiara
@@ -373,11 +373,11 @@
 00217773-n	slk:lemma	skaza
 01207527-v	slk:lemma	štúrať sa
 01826498-v	slk:lemma	mať radšej
-01022785-s	slk:lemma	pružný
+01022785-a	slk:lemma	pružný
 00066025-v	slk:lemma	poplakávať
 01340439-v	slk:lemma	upevňovať
 01091427-v	slk:lemma	hájiť sa
-00570322-s	slk:lemma	neprekonateľný
+00570322-a	slk:lemma	neprekonateľný
 09042322-n	slk:lemma	Smyrna
 07966570-n	slk:lemma	minorita
 00685683-v	slk:lemma	zamietať
@@ -421,18 +421,18 @@
 00266812-r	slk:lemma	istotne
 05984936-n	slk:lemma	kultúra
 00358431-v	slk:lemma	umrieť
-01870636-s	slk:lemma	amatérsky
+01870636-a	slk:lemma	amatérsky
 02131653-n	slk:lemma	medveď
 15169421-n	slk:lemma	súmrak
-02343110-s	slk:lemma	vynikajúci
+02343110-a	slk:lemma	vynikajúci
 00700708-v	slk:lemma	stanoviť
-01981009-s	slk:lemma	geometrický
+01981009-a	slk:lemma	geometrický
 04198562-n	slk:lemma	dámske voľné šaty
 07125096-n	slk:lemma	nadávka
 01171183-v	slk:lemma	ďugnúť si
 04188179-n	slk:lemma	plachta
 05995576-n	slk:lemma	liberalizmus
-02126430-s	slk:lemma	rozložený
+02126430-a	slk:lemma	rozložený
 05298988-n	slk:lemma	útroby
 02637202-v	slk:lemma	počkať
 01749320-a	slk:lemma	dokonalý
@@ -443,7 +443,7 @@
 09256663-n	slk:lemma	Koralové more
 01009871-n	slk:lemma	usporiadanie
 03407369-n	slk:lemma	poistka
-02388921-s	slk:lemma	zdomácnený
+02388921-a	slk:lemma	zdomácnený
 09874862-n	slk:lemma	družička
 14033185-n	slk:lemma	kritický bod
 08415272-n	slk:lemma	obvyklá porota
@@ -460,7 +460,7 @@
 02363358-a	slk:lemma	nepodliehajúci
 06834458-n	slk:lemma	delta
 01907076-v	slk:lemma	odprevadiť
-00796715-s	slk:lemma	neprirodzený
+00796715-a	slk:lemma	neprirodzený
 07206096-n	slk:lemma	odvolanie
 01835496-v	slk:lemma	presunúť
 03214966-n	slk:lemma	pohovka
@@ -476,7 +476,7 @@
 01171183-v	slk:lemma	nacengávať sa
 03390207-n	slk:lemma	fragment
 02972182-n	slk:lemma	kazeta
-01729819-s	slk:lemma	predošlý
+01729819-a	slk:lemma	predošlý
 09007723-n	slk:lemma	Sovietske Rusko
 14488118-n	slk:lemma	usadenina
 13525549-n	slk:lemma	fungovanie
@@ -499,12 +499,12 @@
 05405139-n	slk:lemma	slzný sekrét
 13397174-n	slk:lemma	dlh
 02727462-v	slk:lemma	pobývať
-02421364-s	slk:lemma	sporivý
+02421364-a	slk:lemma	sporivý
 00801724-n	slk:lemma	predajná kampaň
 13983147-n	slk:lemma	iluminácia
 14839322-n	slk:lemma	Duralumín
 06667169-n	slk:lemma	faktická otázka
-00819526-s	slk:lemma	pokročilý
+00819526-a	slk:lemma	pokročilý
 10513120-n	slk:lemma	editor
 00355420-n	slk:lemma	uvoľnenie
 03580615-n	slk:lemma	net
@@ -532,11 +532,11 @@
 02172888-v	slk:lemma	znieť
 05509889-n	slk:lemma	dýchací systém
 00204125-r	slk:lemma	nesprávne
-01649720-s	slk:lemma	mladý
+01649720-a	slk:lemma	mladý
 13382614-n	slk:lemma	priehradkový šek
 01845272-n	slk:lemma	Anseriformes
 01712704-v	slk:lemma	vykonať
-02558528-s	slk:lemma	poriadny
+02558528-a	slk:lemma	poriadny
 14122235-n	slk:lemma	nákaza
 00087188-r	slk:lemma	rozhodne
 04694441-n	slk:lemma	škvrna
@@ -553,14 +553,14 @@
 01343204-v	slk:lemma	pripevniť
 02061069-v	slk:lemma	strhávať sa
 02496816-v	slk:lemma	utláčať
-01199083-s	slk:lemma	pestrý
+01199083-a	slk:lemma	pestrý
 05531814-n	slk:lemma	priedušnica
-01388062-s	slk:lemma	fantastický
+01388062-a	slk:lemma	fantastický
 04093625-n	slk:lemma	korčuliarska dráha
-01715287-s	slk:lemma	opísaný
+01715287-a	slk:lemma	opísaný
 10291469-n	slk:lemma	muž v zbrani
-01114973-s	slk:lemma	nezávidiaci
-01781076-s	slk:lemma	psychologický
+01114973-a	slk:lemma	nezávidiaci
+01781076-a	slk:lemma	psychologický
 00424599-n	slk:lemma	neľudské zaobchádzanie
 01195867-n	slk:lemma	súdne konanie
 06632097-n	slk:lemma	stisknutie ruky
@@ -569,7 +569,7 @@
 05109808-n	slk:lemma	klesanie
 00705924-v	slk:lemma	prebiehať
 03404449-n	slk:lemma	ohnisko
-00459553-s	slk:lemma	v Adamovom rúchu
+00459553-a	slk:lemma	v Adamovom rúchu
 00781355-n	slk:lemma	drobná krádež
 00419375-v	slk:lemma	uvoľniť
 08411170-n	slk:lemma	súkromná škola (akadémia)
@@ -586,7 +586,7 @@
 02539686-v	slk:lemma	brať na seba
 02734544-a	slk:lemma	genetický
 02050132-v	slk:lemma	prechádzať
-02398378-s	slk:lemma	ostrý
+02398378-a	slk:lemma	ostrý
 08734044-n	slk:lemma	Kongo
 02462580-v	slk:lemma	odhlasovať
 00206479-r	slk:lemma	rýchlo
@@ -619,12 +619,12 @@
 06724942-n	slk:lemma	popis práce
 00713167-v	slk:lemma	spojiť si
 00362355-n	slk:lemma	oslabovanie
-00904745-s	slk:lemma	hnusný
+00904745-a	slk:lemma	hnusný
 06269956-n	slk:lemma	vedecký článok
 14085474-n	slk:lemma	akinéza
 00059854-r	slk:lemma	stále viac
 05949726-n	slk:lemma	hlas ľudu
-00602563-s	slk:lemma	diskutabilný
+00602563-a	slk:lemma	diskutabilný
 08349916-n	slk:lemma	ústredná banka
 02640226-v	slk:lemma	zdržať sa
 00318082-a	slk:lemma	neúplný
@@ -636,7 +636,7 @@
 10592152-n	slk:lemma	maloobchodník
 02710438-a	slk:lemma	na dodanie
 01153548-n	slk:lemma	diskriminovanie
-01091728-s	slk:lemma	prevádzkový
+01091728-a	slk:lemma	prevádzkový
 00828990-n	slk:lemma	imunizácia
 02108026-v	slk:lemma	trpieť
 07452699-n	slk:lemma	slávnostné otvorenie
@@ -651,7 +651,7 @@
 00070965-n	slk:lemma	lapsus
 00153961-n	slk:lemma	overenie
 04589745-n	slk:lemma	okno
-01517632-s	slk:lemma	bojujúci
+01517632-a	slk:lemma	bojujúci
 01640855-v	slk:lemma	zrealizovať
 00722232-v	slk:lemma	koncentrovať sa
 00890590-v	slk:lemma	zaručovať
@@ -661,11 +661,11 @@
 00726300-v	slk:lemma	pripisovať
 09167101-n	slk:lemma	Zimbabwe
 10703336-n	slk:lemma	zhotoviteľ závetu
-02378872-s	slk:lemma	súčasný
+02378872-a	slk:lemma	súčasný
 13278375-n	slk:lemma	poplatok
 10720964-n	slk:lemma	člen odborovej únie
-00860932-s	slk:lemma	schopný abstraktne myslieť
-02179968-s	slk:lemma	vrelý
+00860932-a	slk:lemma	schopný abstraktne myslieť
+02179968-a	slk:lemma	vrelý
 08674970-n	slk:lemma	pozemok
 00966152-v	slk:lemma	prihlásiť sa (na recepcii)
 08981244-n	slk:lemma	Filipíny
@@ -674,7 +674,7 @@
 06763273-n	slk:lemma	poznámka
 06641524-n	slk:lemma	index producentských cien
 05098311-n	slk:lemma	amplitúda
-01375831-s	slk:lemma	povestný
+01375831-a	slk:lemma	povestný
 07000195-n	slk:lemma	diagram
 11808468-n	slk:lemma	klinec
 08753933-n	slk:lemma	Jamajka
@@ -689,12 +689,12 @@
 02022804-v	slk:lemma	ísť naproti
 00199659-v	slk:lemma	dávať
 01130169-v	slk:lemma	byť na stráži
-01560821-s	slk:lemma	dojemný
+01560821-a	slk:lemma	dojemný
 15010703-n	slk:lemma	soľ
 00085512-r	slk:lemma	jednoznačne
 05553768-n	slk:lemma	hrudný kôš
 07232988-n	slk:lemma	osočenie
-01041209-s	slk:lemma	mierny
+01041209-a	slk:lemma	mierny
 03578656-n	slk:lemma	rozhranie
 00853633-v	slk:lemma	žartovať
 05691492-n	slk:lemma	ideologická bariéra
@@ -708,7 +708,7 @@
 08651832-n	slk:lemma	brloh
 04978216-n	slk:lemma	ponurosť
 03899328-n	slk:lemma	cestička
-01282510-s	slk:lemma	strašný
+01282510-a	slk:lemma	strašný
 00273048-r	slk:lemma	prudko
 04882968-n	slk:lemma	prekážka
 01982646-a	slk:lemma	uznávaný
@@ -718,7 +718,7 @@
 00579712-v	slk:lemma	podrobovať sa
 00839834-v	slk:lemma	preháňať (niečo)
 01631072-v	slk:lemma	zlepšiť
-00157268-s	slk:lemma	uzavretý
+00157268-a	slk:lemma	uzavretý
 02536557-v	slk:lemma	ovplyvniť
 00089351-n	slk:lemma	obnova
 00609683-v	slk:lemma	nezabúdať
@@ -726,9 +726,9 @@
 09203217-n	slk:lemma	Araxes
 13903079-n	slk:lemma	hrana
 07553741-n	slk:lemma	súcit
-02465519-s	slk:lemma	spoľahlivý
+02465519-a	slk:lemma	spoľahlivý
 10121952-n	slk:lemma	pohroma
-00124685-s	slk:lemma	ponorený
+00124685-a	slk:lemma	ponorený
 06628861-n	slk:lemma	potvrdenie
 04061442-n	slk:lemma	objímka
 09242514-n	slk:lemma	rieka Chattahoochee
@@ -777,8 +777,8 @@
 02298160-v	slk:lemma	predať na trhu
 00943837-v	slk:lemma	vyjadriť
 04590553-n	slk:lemma	predné sklo
-00798103-s	slk:lemma	otupelý
-02341864-s	slk:lemma	prvoradý
+00798103-a	slk:lemma	otupelý
+02341864-a	slk:lemma	prvoradý
 02141973-v	slk:lemma	pochváliť
 00630380-v	slk:lemma	hĺbať
 05528854-n	slk:lemma	nosohltan
@@ -788,12 +788,12 @@
 02157731-v	slk:lemma	pokrývať mrakmi
 03347731-n	slk:lemma	ohnivá pasca
 02412080-n	slk:lemma	baran
-02104727-s	slk:lemma	fotosenzitívny
+02104727-a	slk:lemma	fotosenzitívny
 02452464-n	slk:lemma	pysk
 07397355-n	slk:lemma	hrom
 05859991-n	slk:lemma	násobok
 06956129-n	slk:lemma	uralčina
-00563288-s	slk:lemma	ironický
+00563288-a	slk:lemma	ironický
 01212572-v	slk:lemma	chopiť sa
 11878520-n	slk:lemma	horčičný olej
 04151940-n	slk:lemma	skrýša
@@ -801,7 +801,7 @@
 04146050-n	slk:lemma	školská budova
 00978993-n	slk:lemma	plošný nálet
 05129565-n	slk:lemma	vzdialenosť
-01998730-s	slk:lemma	nešikovný
+01998730-a	slk:lemma	nešikovný
 12590715-n	slk:lemma	palmový orech
 00052500-n	slk:lemma	pristávanie
 09272595-n	slk:lemma	rieka Elizabeth
@@ -815,7 +815,7 @@
 06415419-n	slk:lemma	zošit
 02824448-n	slk:lemma	zvon
 11482312-n	slk:lemma	mikrovlny
-01262284-s	slk:lemma	humanitárny
+01262284-a	slk:lemma	humanitárny
 02811774-a	slk:lemma	tykadlovitý
 00512186-v	slk:lemma	blokovať
 13932421-n	slk:lemma	prijateľnosť
@@ -824,7 +824,7 @@
 00270215-v	slk:lemma	povolávať do vojenskej služby
 05596651-n	slk:lemma	bedro
 00930290-a	slk:lemma	nepredvídaný
-01463414-s	slk:lemma	nešťastne zamilovaný
+01463414-a	slk:lemma	nešťastne zamilovaný
 00963570-v	slk:lemma	hovoriť
 12694048-n	slk:lemma	čeľaď Malpighiaceae
 09466280-n	slk:lemma	makrokozmos
@@ -872,7 +872,7 @@
 01350449-v	slk:lemma	prinútiť
 02722782-v	slk:lemma	naliehať
 04328329-n	slk:lemma	akumulátorová batéria
-01649720-s	slk:lemma	mladícky
+01649720-a	slk:lemma	mladícky
 14016361-n	slk:lemma	únava
 10671387-n	slk:lemma	obyvateľ predmestia
 00333613-r	slk:lemma	nadmieru
@@ -889,16 +889,16 @@
 09929298-n	slk:lemma	horolezec
 00509607-v	slk:lemma	kvapkať
 10561222-n	slk:lemma	ratolesť
-00345694-s	slk:lemma	meniaci sa
+00345694-a	slk:lemma	meniaci sa
 14395403-n	slk:lemma	demencia
 00339934-v	slk:lemma	stávať sa
 00570066-n	slk:lemma	plavecký štýl
-00792202-s	slk:lemma	prevažný
+00792202-a	slk:lemma	prevažný
 12708293-n	slk:lemma	pomaranč
 01911232-v	slk:lemma	prejsť okolo niečoho
-00624576-s	slk:lemma	značný
+00624576-a	slk:lemma	značný
 08185758-n	slk:lemma	verejný záujem
-01212095-s	slk:lemma	maximálny
+01212095-a	slk:lemma	maximálny
 06193203-n	slk:lemma	zmýšľanie
 02064887-v	slk:lemma	odkloniť sa
 00232956-v	slk:lemma	ustúpiť
@@ -915,7 +915,7 @@
 02476518-v	slk:lemma	potvrdiť
 01280488-v	slk:lemma	ohýbať
 07377473-n	slk:lemma	kakofónia
-02257731-s	slk:lemma	elitársky
+02257731-a	slk:lemma	elitársky
 05456257-n	slk:lemma	čapík
 01790739-v	slk:lemma	rozrušiť
 05119714-n	slk:lemma	nadmiera
@@ -936,12 +936,12 @@
 09930772-n	slk:lemma	obchodník s konfekciou
 02004874-v	slk:lemma	vrátiť sa
 07197021-n	slk:lemma	testovanie
-02462089-s	slk:lemma	nepravdivý
+02462089-a	slk:lemma	nepravdivý
 03740161-n	slk:lemma	medikament
 13771404-n	slk:lemma	štipka
 15141894-n	slk:lemma	uchovateľnosť
 08397255-n	slk:lemma	armádny personál
-01755024-s	slk:lemma	nekonečný
+01755024-a	slk:lemma	nekonečný
 04695963-n	slk:lemma	poškvrna
 00706243-v	slk:lemma	ponúknuť
 08800258-n	slk:lemma	Rímska ríša
@@ -952,7 +952,7 @@
 00047392-r	slk:lemma	príliš
 00022131-r	slk:lemma	úplne (ako)
 04797482-n	slk:lemma	cudzosť
-01051814-s	slk:lemma	nešťastný
+01051814-a	slk:lemma	nešťastný
 02687172-n	slk:lemma	materská lietadlová loď
 05578442-n	slk:lemma	členok
 00358089-n	slk:lemma	drvenie
@@ -960,7 +960,7 @@
 13613985-n	slk:lemma	hektár
 00583246-n	slk:lemma	zameranie
 00203783-r	slk:lemma	natrvalo
-01878870-s	slk:lemma	primeraný
+01878870-a	slk:lemma	primeraný
 05779712-n	slk:lemma	predpoklad
 01238058-n	slk:lemma	decentralizácia
 09038597-n	slk:lemma	Turecká ríša
@@ -1006,7 +1006,7 @@
 01776974-a	slk:lemma	psychotropný
 02141973-v	slk:lemma	pochváliť sa
 07201804-n	slk:lemma	popis
-01280908-s	slk:lemma	banálny
+01280908-a	slk:lemma	banálny
 00322488-n	slk:lemma	zapúzdrenie
 00151426-r	slk:lemma	po úradných hodinách
 10597234-n	slk:lemma	podpisujúca strana
@@ -1015,11 +1015,11 @@
 02641463-v	slk:lemma	odsunúť
 00909219-v	slk:lemma	zahromžiť
 09230361-n	slk:lemma	Buzzardský záliv
-00477661-s	slk:lemma	vyzerajúci ako doma
+00477661-a	slk:lemma	vyzerajúci ako doma
 01922562-a	slk:lemma	nervózny
 04472098-n	slk:lemma	dopravná linka
 02434976-v	slk:lemma	stávať sa členom
-01427333-s	slk:lemma	zhubný
+01427333-a	slk:lemma	zhubný
 00008007-r	slk:lemma	dokonale
 05404336-n	slk:lemma	semeno
 00037006-n	slk:lemma	majstrovský kus
@@ -1040,7 +1040,7 @@
 04317420-n	slk:lemma	palička
 14433587-n	slk:lemma	dôležitosť
 02620587-v	slk:lemma	zobrazovať
-01499269-s	slk:lemma	neobmedzený
+01499269-a	slk:lemma	neobmedzený
 02200035-a	slk:lemma	radový
 00084759-r	slk:lemma	obzvlášť
 00964569-n	slk:lemma	napadnutie
@@ -1079,7 +1079,7 @@
 10791221-n	slk:lemma	pracujúci
 02415573-v	slk:lemma	pracovať ostošesť
 07966140-n	slk:lemma	spoločnosť
-00527188-s	slk:lemma	univerzálny
+00527188-a	slk:lemma	univerzálny
 08381165-n	slk:lemma	management
 14563784-n	slk:lemma	osvietenie
 02479323-v	slk:lemma	vydať
@@ -1091,8 +1091,8 @@
 09223725-n	slk:lemma	obal
 01066163-n	slk:lemma	odklad
 01853461-a	slk:lemma	sekundárny
-00195684-s	slk:lemma	hrozný
-01649031-s	slk:lemma	maličký
+00195684-a	slk:lemma	hrozný
+01649031-a	slk:lemma	maličký
 02066939-v	slk:lemma	natiecť prúdom
 10375794-n	slk:lemma	starý majster
 10768903-n	slk:lemma	umývač
@@ -1107,10 +1107,10 @@
 01609287-v	slk:lemma	ťahať
 04594218-n	slk:lemma	drôt
 00034634-v	slk:lemma	skriviť
-02038126-s	slk:lemma	urastený
+02038126-a	slk:lemma	urastený
 00293141-v	slk:lemma	skrášliť
 03702719-n	slk:lemma	plášť do dažďa
-00459553-s	slk:lemma	v Evinom rúchu
+00459553-a	slk:lemma	v Evinom rúchu
 00906367-v	slk:lemma	usvedčovať
 01264283-v	slk:lemma	dať povrchový finiš
 00397576-v	slk:lemma	rozložiť sa
@@ -1159,7 +1159,7 @@
 03901338-n	slk:lemma	ťažký ochranný štít
 00623162-n	slk:lemma	ručná práca
 15155220-n	slk:lemma	stredný slnečný deň
-01885991-s	slk:lemma	chránený
+01885991-a	slk:lemma	chránený
 10434160-n	slk:lemma	hráč nastupujúci len na odpal
 09867956-n	slk:lemma	šéf
 02154508-v	slk:lemma	nachádzať
@@ -1171,7 +1171,7 @@
 00211462-n	slk:lemma	skončenie
 00212808-n	slk:lemma	prenechanie
 00836277-a	slk:lemma	namáhavý
-00901969-s	slk:lemma	podstatný
+00901969-a	slk:lemma	podstatný
 00434075-n	slk:lemma	prevaľovanie
 13659604-n	slk:lemma	hm
 00847478-v	slk:lemma	zničiť (niekoho)
@@ -1204,7 +1204,7 @@
 02274482-v	slk:lemma	uzurpovať si
 02671062-n	slk:lemma	prístup
 13880102-n	slk:lemma	trojuholníkový tvar
-01392249-s	slk:lemma	trpasličí
+01392249-a	slk:lemma	trpasličí
 05645854-n	slk:lemma	tuposť
 01578254-v	slk:lemma	ponárať sa
 00071178-v	slk:lemma	mučiť
@@ -1221,7 +1221,7 @@
 02274482-v	slk:lemma	zbaviť
 01565360-v	slk:lemma	pohlcovať
 01010118-v	slk:lemma	vysloviť sa
-00453053-s	slk:lemma	dôverný
+00453053-a	slk:lemma	dôverný
 00436879-v	slk:lemma	obohacovať
 02469835-v	slk:lemma	spájať
 00899847-v	slk:lemma	pozdraviť šalom
@@ -1241,10 +1241,10 @@
 02496816-v	slk:lemma	podriaďovať sa
 09026614-n	slk:lemma	Malaga
 05510702-n	slk:lemma	zmyslové orgány
-01439496-s	slk:lemma	zakorenený
+01439496-a	slk:lemma	zakorenený
 10640620-n	slk:lemma	partner
 00356199-n	slk:lemma	spotreba
-01318741-s	slk:lemma	ranený
+01318741-a	slk:lemma	ranený
 00823316-n	slk:lemma	prostriedky zabezpečenia
 05365164-n	slk:lemma	prstová žila
 00183505-n	slk:lemma	voľby
@@ -1254,10 +1254,10 @@
 15238895-n	slk:lemma	obdobie dažďov
 00632236-v	slk:lemma	predpokladať
 15229875-n	slk:lemma	tercia
-01888554-s	slk:lemma	ochranný
+01888554-a	slk:lemma	ochranný
 06734823-n	slk:lemma	usvedčujúci dôkaz
 00503102-r	slk:lemma	naliehavo
-01730060-s	slk:lemma	historický
+01730060-a	slk:lemma	historický
 08430203-n	slk:lemma	rad
 07467027-n	slk:lemma	pohárové finále
 00648224-v	slk:lemma	bádať
@@ -1276,11 +1276,11 @@
 00898019-v	slk:lemma	podávať si ruku s
 13744304-n	slk:lemma	štvorka
 07464725-n	slk:lemma	súťaž
-01025212-s	slk:lemma	skalný
+01025212-a	slk:lemma	skalný
 06713752-n	slk:lemma	hana
 09925592-n	slk:lemma	uchádzač
 00140967-v	slk:lemma	deformovať sa
-00580684-s	slk:lemma	poznačený
+00580684-a	slk:lemma	poznačený
 02483267-v	slk:lemma	popravovať
 00755447-v	slk:lemma	žiadať (o pomoc)
 13591761-n	slk:lemma	počet
@@ -1296,10 +1296,10 @@
 00954608-v	slk:lemma	vyjadrovať (názor)
 00356339-a	slk:lemma	nestály
 01306425-v	slk:lemma	obiť latami
-01392633-s	slk:lemma	maličký
+01392633-a	slk:lemma	maličký
 02099774-a	slk:lemma	starší
 02826877-a	slk:lemma	elektrický
-00712877-s	slk:lemma	nástojčivý
+00712877-a	slk:lemma	nástojčivý
 13864153-n	slk:lemma	vypuklý útvar
 14438125-n	slk:lemma	renomé
 00794825-a	slk:lemma	dramatický
@@ -1330,11 +1330,11 @@
 00029985-r	slk:lemma	ďalej
 02614023-v	slk:lemma	uliať sa
 01249724-v	slk:lemma	trieť
-01248958-s	slk:lemma	ostrý (vietor)
+01248958-a	slk:lemma	ostrý (vietor)
 01494310-v	slk:lemma	umiestňovať
-01192035-s	slk:lemma	mierny
+01192035-a	slk:lemma	mierny
 02630189-v	slk:lemma	charakterizovať
-02215087-s	slk:lemma	osobitý
+02215087-a	slk:lemma	osobitý
 01029500-v	slk:lemma	pomenúvať
 03593526-n	slk:lemma	pohár
 01048912-n	slk:lemma	ukrývanie
@@ -1348,7 +1348,7 @@
 00406243-v	slk:lemma	chystať si
 14801921-n	slk:lemma	liatina
 06422740-n	slk:lemma	návod
-00421513-s	slk:lemma	kalný
+00421513-a	slk:lemma	kalný
 08732807-n	slk:lemma	Barranquilla
 08752974-n	slk:lemma	Porto Rico
 10559192-n	slk:lemma	školák
@@ -1360,9 +1360,9 @@
 01220152-n	slk:lemma	prosba za odvrátenie
 02292004-v	slk:lemma	oplácať sa
 01171183-v	slk:lemma	piť
-01744515-s	slk:lemma	ostrý
+01744515-a	slk:lemma	ostrý
 04018155-n	slk:lemma	miestny rozhlas
-01744515-s	slk:lemma	prenikavý
+01744515-a	slk:lemma	prenikavý
 00164751-r	slk:lemma	ak)
 03416094-n	slk:lemma	brána
 02709908-n	slk:lemma	súčinové hradlo
@@ -1407,7 +1407,7 @@
 02419773-v	slk:lemma	oddrieť
 02877266-n	slk:lemma	kojenecká fľaša
 13328357-n	slk:lemma	depreciácia
-00126497-s	slk:lemma	predchádzajúci
+00126497-a	slk:lemma	predchádzajúci
 07150023-n	slk:lemma	kolektívne vyjednávanie
 01615180-a	slk:lemma	objektívny
 00188779-r	slk:lemma	nadšene
@@ -1438,20 +1438,20 @@
 02060141-v	slk:lemma	rozptýliť
 06438748-n	slk:lemma	Kniha proroka Ezechiela
 00249852-v	slk:lemma	dozrievať
-01710543-s	slk:lemma	nezaplatený
+01710543-a	slk:lemma	nezaplatený
 03523633-n	slk:lemma	hojdací koník
-00361125-s	slk:lemma	nepoškvrnený
+00361125-a	slk:lemma	nepoškvrnený
 02565687-v	slk:lemma	prehrešiť sa
 00402539-v	slk:lemma	komplikovať
 07200290-n	slk:lemma	odozva
 01022824-n	slk:lemma	zbavenie práv
-01134486-s	slk:lemma	vyrovnaný
-00177547-s	slk:lemma	šťastlivý
+01134486-a	slk:lemma	vyrovnaný
+00177547-a	slk:lemma	šťastlivý
 00550341-n	slk:lemma	javisková akcia
 07478874-n	slk:lemma	zrútenie
 00277064-r	slk:lemma	súkromne
 14173484-n	slk:lemma	angína
-00012071-s	slk:lemma	teoretický
+00012071-a	slk:lemma	teoretický
 14580897-n	slk:lemma	materiál
 13292613-n	slk:lemma	náhrada
 02477755-v	slk:lemma	odvolať
@@ -1465,9 +1465,9 @@
 00166952-v	slk:lemma	umŕtviť
 00689809-v	slk:lemma	domnievať sa
 06688522-n	slk:lemma	pripomienka
-01136248-s	slk:lemma	ufrfľaný
+01136248-a	slk:lemma	ufrfľaný
 08136027-n	slk:lemma	BJS
-00195383-s	slk:lemma	vzbudzujci rešpekt
+00195383-a	slk:lemma	vzbudzujci rešpekt
 05596004-n	slk:lemma	articulatio coxae
 02387034-v	slk:lemma	vychovať
 09686536-n	slk:lemma	Európan
@@ -1501,7 +1501,7 @@
 05762149-n	slk:lemma	myseľ
 00256507-v	slk:lemma	spuchnúť
 01597096-v	slk:lemma	ťahať dolu
-00557108-s	slk:lemma	zákonom ustanovený
+00557108-a	slk:lemma	zákonom ustanovený
 08324274-n	slk:lemma	sekretariát
 02769748-n	slk:lemma	batoh
 03097673-n	slk:lemma	riadiace tlačidlo
@@ -1511,8 +1511,8 @@
 11878808-n	slk:lemma	čínska kapusta
 07420538-n	slk:lemma	škoda
 00404073-r	slk:lemma	smrteľne
-00635244-s	slk:lemma	zdokonaliteľný
-01178458-s	slk:lemma	varixový
+00635244-a	slk:lemma	zdokonaliteľný
+01178458-a	slk:lemma	varixový
 09399592-n	slk:lemma	predhorie
 02189398-v	slk:lemma	zachytiť (sluchom)
 03145719-n	slk:lemma	guľa v biliarde alebo gulečníku
@@ -1527,7 +1527,7 @@
 04076846-n	slk:lemma	reprezentácia
 04850117-n	slk:lemma	spravodlivosť
 02678839-v	slk:lemma	uchvacovať
-01300187-s	slk:lemma	prísny
+01300187-a	slk:lemma	prísny
 00296178-v	slk:lemma	justovať
 00828779-a	slk:lemma	požívateľný
 10279018-n	slk:lemma	mechanik
@@ -1538,8 +1538,8 @@
 13837439-n	slk:lemma	pracovný vzťah
 08556491-n	slk:lemma	teritórium
 00334790-r	slk:lemma	prvou triedou (list)
-01443097-s	slk:lemma	miznúci
-00859632-s	slk:lemma	existenčný
+01443097-a	slk:lemma	miznúci
+00859632-a	slk:lemma	existenčný
 00178102-v	slk:lemma	obrať
 02663141-v	slk:lemma	byť v rozpore (s)
 00035758-v	slk:lemma	umývať
@@ -1555,40 +1555,40 @@
 00791134-v	slk:lemma	predvolať
 06371999-n	slk:lemma	novela
 00085811-r	slk:lemma	chvatne
-00616532-s	slk:lemma	upečený
-01253592-s	slk:lemma	studený ako ľad
+00616532-a	slk:lemma	upečený
+01253592-a	slk:lemma	studený ako ľad
 00183823-r	slk:lemma	rozvážne
 06650431-n	slk:lemma	potvrdenie
 05164353-n	slk:lemma	najvyššia daň
 07407137-n	slk:lemma	povodeň
 08388636-n	slk:lemma	baróni
-00012071-s	slk:lemma	abstraktný
-01223271-s	slk:lemma	falošný
-01765132-s	slk:lemma	vopred vylučujúci
+00012071-a	slk:lemma	abstraktný
+01223271-a	slk:lemma	falošný
+01765132-a	slk:lemma	vopred vylučujúci
 05124928-n	slk:lemma	krajnosť
 02299801-v	slk:lemma	ponúknuť viac
 09124039-n	slk:lemma	Long Island
 00285889-n	slk:lemma	krok
 05819644-n	slk:lemma	horká pravda
-01857956-s	slk:lemma	sekundárny
+01857956-a	slk:lemma	sekundárny
 02724483-a	slk:lemma	existenčný
 00164444-v	slk:lemma	občerstvovať sa
 05035353-n	slk:lemma	sila
 07943480-n	slk:lemma	veková skupina
 09050730-n	slk:lemma	juh Spojených štátov
 04436185-n	slk:lemma	trám
-01385773-s	slk:lemma	gargantuovský
+01385773-a	slk:lemma	gargantuovský
 13447361-n	slk:lemma	chemická reakcia
 00912048-v	slk:lemma	vykríknuť
 02312996-v	slk:lemma	snímať bremeno
 13489037-n	slk:lemma	vývin
-00545746-s	slk:lemma	nepozorný
+00545746-a	slk:lemma	nepozorný
 15272571-n	slk:lemma	polčas
-00027599-s	slk:lemma	prijatý
-01084297-s	slk:lemma	prepchatý
+00027599-a	slk:lemma	prijatý
+01084297-a	slk:lemma	prepchatý
 06695227-n	slk:lemma	pocta
 04355338-n	slk:lemma	slnečné hodiny
-00915321-s	slk:lemma	ideálny
+00915321-a	slk:lemma	ideálny
 00704690-v	slk:lemma	naplánovať
 01048210-n	slk:lemma	kriesenie
 06651577-n	slk:lemma	pokyn
@@ -1600,7 +1600,7 @@
 03094347-n	slk:lemma	kontaktná fotografia
 00167447-r	slk:lemma	koniec-koncov
 01184814-n	slk:lemma	súdny proces
-01035559-s	slk:lemma	zahraničného pôvodu
+01035559-a	slk:lemma	zahraničného pôvodu
 01761706-v	slk:lemma	zachvieť sa
 10500217-n	slk:lemma	kráľovná
 13586122-n	slk:lemma	ukazovateľ
@@ -1630,7 +1630,7 @@
 14376188-n	slk:lemma	stres
 02811980-a	slk:lemma	teratogénny
 00480993-n	slk:lemma	basketbal
-00998207-s	slk:lemma	podobný periu
+00998207-a	slk:lemma	podobný periu
 09367203-n	slk:lemma	niečo nevyhnutné
 06782680-n	slk:lemma	domnienka
 02830501-a	slk:lemma	literárny
@@ -1657,7 +1657,7 @@
 02381726-v	slk:lemma	preberať zodpovednosť
 10351874-n	slk:lemma	sprostredkovateľ
 03572449-n	slk:lemma	intarzia
-01124768-s	slk:lemma	prijateľný
+01124768-a	slk:lemma	prijateľný
 01237415-n	slk:lemma	spojenie
 01223182-v	slk:lemma	skrútiť
 00828704-n	slk:lemma	obliekanie
@@ -1683,13 +1683,13 @@
 05912814-n	slk:lemma	plán nákupu akcií
 05284851-n	slk:lemma	oblúk jarmový
 02154508-v	slk:lemma	všimnúť si
-00592880-s	slk:lemma	rekurentný
+00592880-a	slk:lemma	rekurentný
 00466053-v	slk:lemma	usporadúvať
-00893118-s	slk:lemma	pravdepodobný
+00893118-a	slk:lemma	pravdepodobný
 09131654-n	slk:lemma	OK
-01634027-s	slk:lemma	neoficiálny
+01634027-a	slk:lemma	neoficiálny
 03177349-n	slk:lemma	úschovňa
-00666610-s	slk:lemma	momentálny
+00666610-a	slk:lemma	momentálny
 09503877-n	slk:lemma	okultizmus
 02414710-v	slk:lemma	asistovať
 01048210-n	slk:lemma	resuscitácia
@@ -1701,7 +1701,7 @@
 00839194-v	slk:lemma	obalamutiť
 04722373-n	slk:lemma	nevhodnosť
 00598318-n	slk:lemma	funkcia, verejná
-01335903-s	slk:lemma	pohotový
+01335903-a	slk:lemma	pohotový
 13939892-n	slk:lemma	úroveň
 13925752-n	slk:lemma	postavenie
 01671039-v	slk:lemma	pliesť
@@ -1714,11 +1714,11 @@
 00807178-v	slk:lemma	zamietať
 03166213-n	slk:lemma	slepé okno
 00431552-n	slk:lemma	zábava
-01533535-s	slk:lemma	nadmerný
-01466476-s	slk:lemma	manželke verný
+01533535-a	slk:lemma	nadmerný
+01466476-a	slk:lemma	manželke verný
 08005877-n	slk:lemma	skalárne pole
 02525868-v	slk:lemma	prepočítať sa
-00011327-s	slk:lemma	pripomínajúci prasa
+00011327-a	slk:lemma	pripomínajúci prasa
 03112177-a	slk:lemma	rómsky
 00105603-r	slk:lemma	bystro
 09428628-n	slk:lemma	prímorie
@@ -1735,12 +1735,12 @@
 02308741-v	slk:lemma	prispievať
 03315805-n	slk:lemma	našité zdobenie
 07456906-n	slk:lemma	kolo
-01835409-s	slk:lemma	pragmatický
+01835409-a	slk:lemma	pragmatický
 00414881-n	slk:lemma	zvyk
 09375891-n	slk:lemma	Ob
 08250501-n	slk:lemma	rocková kapela
 01236164-v	slk:lemma	vrážať
-02552415-s	slk:lemma	bezvodý
+02552415-a	slk:lemma	bezvodý
 14923458-n	slk:lemma	železná ruda
 01810447-v	slk:lemma	zosmiešniť sa
 02294179-v	slk:lemma	dávať diel
@@ -1752,7 +1752,7 @@
 00709379-v	slk:lemma	chcieť
 03313333-n	slk:lemma	fasáda
 09019726-n	slk:lemma	Kazachstan
-01990653-s	slk:lemma	pevný
+01990653-a	slk:lemma	pevný
 01686956-v	slk:lemma	vyjadrovať
 00024814-v	slk:lemma	osviežovať sa
 10249270-n	slk:lemma	zákonodarca
@@ -1762,7 +1762,7 @@
 02877266-n	slk:lemma	fľaša pre kojencov
 12715569-n	slk:lemma	čeľaď Simaroubaceae
 01216522-v	slk:lemma	spájať sa
-00830051-s	slk:lemma	sčítaný
+00830051-a	slk:lemma	sčítaný
 02046755-v	slk:lemma	rotovať
 00257269-v	slk:lemma	rozrásť sa
 03686130-n	slk:lemma	pôjd
@@ -1798,15 +1798,15 @@
 14415518-n	slk:lemma	odlúčenosť
 02145814-v	slk:lemma	skrývať sa
 14464203-n	slk:lemma	porucha
-01306645-s	slk:lemma	oboznámený
-02552222-s	slk:lemma	vysušený na vzduchu
+01306645-a	slk:lemma	oboznámený
+02552222-a	slk:lemma	vysušený na vzduchu
 01774136-v	slk:lemma	hnusiť sa
 02795925-a	slk:lemma	semenonosný
 07270718-n	slk:lemma	poštová pečiatka
 00010054-v	slk:lemma	hýbať sa
 01635432-v	slk:lemma	v duchu vidieť
 10517405-n	slk:lemma	stály návštevník
-01263445-s	slk:lemma	beštiálny
+01263445-a	slk:lemma	beštiálny
 01291391-a	slk:lemma	prívesný
 02974697-n	slk:lemma	škatuľa
 04828925-n	slk:lemma	ľudskosť
@@ -1826,7 +1826,7 @@
 02737351-n	slk:lemma	koráb
 01338501-v	slk:lemma	pobíjať
 08173289-n	slk:lemma	Južná Amerika
-00547317-s	slk:lemma	stručný
+00547317-a	slk:lemma	stručný
 08388636-n	slk:lemma	peerstvo
 07950685-n	slk:lemma	obchodníci
 02760116-a	slk:lemma	lekársky
@@ -1839,13 +1839,13 @@
 04257790-n	slk:lemma	solárny článok
 02767308-v	slk:lemma	vydať
 08049989-n	slk:lemma	Britské spoločenstvo národov
-02535533-s	slk:lemma	rastúci
+02535533-a	slk:lemma	rastúci
 11473954-n	slk:lemma	viditeľné žiarenie
 10516016-n	slk:lemma	utečenec
 15230180-n	slk:lemma	šiesta hodina posvätného ofícia
 00416135-v	slk:lemma	emigrovať
 03816005-n	slk:lemma	odevné doplnky, ktoré sa nosia okolo krku
-01158180-s	slk:lemma	kamenný
+01158180-a	slk:lemma	kamenný
 02796623-n	slk:lemma	zátarasa
 02453321-v	slk:lemma	potláčať
 00413239-n	slk:lemma	zvyklosť
@@ -1860,15 +1860,15 @@
 08897065-n	slk:lemma	Egypt
 04678908-n	slk:lemma	ruško
 03588414-n	slk:lemma	prvok
-02130821-s	slk:lemma	nedoriešený
+02130821-a	slk:lemma	nedoriešený
 02642814-v	slk:lemma	odsúvať
 00807461-v	slk:lemma	namietnuť
 00876332-v	slk:lemma	predložiť na diskusiu
-00310433-s	slk:lemma	prepracovaný
+00310433-a	slk:lemma	prepracovaný
 06441607-n	slk:lemma	Matúš
 06399503-n	slk:lemma	pokračovanie
-00425313-s	slk:lemma	oplzlý
-00361125-s	slk:lemma	panenský
+00425313-a	slk:lemma	oplzlý
+00361125-a	slk:lemma	panenský
 00305005-n	slk:lemma	pristátie
 00293657-n	slk:lemma	výlet
 05000342-n	slk:lemma	telnatosť
@@ -1881,7 +1881,7 @@
 13883346-n	slk:lemma	obdĺžnik
 07702193-n	slk:lemma	halušky
 00712031-n	slk:lemma	obrusovanie
-00049879-s	slk:lemma	doplnkový
+00049879-a	slk:lemma	doplnkový
 13634418-n	slk:lemma	jednotka svetla
 06174404-n	slk:lemma	gramatika
 13880811-n	slk:lemma	hexagram
@@ -1889,17 +1889,17 @@
 00342755-n	slk:lemma	vírenie
 02299801-v	slk:lemma	prekonať koho
 14452151-n	slk:lemma	plnosť
-01357027-s	slk:lemma	povzbudzujúci
+01357027-a	slk:lemma	povzbudzujúci
 02742322-n	slk:lemma	rúcho
 02106006-v	slk:lemma	cítiť
 01378123-v	slk:lemma	rozhadzovať
 07553301-n	slk:lemma	láska k blížnemu
-01742715-s	slk:lemma	bojovný
+01742715-a	slk:lemma	bojovný
 12712820-n	slk:lemma	Fortunella
 01038666-v	slk:lemma	rozprávať sa
 06381869-n	slk:lemma	verš
-01636205-s	slk:lemma	zákonný
-01712753-s	slk:lemma	boľavý
+01636205-a	slk:lemma	zákonný
+01712753-a	slk:lemma	boľavý
 02294179-v	slk:lemma	dať podiel
 01242164-n	slk:lemma	protest zamestnancov
 01170502-n	slk:lemma	verejné násilie
@@ -1912,12 +1912,12 @@
 00964343-n	slk:lemma	súboj
 06768901-n	slk:lemma	novelizácia
 14687633-n	slk:lemma	olej na svietenie
-00995647-s	slk:lemma	opačný
+00995647-a	slk:lemma	opačný
 06688274-n	slk:lemma	uznanie
 09220574-n	slk:lemma	Big Sioux River
 03106110-n	slk:lemma	povraz
 01195804-v	slk:lemma	márniť
-01742119-s	slk:lemma	mierumilovný
+01742119-a	slk:lemma	mierumilovný
 00971075-a	slk:lemma	štýlový
 00476819-a	slk:lemma	príjemný
 06833220-n	slk:lemma	T
@@ -1931,7 +1931,7 @@
 02373093-n	slk:lemma	Perissodactyla
 01925372-a	slk:lemma	rozumový
 02763901-n	slk:lemma	markíza
-02026629-s	slk:lemma	insolventný
+02026629-a	slk:lemma	insolventný
 00268112-n	slk:lemma	servis
 09142887-n	slk:lemma	Arlington
 09340644-n	slk:lemma	Little Missouri
@@ -1958,9 +1958,9 @@
 14799244-n	slk:lemma	abrazívny materiál
 00387310-v	slk:lemma	obracať sa
 02752987-a	slk:lemma	právnický
-00304144-s	slk:lemma	búrlivý
-01280908-s	slk:lemma	drobný
-02131958-s	slk:lemma	záletný
+00304144-a	slk:lemma	búrlivý
+01280908-a	slk:lemma	drobný
+02131958-a	slk:lemma	záletný
 01780434-v	slk:lemma	obávať sa
 10503247-n	slk:lemma	kšeftár
 10285135-n	slk:lemma	šľachtic
@@ -2020,9 +2020,9 @@
 02012344-v	slk:lemma	presunúť
 00382635-v	slk:lemma	pretvárať
 04049405-n	slk:lemma	nepremokavý plášť
-02250430-s	slk:lemma	samotný
+02250430-a	slk:lemma	samotný
 01824532-v	slk:lemma	želať
-01165943-s	slk:lemma	alternatívny
+01165943-a	slk:lemma	alternatívny
 02111129-n	slk:lemma	Leonberg
 06435394-n	slk:lemma	Knihy kroník
 01058574-v	slk:lemma	nadhadzovať
@@ -2055,11 +2055,11 @@
 04756172-n	slk:lemma	pravdepodobnosť
 02607455-a	slk:lemma	medicínsky
 06435394-n	slk:lemma	Knihy Paralipomenon
-01562416-s	slk:lemma	blížiaci sa
+01562416-a	slk:lemma	blížiaci sa
 04155625-n	slk:lemma	priesvitná opona
 10770059-n	slk:lemma	strážca
 00151497-n	slk:lemma	zisťovanie
-01525320-s	slk:lemma	nepohyblivý
+01525320-a	slk:lemma	nepohyblivý
 05945642-n	slk:lemma	presvedčenie
 01642924-v	slk:lemma	vykonať
 07382572-n	slk:lemma	krik
@@ -2090,18 +2090,18 @@
 00212414-v	slk:lemma	zachovávať
 01362736-v	slk:lemma	namaľovať
 00047534-r	slk:lemma	tak isto
-01619475-s	slk:lemma	samozrejmý
+01619475-a	slk:lemma	samozrejmý
 10322546-n	slk:lemma	mizogám
-02152473-s	slk:lemma	spoločný
+02152473-a	slk:lemma	spoločný
 05729036-n	slk:lemma	štatistické rozdelenie
 02216710-v	slk:lemma	dotovať
 00545344-n	slk:lemma	vokálna hudba
 07849336-n	slk:lemma	jogurt
 09917593-n	slk:lemma	mladík
 01525666-v	slk:lemma	ísť
-00453308-s	slk:lemma	dôverný
+00453308-a	slk:lemma	dôverný
 06634095-n	slk:lemma	odmietnutie
-00475308-s	slk:lemma	v plameňoch
+00475308-a	slk:lemma	v plameňoch
 00174987-r	slk:lemma	prudko
 06756407-n	slk:lemma	lož
 04498523-n	slk:lemma	turbína
@@ -2137,14 +2137,14 @@
 13996719-n	slk:lemma	utlačenosť
 00933154-a	slk:lemma	nákladný
 00146856-n	slk:lemma	spojenie
-01246148-s	slk:lemma	antagonistický
+01246148-a	slk:lemma	antagonistický
 00107230-r	slk:lemma	mimoriadne
 10683593-n	slk:lemma	ošetrovateľ prasiat
 02328150-n	slk:lemma	angorský králik
 10020807-n	slk:lemma	docent
 06833328-n	slk:lemma	U
 00281237-r	slk:lemma	tajnoskársky
-00746451-s	slk:lemma	mätúci
+00746451-a	slk:lemma	mätúci
 02467662-v	slk:lemma	deliť
 03051889-a	slk:lemma	lúpežný
 00925490-v	slk:lemma	žasnúť
@@ -2161,7 +2161,7 @@
 15247110-n	slk:lemma	mihnutie oka
 00282858-r	slk:lemma	neprestajne
 00152519-n	slk:lemma	genetická analýza
-01818077-s	slk:lemma	konštruktívny
+01818077-a	slk:lemma	konštruktívny
 14739861-n	slk:lemma	sebaková kyselina
 02463810-n	slk:lemma	stehno
 03933529-n	slk:lemma	nábrežie
@@ -2171,14 +2171,14 @@
 08247251-n	slk:lemma	kvarteto
 01203234-v	slk:lemma	žiť (z niečoho)
 00798717-v	slk:lemma	odprisahať
-01403760-s	slk:lemma	zakázaný
+01403760-a	slk:lemma	zakázaný
 10119874-n	slk:lemma	predák
-00547317-s	slk:lemma	kompaktný
+00547317-a	slk:lemma	kompaktný
 06279326-n	slk:lemma	elektronická pošta
 00406243-v	slk:lemma	pripravovať
 02406585-v	slk:lemma	byť nástupcom
 06271778-n	slk:lemma	telekomunikácia
-00792202-s	slk:lemma	nadradený
+00792202-a	slk:lemma	nadradený
 00150287-v	slk:lemma	podrobiť
 00366846-n	slk:lemma	stupňovanie
 00900726-n	slk:lemma	kreslenie
@@ -2200,7 +2200,7 @@
 00971650-v	slk:lemma	označiť
 02118933-v	slk:lemma	poznamenať si
 04633453-n	slk:lemma	verva
-00733743-s	slk:lemma	preferovaný
+00733743-a	slk:lemma	preferovaný
 00614999-v	slk:lemma	prehliadať
 04782878-n	slk:lemma	dôveryhodnosť
 00214951-v	slk:lemma	zmočiť sa
@@ -2247,13 +2247,13 @@
 01948450-v	slk:lemma	pestovať windsurfing
 03147509-n	slk:lemma	hrnček
 14918023-n	slk:lemma	tlačiarenská farba
-00850648-s	slk:lemma	upravený
-01044730-s	slk:lemma	neobradný
+00850648-a	slk:lemma	upravený
+01044730-a	slk:lemma	neobradný
 06831819-n	slk:lemma	géčko
 06518420-n	slk:lemma	poukážka na obed
-01207546-s	slk:lemma	dolný
+01207546-a	slk:lemma	dolný
 00366521-n	slk:lemma	predlžovanie
-01439155-s	slk:lemma	únavný
+01439155-a	slk:lemma	únavný
 00869596-v	slk:lemma	hádať sa
 12994979-n	slk:lemma	Eumycota
 01313093-n	slk:lemma	Animalia
@@ -2261,10 +2261,10 @@
 00640188-n	slk:lemma	prieskum trhu
 03199775-n	slk:lemma	jedálenský kút
 05860200-n	slk:lemma	dvojnásobok
-02007067-s	slk:lemma	sieťový
+02007067-a	slk:lemma	sieťový
 00067038-a	slk:lemma	odporúčaný
 02076676-v	slk:lemma	vyprázdňovať
-01517526-s	slk:lemma	vojenský
+01517526-a	slk:lemma	vojenský
 09168193-n	slk:lemma	púšť Atacama
 08494459-n	slk:lemma	Antarktická oblasť
 00353782-n	slk:lemma	zníženie
@@ -2285,7 +2285,7 @@
 00733883-n	slk:lemma	bezprávie
 09937056-n	slk:lemma	poslucháč
 00171586-v	slk:lemma	obohacovať
-01192035-s	slk:lemma	jemný
+01192035-a	slk:lemma	jemný
 00219856-n	slk:lemma	usmrtenie zo súcitu
 14174549-n	slk:lemma	infekcia
 03953020-n	slk:lemma	miesto podnikania
@@ -2296,7 +2296,7 @@
 13319032-n	slk:lemma	úroková miera
 10513120-n	slk:lemma	vydavateľ
 00666510-v	slk:lemma	potvrdiť
-01950198-s	slk:lemma	neforemný
+01950198-a	slk:lemma	neforemný
 00812298-v	slk:lemma	čeliť
 07807922-n	slk:lemma	ovocný šalát
 00688768-v	slk:lemma	rozmyslieť si
@@ -2307,25 +2307,25 @@
 07964144-n	slk:lemma	farebná škála
 01603303-v	slk:lemma	pokryť kovom
 02439728-n	slk:lemma	predná noha
-01263013-s	slk:lemma	barbarský
+01263013-a	slk:lemma	barbarský
 01066163-n	slk:lemma	brzdenie
 00134701-a	slk:lemma	vhodný
-01155603-s	slk:lemma	rafinovaný
+01155603-a	slk:lemma	rafinovaný
 00040928-v	slk:lemma	maľovať
 00397576-v	slk:lemma	drviť
-01046226-s	slk:lemma	regionálny
+01046226-a	slk:lemma	regionálny
 06100555-n	slk:lemma	nukleonika
 14877585-n	slk:lemma	plyn
-01784217-s	slk:lemma	neveriaci
+01784217-a	slk:lemma	neveriaci
 05462674-n	slk:lemma	neurálna štruktúra
 02118933-v	slk:lemma	zaregistrovať
-00656507-s	slk:lemma	podstatný
-02131958-s	slk:lemma	koketný
+00656507-a	slk:lemma	podstatný
+02131958-a	slk:lemma	koketný
 06037298-n	slk:lemma	veda o živote
 08210982-n	slk:lemma	súkromná bezpečnostná jednotka
 04526241-n	slk:lemma	vetrací otvor
 06471069-n	slk:lemma	diplom
-01518860-s	slk:lemma	vojnový
+01518860-a	slk:lemma	vojnový
 00751567-v	slk:lemma	nútiť
 00150134-r	slk:lemma	bezpochyby
 00063483-r	slk:lemma	tým skôr
@@ -2336,15 +2336,15 @@
 00668099-v	slk:lemma	znášať
 05490578-n	slk:lemma	kôra
 09607280-n	slk:lemma	žiadateľ
-02549691-s	slk:lemma	dusný
+02549691-a	slk:lemma	dusný
 00609683-v	slk:lemma	zachovať v pamäti
-01246388-s	slk:lemma	nepriateľský
+01246388-a	slk:lemma	nepriateľský
 08514592-n	slk:lemma	okruh
 01770802-v	slk:lemma	vzrušovať
 02055649-v	slk:lemma	hnať sa
 06691989-n	slk:lemma	aplauz
 00931467-v	slk:lemma	predstavovať
-02524688-s	slk:lemma	ohrozený
+02524688-a	slk:lemma	ohrozený
 00539936-v	slk:lemma	poskytovať
 01196037-v	slk:lemma	nepiť
 00878636-v	slk:lemma	predkladať
@@ -2359,7 +2359,7 @@
 02681795-v	slk:lemma	zachovávať
 12630641-n	slk:lemma	jahoda obyčajná
 01233993-v	slk:lemma	dávať pod strechu
-02092460-s	slk:lemma	ekumenický
+02092460-a	slk:lemma	ekumenický
 13902048-n	slk:lemma	spoj
 03279153-n	slk:lemma	elektronický hudobný nástroj
 01647229-v	slk:lemma	založiť
@@ -2368,7 +2368,7 @@
 02090435-v	slk:lemma	otočiť
 00222485-n	slk:lemma	samovražda
 00047534-r	slk:lemma	tak isto ako
-00324481-s	slk:lemma	motorový
+00324481-a	slk:lemma	motorový
 02681795-v	slk:lemma	držať sa
 13686526-n	slk:lemma	britská peňažná jednotka
 08622950-n	slk:lemma	poloha
@@ -2381,7 +2381,7 @@
 00786816-v	slk:lemma	preskúmať
 09283405-n	slk:lemma	predhorie
 00477941-v	slk:lemma	znečisťovať
-02503305-s	slk:lemma	nezmyselný
+02503305-a	slk:lemma	nezmyselný
 02294179-v	slk:lemma	dávať podiel
 07234230-n	slk:lemma	obvinenie
 01119192-a	slk:lemma	nadaný
@@ -2399,9 +2399,9 @@
 03121897-n	slk:lemma	plášť
 05285623-n	slk:lemma	kostná dreň
 05872742-n	slk:lemma	základné pojmy (princípy)
-01136248-s	slk:lemma	hundravý
+01136248-a	slk:lemma	hundravý
 00403783-n	slk:lemma	ublíženie, poranenie
-00667079-s	slk:lemma	súčasný
+00667079-a	slk:lemma	súčasný
 08613593-n	slk:lemma	exteriér
 02710137-v	slk:lemma	rozdeliť sa
 02085320-v	slk:lemma	rozliať sa
@@ -2411,14 +2411,14 @@
 01782209-n	slk:lemma	roztočec
 10509810-n	slk:lemma	realitný sprostredkovateľ
 15252021-n	slk:lemma	päťstoročie
-00438909-s	slk:lemma	rafinovaný
+00438909-a	slk:lemma	rafinovaný
 00042757-n	slk:lemma	odchádzanie
 02649830-v	slk:lemma	bývať
 05057275-n	slk:lemma	veľmi nízka frekvencia
 04676959-n	slk:lemma	strácajúci sa bod
 00079018-n	slk:lemma	získanie
 02705428-v	slk:lemma	naťahovať
-01860328-s	slk:lemma	zákulisný
+01860328-a	slk:lemma	zákulisný
 06546408-n	slk:lemma	zmluva, trustová
 14691822-n	slk:lemma	pohonná hmota
 01066881-n	slk:lemma	oddialenie
@@ -2438,12 +2438,12 @@
 00161243-n	slk:lemma	výber
 00878636-v	slk:lemma	predložiť
 07477587-n	slk:lemma	vietor do plachiet
-01642657-s	slk:lemma	radikálny
-00228294-s	slk:lemma	najlepší
+01642657-a	slk:lemma	radikálny
+00228294-a	slk:lemma	najlepší
 03058107-n	slk:lemma	náter
 05088804-n	slk:lemma	koncentrácia
 04393404-n	slk:lemma	gobelín
-01937390-s	slk:lemma	zdanlivý
+01937390-a	slk:lemma	zdanlivý
 01845132-n	slk:lemma	vodný vták
 01096245-n	slk:lemma	obchod
 11456760-n	slk:lemma	silové pole
@@ -2466,7 +2466,7 @@
 02638835-n	slk:lemma	čeľaď Amiidae
 14299637-n	slk:lemma	symptóm
 00451866-n	slk:lemma	lov
-00798103-s	slk:lemma	totálne ožratý
+00798103-a	slk:lemma	totálne ožratý
 03014288-a	slk:lemma	bojový
 01813884-v	slk:lemma	potešiť sa
 02162947-v	slk:lemma	blyšťať sa
@@ -2476,9 +2476,9 @@
 00391417-v	slk:lemma	potláčať
 03088707-n	slk:lemma	vedenie
 00915830-v	slk:lemma	zašepkať
-00848466-s	slk:lemma	povinný
+00848466-a	slk:lemma	povinný
 02460619-v	slk:lemma	najať si
-01263445-s	slk:lemma	krutý
+01263445-a	slk:lemma	krutý
 00078760-v	slk:lemma	liečiť
 01482449-v	slk:lemma	baliť
 01108627-v	slk:lemma	prekonávať
@@ -2499,7 +2499,7 @@
 02664769-v	slk:lemma	byť
 00712135-v	slk:lemma	nazdávať sa
 02535457-v	slk:lemma	oddeliť sa
-00768397-s	slk:lemma	plný odbočiek
+00768397-a	slk:lemma	plný odbočiek
 01238424-n	slk:lemma	zlúčenie
 02063018-v	slk:lemma	skloniť
 00766418-v	slk:lemma	prehovoriť (niekoho)
@@ -2515,13 +2515,13 @@
 13622209-n	slk:lemma	galón
 01673891-v	slk:lemma	pliesť
 07291312-n	slk:lemma	koniec
-01214430-s	slk:lemma	prenikavý
+01214430-a	slk:lemma	prenikavý
 01447257-v	slk:lemma	pritlačiť
 03322570-n	slk:lemma	poľnohospodárska budova
 06247701-n	slk:lemma	obmedzenie
 01149480-n	slk:lemma	ohraničenie
 00884011-v	slk:lemma	prisľúbiť
-01415219-s	slk:lemma	vreckový
+01415219-a	slk:lemma	vreckový
 07199565-n	slk:lemma	odpoveď
 13354985-n	slk:lemma	zúčtovanie
 00401459-n	slk:lemma	znovuobsadenie
@@ -2540,11 +2540,11 @@
 02498320-v	slk:lemma	objednať si
 04323026-n	slk:lemma	burza
 05836468-n	slk:lemma	nazeranie
-00661640-s	slk:lemma	pokrájaný
+00661640-a	slk:lemma	pokrájaný
 01435380-v	slk:lemma	presunúť
 01057200-n	slk:lemma	prívod
 06404147-n	slk:lemma	škrabanica
-00669942-s	slk:lemma	naničhodný
+00669942-a	slk:lemma	naničhodný
 06956129-n	slk:lemma	uralský jazyk
 00544136-v	slk:lemma	grilovať
 10417551-n	slk:lemma	predstaviteľ odkazovateľa
@@ -2553,7 +2553,7 @@
 10564905-n	slk:lemma	scenárista
 02374451-n	slk:lemma	Equus caballus
 04378489-n	slk:lemma	krátky plášť
-01011753-s	slk:lemma	elementárny
+01011753-a	slk:lemma	elementárny
 13347489-n	slk:lemma	poistenie na dožitie
 09312231-n	slk:lemma	Indus
 02467662-v	slk:lemma	členiť
@@ -2573,14 +2573,14 @@
 01449974-v	slk:lemma	nosiť
 01412415-a	slk:lemma	nepravdepodobný
 04271891-n	slk:lemma	predstavenie
-00177547-s	slk:lemma	priaznivý
+00177547-a	slk:lemma	priaznivý
 00196485-n	slk:lemma	premena
 11419404-n	slk:lemma	fyzikálny fenomén
 01411085-v	slk:lemma	mlátiť
 05015117-n	slk:lemma	chlad
 10335246-n	slk:lemma	smútiaci príbuzný
 02690081-n	slk:lemma	aerolinky
-00341655-s	slk:lemma	neplánovaný
+00341655-a	slk:lemma	neplánovaný
 06729499-n	slk:lemma	potvrdenie
 01993926-v	slk:lemma	posunúť dopredu
 01523908-n	slk:lemma	Passeriformes
@@ -2604,7 +2604,7 @@
 01842888-v	slk:lemma	pohybovať sa
 11668117-n	slk:lemma	jednoklíčnolistové rastliny
 12874783-n	slk:lemma	semená sézamu
-01165943-s	slk:lemma	liečebný
+01165943-a	slk:lemma	liečebný
 00928630-v	slk:lemma	odovzdať (informáciu)
 00463246-n	slk:lemma	športová hra
 01875295-v	slk:lemma	knísať sa
@@ -2612,14 +2612,14 @@
 10091012-n	slk:lemma	policajný informátor
 00900375-n	slk:lemma	zobrazenie
 04820258-n	slk:lemma	jasno
-01977669-s	slk:lemma	spomínajúci
+01977669-a	slk:lemma	spomínajúci
 09079153-n	slk:lemma	Sendvičové ostrovy
 02856584-a	slk:lemma	perianálny
 09870926-n	slk:lemma	chalan
 03723439-n	slk:lemma	manželská posteľ
 13566928-n	slk:lemma	termoelektrická emisia
 00678010-n	slk:lemma	vpich
-02332845-s	slk:lemma	istý
+02332845-a	slk:lemma	istý
 01768969-n	slk:lemma	trieda Arachnida
 01204191-v	slk:lemma	zaplatiť výživné
 00968211-v	slk:lemma	šíriť
@@ -2640,7 +2640,7 @@
 00751567-v	slk:lemma	rozkazovať
 09894654-n	slk:lemma	hráč kariet
 01116447-v	slk:lemma	nevzpierať sa
-00340827-s	slk:lemma	odsúdený na
+00340827-a	slk:lemma	odsúdený na
 04014297-n	slk:lemma	ochrana
 04752221-n	slk:lemma	rozdiel
 00531489-v	slk:lemma	oslabiť
@@ -2670,7 +2670,7 @@
 00020280-r	slk:lemma	nepretržite
 01387786-v	slk:lemma	zovrieť
 04566862-n	slk:lemma	ochranná paluba
-02144436-s	slk:lemma	tvárny
+02144436-a	slk:lemma	tvárny
 03183080-n	slk:lemma	prístroj
 00373544-n	slk:lemma	zväčšenie
 02724417-v	slk:lemma	týkať sa
@@ -2678,7 +2678,7 @@
 09135246-n	slk:lemma	Bethlehem
 15091846-n	slk:lemma	vitamín M
 01809064-v	slk:lemma	zarážať
-01712753-s	slk:lemma	citlivý
+01712753-a	slk:lemma	citlivý
 10353016-n	slk:lemma	novorodenec
 02783324-n	slk:lemma	tanečná miestnosť
 06457952-n	slk:lemma	Apokryfné spisy
@@ -2694,7 +2694,7 @@
 02464965-n	slk:lemma	predná noha
 06782680-n	slk:lemma	teória
 06611147-n	slk:lemma	vrcholná hlúposť
-02000968-s	slk:lemma	prehnaný
+02000968-a	slk:lemma	prehnaný
 02549392-v	slk:lemma	poskytovať pomoc
 03135532-n	slk:lemma	kríž
 06941644-n	slk:lemma	indoeurópsky
@@ -2705,9 +2705,9 @@
 02106006-v	slk:lemma	pocítiť
 10112591-n	slk:lemma	priateľka
 07427224-n	slk:lemma	posilňovanie
-00417204-s	slk:lemma	nespracovaný
+00417204-a	slk:lemma	nespracovaný
 00689344-v	slk:lemma	pokladať za
-00488857-s	slk:lemma	zvláštny
+00488857-a	slk:lemma	zvláštny
 13086063-n	slk:lemma	trhová plodina
 00621058-v	slk:lemma	ujasniť si
 10696508-n	slk:lemma	technik
@@ -2717,10 +2717,10 @@
 00819024-n	slk:lemma	zachovanie
 07498210-n	slk:lemma	vkus
 10376523-n	slk:lemma	starší občan
-01683349-s	slk:lemma	obrátený k domovu
+01683349-a	slk:lemma	obrátený k domovu
 04557648-n	slk:lemma	fľaša na vodu
 08801678-n	slk:lemma	Taliansko
-01567694-s	slk:lemma	celosvetový
+01567694-a	slk:lemma	celosvetový
 03932670-n	slk:lemma	utierka
 04153330-n	slk:lemma	sieťové pletivo
 00708538-v	slk:lemma	zvažovať
@@ -2735,21 +2735,21 @@
 02075049-v	slk:lemma	vziať roha
 02629535-v	slk:lemma	obsahovať
 04869106-n	slk:lemma	pocta
-01383394-s	slk:lemma	značný
+01383394-a	slk:lemma	značný
 00586598-v	slk:lemma	tlmiť
 02554922-v	slk:lemma	doporučovať
 01691057-v	slk:lemma	zaznamenať
 09363620-n	slk:lemma	Murrumbidgee
 13743269-n	slk:lemma	dvojka
-00667079-s	slk:lemma	dnešný
-00856011-s	slk:lemma	lyrický
-00528167-s	slk:lemma	valný
+00667079-a	slk:lemma	dnešný
+00856011-a	slk:lemma	lyrický
+00528167-a	slk:lemma	valný
 00422090-v	slk:lemma	ukázať sa
-01809245-s	slk:lemma	hrozný
+01809245-a	slk:lemma	hrozný
 00038625-r	slk:lemma	prirodzene
 08325686-n	slk:lemma	výbor
 00081486-r	slk:lemma	denne
-01950711-s	slk:lemma	necitlivý
+01950711-a	slk:lemma	necitlivý
 01212572-v	slk:lemma	uchmatnúť
 02162947-v	slk:lemma	ligotať sa
 03058726-n	slk:lemma	oficiálny symbol
@@ -2772,7 +2772,7 @@
 01207951-v	slk:lemma	obaliť
 01947352-v	slk:lemma	plávať na chrbáte
 01679055-a	slk:lemma	organický
-01439496-s	slk:lemma	dlhoveký
+01439496-a	slk:lemma	dlhoveký
 00793785-v	slk:lemma	prilákať
 09251407-n	slk:lemma	kométa
 01547001-v	slk:lemma	ležať si
@@ -2785,13 +2785,13 @@
 00067999-v	slk:lemma	tiecť
 11527014-n	slk:lemma	víchrica
 01069809-v	slk:lemma	opýtať sa
-00242575-s	slk:lemma	farebný
-00522463-s	slk:lemma	vysiľujúci
+00242575-a	slk:lemma	farebný
+00522463-a	slk:lemma	vysiľujúci
 04322026-n	slk:lemma	pažba
-02477557-s	slk:lemma	včlenený
+02477557-a	slk:lemma	včlenený
 04010205-n	slk:lemma	promenáda
 13281275-n	slk:lemma	pravidelná platba
-00445169-s	slk:lemma	blízky
+00445169-a	slk:lemma	blízky
 00142191-v	slk:lemma	vyformovať
 02225492-v	slk:lemma	uchovávať
 00322488-n	slk:lemma	zadebnenie
@@ -2826,23 +2826,23 @@
 11902389-n	slk:lemma	mak siaty
 05475681-n	slk:lemma	zväzok vlákien
 00229260-n	slk:lemma	vypnutie
-01308736-s	slk:lemma	neinformovaný
-01320705-s	slk:lemma	bezúhonný
+01308736-a	slk:lemma	neinformovaný
+01320705-a	slk:lemma	bezúhonný
 03025250-n	slk:lemma	črievica s vysokou podrážkou
 13999663-n	slk:lemma	zadržanie
 00480508-n	slk:lemma	bedminton
-01899167-s	slk:lemma	opatrný
+01899167-a	slk:lemma	opatrný
 00003483-r	slk:lemma	podstatne
 00390842-v	slk:lemma	utlmiť
 02659763-v	slk:lemma	sedieť
 02034300-v	slk:lemma	odraziť
-00016647-s	slk:lemma	zelený
-00968730-s	slk:lemma	exotický
-00224515-s	slk:lemma	diabolský
-00877816-s	slk:lemma	primárny
+00016647-a	slk:lemma	zelený
+00968730-a	slk:lemma	exotický
+00224515-a	slk:lemma	diabolský
+00877816-a	slk:lemma	primárny
 00429440-n	slk:lemma	eskapizmus
 05036715-n	slk:lemma	škodlivosť
-00402855-s	slk:lemma	živý
+00402855-a	slk:lemma	živý
 08112096-n	slk:lemma	profesia
 00690614-v	slk:lemma	vidieť
 00890590-v	slk:lemma	garantovať
@@ -2850,7 +2850,7 @@
 00588221-v	slk:lemma	získavať obraz
 00183995-n	slk:lemma	vážené hlasovanie
 14867858-n	slk:lemma	filament
-02331857-s	slk:lemma	plný života
+02331857-a	slk:lemma	plný života
 01020005-v	slk:lemma	spozorovať
 00524682-v	slk:lemma	nadobúdať
 08075388-n	slk:lemma	spoločenstvo
@@ -2871,43 +2871,43 @@
 09450553-n	slk:lemma	rieka Sun
 09612848-n	slk:lemma	spotrebiteľ
 01435380-v	slk:lemma	zaslať
-00193480-s	slk:lemma	hnusný
+00193480-a	slk:lemma	hnusný
 08277805-n	slk:lemma	akadémia
 04590553-n	slk:lemma	sklo
 01568630-v	slk:lemma	zadržiavať
 02976641-n	slk:lemma	kefová strela
 13939892-n	slk:lemma	hladina
-02587556-s	slk:lemma	cenený
-01455732-s	slk:lemma	slabý
+02587556-a	slk:lemma	cenený
+01455732-a	slk:lemma	slabý
 02238085-v	slk:lemma	nadobudnúť
 02629535-v	slk:lemma	pokrývať
 00169298-v	slk:lemma	oživovať
 00664276-v	slk:lemma	preukázať (pravosť)
 00358985-r	slk:lemma	hodinu čo hodinu
-00211564-s	slk:lemma	holý
+00211564-a	slk:lemma	holý
 05454070-n	slk:lemma	RBC
-00361125-s	slk:lemma	cudný
+00361125-a	slk:lemma	cudný
 03165096-n	slk:lemma	gauč
 14187378-n	slk:lemma	autoimunitná porucha
 10378026-n	slk:lemma	divák
 03112177-a	slk:lemma	cigánsky
 04220036-n	slk:lemma	parapet
 09338013-n	slk:lemma	leptón
-01968165-s	slk:lemma	dennodenný
+01968165-a	slk:lemma	dennodenný
 05547508-n	slk:lemma	krk
 05033681-n	slk:lemma	nezraniteľnosť
 03499796-n	slk:lemma	útočisko
 00297062-n	slk:lemma	potulovanie
 03414162-n	slk:lemma	športové náčinie
-02121123-s	slk:lemma	popletený
+02121123-a	slk:lemma	popletený
 14488317-n	slk:lemma	stav financií
 00833575-a	slk:lemma	nevýkonný
-00051571-s	slk:lemma	vhodný
+00051571-a	slk:lemma	vhodný
 03379989-n	slk:lemma	opora
 13850304-n	slk:lemma	stupnica
 11499284-n	slk:lemma	radiácia
 09698788-n	slk:lemma	Kostaričan
-00228645-s	slk:lemma	ideálny
+00228645-a	slk:lemma	ideálny
 05686955-n	slk:lemma	problém
 02648502-v	slk:lemma	platiť
 00341560-v	slk:lemma	pokročiť
@@ -2916,7 +2916,7 @@
 00312380-v	slk:lemma	mračiť sa
 13729902-n	slk:lemma	reálne číslo
 03149169-a	slk:lemma	ručný
-02144436-s	slk:lemma	vláčny
+02144436-a	slk:lemma	vláčny
 02641463-v	slk:lemma	počkať
 02460619-v	slk:lemma	prenajímať si
 09201301-n	slk:lemma	Apalačské vrchy
@@ -2949,13 +2949,13 @@
 08270938-n	slk:lemma	hviezdne zastúpenie
 01955508-v	slk:lemma	odoslať do miesta určenia
 13403643-n	slk:lemma	zápis
-01243102-s	slk:lemma	opustený
+01243102-a	slk:lemma	opustený
 06832788-n	slk:lemma	P
 05921123-n	slk:lemma	základ
 15182053-n	slk:lemma	31. december
 05514081-n	slk:lemma	prirodzenie
 07577374-n	slk:lemma	rýchle občerstvenie
-02199342-s	slk:lemma	miliardový
+02199342-a	slk:lemma	miliardový
 06359877-n	slk:lemma	napísané
 03014705-n	slk:lemma	debna
 09306257-n	slk:lemma	Huang He
@@ -2979,7 +2979,7 @@
 01475953-v	slk:lemma	uvoľniť
 03082979-n	slk:lemma	systém spracovávania informácií
 08801678-n	slk:lemma	Talianska republika
-00228485-s	slk:lemma	sviatočný
+00228485-a	slk:lemma	sviatočný
 04799789-n	slk:lemma	právne postavenie cudzinca
 00011093-r	slk:lemma	dobre
 00109660-v	slk:lemma	meniť
@@ -2999,7 +2999,7 @@
 05079074-n	slk:lemma	nenormálna poloha orgánov
 00038262-n	slk:lemma	cesta
 01952898-v	slk:lemma	odovzdávať
-00197773-s	slk:lemma	posledný
+00197773-a	slk:lemma	posledný
 02701871-n	slk:lemma	Americká burza cenných papierov
 00817680-n	slk:lemma	ochrana
 10006511-n	slk:lemma	následovník
@@ -3016,13 +3016,13 @@
 07976936-n	slk:lemma	pár
 00396642-n	slk:lemma	premývanie
 08566554-n	slk:lemma	zakončenie
-02074673-s	slk:lemma	posadnutý
+02074673-a	slk:lemma	posadnutý
 01741744-n	slk:lemma	veľhadovité
 04623113-n	slk:lemma	povaha
 15252907-n	slk:lemma	kapitola v histórii
 02407766-v	slk:lemma	predchádzať
 07536870-n	slk:lemma	pokánie
-00389310-s	slk:lemma	šedivý
+00389310-a	slk:lemma	šedivý
 04395024-n	slk:lemma	dechtová plachta
 02274482-v	slk:lemma	pripísať si
 00390842-v	slk:lemma	zahášať
@@ -3059,14 +3059,14 @@
 01036996-n	slk:lemma	svadba
 02540670-v	slk:lemma	odslúžiť
 15178694-n	slk:lemma	slnečný kalendár
-01066787-s	slk:lemma	zvyčajný
+01066787-a	slk:lemma	zvyčajný
 02072159-v	slk:lemma	prebehnúť
 05784242-n	slk:lemma	uvažovanie
 01523823-v	slk:lemma	odvinúť
 06308765-n	slk:lemma	prípona
-00792202-s	slk:lemma	hlavný
+00792202-a	slk:lemma	hlavný
 04850117-n	slk:lemma	oprávnenosť
-01176973-s	slk:lemma	gangrenózny
+01176973-a	slk:lemma	gangrenózny
 12587686-n	slk:lemma	Cocos
 07177924-n	slk:lemma	vysporiadanie
 09641757-n	slk:lemma	Ázijčan
@@ -3084,7 +3084,7 @@
 13774404-n	slk:lemma	stoh
 01230350-v	slk:lemma	bodnúť
 00071165-r	slk:lemma	vôkol
-01676026-s	slk:lemma	mimoriadny
+01676026-a	slk:lemma	mimoriadny
 10488309-n	slk:lemma	senzibil
 09620794-n	slk:lemma	domorodec
 02619612-v	slk:lemma	dávať zmysel
@@ -3094,15 +3094,15 @@
 00033615-n	slk:lemma	množstvo
 04895773-n	slk:lemma	podozrenie
 01814815-v	slk:lemma	tíšiť
-01780343-s	slk:lemma	noetický
+01780343-a	slk:lemma	noetický
 00898518-n	slk:lemma	vyobrazenie
 02346724-v	slk:lemma	osvojovať si
 09419281-n	slk:lemma	rieka Saint Francis
 01827858-v	slk:lemma	pochváliť
 01406640-a	slk:lemma	legitímny
-00967646-s	slk:lemma	smiešny
+00967646-a	slk:lemma	smiešny
 01350283-v	slk:lemma	pochytiť
-01459755-s	slk:lemma	roztomilý
+01459755-a	slk:lemma	roztomilý
 05650329-n	slk:lemma	kognitívna schopnosť
 00491438-r	slk:lemma	nadarmo
 00812298-v	slk:lemma	vzdorovať
@@ -3119,7 +3119,7 @@
 07487594-n	slk:lemma	nostalgia
 00783902-n	slk:lemma	veľká krádež
 05237227-n	slk:lemma	sústava
-01385255-s	slk:lemma	nesmierny
+01385255-a	slk:lemma	nesmierny
 01656813-n	slk:lemma	čeľaď plazov
 09193705-n	slk:lemma	vysoké hory
 00511817-n	slk:lemma	rozpustilosť
@@ -3132,7 +3132,7 @@
 01523105-v	slk:lemma	navíjať sa
 00372660-r	slk:lemma	opatrne
 04508163-n	slk:lemma	bielizeň
-01308736-s	slk:lemma	mimo
+01308736-a	slk:lemma	mimo
 01741744-n	slk:lemma	Boidae
 00467913-a	slk:lemma	rozdeľujúci
 12662654-n	slk:lemma	rod Coffea
@@ -3159,13 +3159,13 @@
 03696301-n	slk:lemma	polica na batožiny
 00044900-n	slk:lemma	exhumovanie
 07181043-n	slk:lemma	stret
-01401413-s	slk:lemma	ratifikovaný
-00010726-s	slk:lemma	nenásytný
+01401413-a	slk:lemma	ratifikovaný
+00010726-a	slk:lemma	nenásytný
 02430045-n	slk:lemma	vysoká zver
 07356676-n	slk:lemma	nárast
 02163746-v	slk:lemma	vysliediť
 15157041-n	slk:lemma	kalendárny deň
-00968010-s	slk:lemma	čudný
+00968010-a	slk:lemma	čudný
 15284704-n	slk:lemma	maximálna rýchlosť
 03365374-n	slk:lemma	svetlomet
 02367032-v	slk:lemma	vzdať sa
@@ -3181,7 +3181,7 @@
 02396667-n	slk:lemma	Babyrousa
 00238064-r	slk:lemma	vedome
 00802238-n	slk:lemma	nebezpečenstvo
-01248958-s	slk:lemma	ohnivý
+01248958-a	slk:lemma	ohnivý
 00203342-n	slk:lemma	odmietnutie
 02384041-v	slk:lemma	dosádzať
 02621244-v	slk:lemma	tvoriť
@@ -3189,7 +3189,7 @@
 00818362-n	slk:lemma	ochrana
 00095502-n	slk:lemma	oslobodzovanie
 04655929-n	slk:lemma	srdečnosť
-01335458-s	slk:lemma	šikovný
+01335458-a	slk:lemma	šikovný
 15094053-n	slk:lemma	zberový papier
 00586262-n	slk:lemma	miesto
 02367363-v	slk:lemma	jednať
@@ -3203,7 +3203,7 @@
 02153387-v	slk:lemma	prezerať
 05632446-n	slk:lemma	fantázia
 06155567-n	slk:lemma	dejepis
-00833018-s	slk:lemma	operačný
+00833018-a	slk:lemma	operačný
 00647270-n	slk:lemma	kvantitatívna chemická analýza
 10640620-n	slk:lemma	lepšia polovička
 08550966-n	slk:lemma	diecéza
@@ -3212,7 +3212,7 @@
 02469835-v	slk:lemma	zlúčiť
 04189482-n	slk:lemma	plech
 01278817-v	slk:lemma	zvraštiť
-02413390-s	slk:lemma	priehľadný
+02413390-a	slk:lemma	priehľadný
 08179879-n	slk:lemma	populácia
 00478262-n	slk:lemma	futbal
 03464467-n	slk:lemma	zabezpečenie
@@ -3246,7 +3246,7 @@
 05423882-n	slk:lemma	interlobulárne žily obličky
 00158309-r	slk:lemma	práve
 14363483-n	slk:lemma	jazva
-01568684-s	slk:lemma	svetový
+01568684-a	slk:lemma	svetový
 00859758-v	slk:lemma	baviť sa
 01264283-v	slk:lemma	omietnuť
 13464820-n	slk:lemma	evolúcia
@@ -3291,12 +3291,12 @@
 00317700-v	slk:lemma	predĺžiť
 05307521-n	slk:lemma	hrot zuba
 00715769-v	slk:lemma	skonkretizovať
-01577327-s	slk:lemma	magický
+01577327-a	slk:lemma	magický
 00452152-n	slk:lemma	zápasy kohútov
 00922438-v	slk:lemma	odlíšiť
 05162985-n	slk:lemma	škoda
 05600637-n	slk:lemma	obličaj
-00713853-s	slk:lemma	prenikavý
+00713853-a	slk:lemma	prenikavý
 02514575-n	slk:lemma	Osteichthyes
 01716491-a	slk:lemma	neprijateľný
 03466947-n	slk:lemma	giloš
@@ -3304,11 +3304,11 @@
 00971984-n	slk:lemma	podpora boja v dotyku
 09383793-n	slk:lemma	Tichomorské pobrežie
 12874642-n	slk:lemma	Sesamum
-00312234-s	slk:lemma	letmý
+00312234-a	slk:lemma	letmý
 06427831-n	slk:lemma	úprava
 01108971-n	slk:lemma	výpožička
 00906735-v	slk:lemma	odsúdiť
-01159119-s	slk:lemma	toxický
+01159119-a	slk:lemma	toxický
 05706954-n	slk:lemma	zanedbanie
 10711253-n	slk:lemma	pracovník s drevom
 10757918-n	slk:lemma	životný princíp
@@ -3318,7 +3318,7 @@
 14441498-n	slk:lemma	hanba
 09049909-n	slk:lemma	otrokársky štát
 03085602-n	slk:lemma	displej počítača
-00538891-s	slk:lemma	rastúci v trsoch
+00538891-a	slk:lemma	rastúci v trsoch
 07327805-n	slk:lemma	faktor
 06722186-n	slk:lemma	vsuvka
 00047392-r	slk:lemma	veľmi
@@ -3339,7 +3339,7 @@
 09639237-n	slk:lemma	bieli ľudia
 00079951-v	slk:lemma	zavlažiť
 01664172-v	slk:lemma	variť
-02038994-s	slk:lemma	silný
+02038994-a	slk:lemma	silný
 07109019-n	slk:lemma	audiokomunikácia
 04039848-n	slk:lemma	rádiolokácia
 04862592-n	slk:lemma	pevnosť
@@ -3348,7 +3348,7 @@
 14560360-n	slk:lemma	poškodenosť
 01256332-a	slk:lemma	nový
 00795863-v	slk:lemma	vetovať
-00097674-s	slk:lemma	nebohý
+00097674-a	slk:lemma	nebohý
 03206718-n	slk:lemma	prestrojenie
 00443984-v	slk:lemma	skvapalniť sa
 00070765-r	slk:lemma	nesúvisle
@@ -3365,8 +3365,8 @@
 00753685-n	slk:lemma	podvod
 03950228-n	slk:lemma	kanvica
 12396924-n	slk:lemma	marihuana
-00766102-s	slk:lemma	priamy
-01383394-s	slk:lemma	slušný
+00766102-a	slk:lemma	priamy
+01383394-a	slk:lemma	slušný
 01136614-v	slk:lemma	vystreliť
 03166213-n	slk:lemma	hrubé sklo v podpalubí
 01335804-v	slk:lemma	obrúbiť
@@ -3407,7 +3407,7 @@
 01021128-v	slk:lemma	vysvetliť
 00892467-v	slk:lemma	poďakovať
 00151689-v	slk:lemma	znížiť sa
-01735346-s	slk:lemma	materinský
+01735346-a	slk:lemma	materinský
 01131004-n	slk:lemma	občianska povinnosť
 09847727-n	slk:lemma	veriaci
 04546855-n	slk:lemma	múr
@@ -3427,23 +3427,23 @@
 06471069-n	slk:lemma	čestná hodnosť
 10676877-n	slk:lemma	dozorca
 10214637-n	slk:lemma	objaviteľ
-02503216-s	slk:lemma	márny
+02503216-a	slk:lemma	márny
 02500775-v	slk:lemma	pustošiť
 15229300-n	slk:lemma	nultá hodina
 07523180-n	slk:lemma	opatrnosť
 00197811-r	slk:lemma	konkrétne
 00027384-r	slk:lemma	len
-00970610-s	slk:lemma	bežný
+00970610-a	slk:lemma	bežný
 02640440-v	slk:lemma	váhať
 15043308-n	slk:lemma	čľapkanica
 05145118-n	slk:lemma	peňažná hodnota
-02111981-s	slk:lemma	rodový
+02111981-a	slk:lemma	rodový
 04530283-n	slk:lemma	zvislá chvostová plocha
 08152657-n	slk:lemma	zbor svätých
 07477587-n	slk:lemma	dar z nebies
 00486067-r	slk:lemma	pod
 03076298-n	slk:lemma	komerčná grafika
-02316992-s	slk:lemma	vlnitý
+02316992-a	slk:lemma	vlnitý
 09797606-n	slk:lemma	starožitník
 01814074-v	slk:lemma	udržiavať v dobrej nálade
 02969925-a	slk:lemma	byzantský
@@ -3461,7 +3461,7 @@
 01975880-n	slk:lemma	Decapoda
 02159271-n	slk:lemma	trieda hmyz
 00236592-v	slk:lemma	obmedziť
-01681307-s	slk:lemma	položený
+01681307-a	slk:lemma	položený
 07051975-n	slk:lemma	text
 01613294-n	slk:lemma	orol
 04227050-n	slk:lemma	prútený kôš
@@ -3475,9 +3475,9 @@
 02664769-v	slk:lemma	rovnať sa
 00466053-v	slk:lemma	zrovnať
 01758308-n	slk:lemma	zobák
-01011753-s	slk:lemma	základný
+01011753-a	slk:lemma	základný
 00644839-a	slk:lemma	uveriteľný
-01533974-s	slk:lemma	prehnaný
+01533974-a	slk:lemma	prehnaný
 02151966-v	slk:lemma	dať si pozor na
 02763740-v	slk:lemma	žiariť
 09887034-n	slk:lemma	počtár
@@ -3497,7 +3497,7 @@
 13864542-n	slk:lemma	entáza
 02898750-a	slk:lemma	duševný
 11451442-n	slk:lemma	elektromagnetické spektrum
-00505853-s	slk:lemma	jedinečný
+00505853-a	slk:lemma	jedinečný
 06161223-n	slk:lemma	estetika
 02327200-v	slk:lemma	obstarať
 01170962-n	slk:lemma	súboj
@@ -3515,7 +3515,7 @@
 00023773-n	slk:lemma	popud
 03336459-n	slk:lemma	figurína
 05223370-n	slk:lemma	ryha
-00453308-s	slk:lemma	intímny
+00453308-a	slk:lemma	intímny
 07356676-n	slk:lemma	vzrast
 03120198-n	slk:lemma	nádvorie
 01525720-n	slk:lemma	spevavec
@@ -3524,27 +3524,27 @@
 01278427-v	slk:lemma	vraštiť
 00943837-v	slk:lemma	vyjadrovať
 03247620-n	slk:lemma	droga
-01732131-s	slk:lemma	súčasný
+01732131-a	slk:lemma	súčasný
 03940256-n	slk:lemma	pripináčik
 06609909-n	slk:lemma	nezmysly
 00392588-v	slk:lemma	vylepšovať
 00531489-v	slk:lemma	pokoriť
 10405410-n	slk:lemma	držiteľ patentu
 01779986-a	slk:lemma	rozumový
-01564881-s	slk:lemma	nehybný
+01564881-a	slk:lemma	nehybný
 00213903-n	slk:lemma	oslobodenie
-00809790-s	slk:lemma	pohonný
+00809790-a	slk:lemma	pohonný
 05661996-n	slk:lemma	poriadok
 00061203-r	slk:lemma	neskoršie
 14067076-n	slk:lemma	zlyhanie
 01770802-v	slk:lemma	pohýnať
 14940100-n	slk:lemma	kvapalina
 09543353-n	slk:lemma	Belzebub
-00383291-s	slk:lemma	zafírový
+00383291-a	slk:lemma	zafírový
 08744871-n	slk:lemma	Orizaba
 03282060-n	slk:lemma	násyp
 03530910-n	slk:lemma	kryt motora
-00813589-s	slk:lemma	predhistorický
+00813589-a	slk:lemma	predhistorický
 06740644-n	slk:lemma	odôvodnenie
 03929443-n	slk:lemma	špičiak
 01248852-n	slk:lemma	obnovovanie
@@ -3552,11 +3552,11 @@
 09252078-n	slk:lemma	Congo
 00283235-r	slk:lemma	večne
 13743269-n	slk:lemma	číslica 2
-00358534-s	slk:lemma	záporne nabitý
+00358534-a	slk:lemma	záporne nabitý
 13354260-n	slk:lemma	rizikový kapitál
-00974697-s	slk:lemma	zadubený
+00974697-a	slk:lemma	zadubený
 00160415-n	slk:lemma	pokúšanie
-02395910-s	slk:lemma	lahodný
+02395910-a	slk:lemma	lahodný
 02487217-n	slk:lemma	Macaca
 13779032-n	slk:lemma	objem
 00649362-v	slk:lemma	obzerať
@@ -3599,7 +3599,7 @@
 01064148-n	slk:lemma	oddych
 01615602-v	slk:lemma	urobiť vodivým
 03491178-n	slk:lemma	nástenný záves
-00820975-s	slk:lemma	súčasný
+00820975-a	slk:lemma	súčasný
 04401088-n	slk:lemma	telefónny prístroj
 05669934-n	slk:lemma	kognitívny stav
 01127019-n	slk:lemma	vynucovanie
@@ -3612,7 +3612,7 @@
 14489113-n	slk:lemma	kríza
 09972661-n	slk:lemma	honelník
 14288871-n	slk:lemma	podliatina
-01518860-s	slk:lemma	bojovný
+01518860-a	slk:lemma	bojovný
 00908351-v	slk:lemma	uživiť
 07521039-n	slk:lemma	bázeň
 09989290-n	slk:lemma	dáma
@@ -3635,18 +3635,18 @@
 08395465-n	slk:lemma	vojenská akadémia (v USA)
 05555917-n	slk:lemma	veľké brucho
 05680982-n	slk:lemma	bezcitnosť
-00852197-s	slk:lemma	primeraný
-01628531-s	slk:lemma	neslušný
+00852197-a	slk:lemma	primeraný
+01628531-a	slk:lemma	neslušný
 01061526-n	slk:lemma	vymáhanie
 05134547-n	slk:lemma	hĺbka
 00868471-v	slk:lemma	zatváriť sa (drzo )
 06762380-n	slk:lemma	výhrada
-00782216-s	slk:lemma	šerý
+00782216-a	slk:lemma	šerý
 15293328-n	slk:lemma	obdobie vojny
-02316992-s	slk:lemma	vinúci sa
+02316992-a	slk:lemma	vinúci sa
 03291741-n	slk:lemma	obálka
 09028062-n	slk:lemma	Katalánsko
-02341864-s	slk:lemma	super
+02341864-a	slk:lemma	super
 00798717-v	slk:lemma	zriekať sa
 13431380-n	slk:lemma	anafáza
 05232972-n	slk:lemma	kraniometrický bod
@@ -3663,7 +3663,7 @@
 00528339-v	slk:lemma	spamätávať sa
 02216710-v	slk:lemma	podporiť
 02151966-v	slk:lemma	dávať si pozor na
-00874226-s	slk:lemma	rázny
+00874226-a	slk:lemma	rázny
 00120316-v	slk:lemma	urobiť
 03571706-n	slk:lemma	cartridge
 01532589-v	slk:lemma	leštiť
@@ -3672,10 +3672,10 @@
 00279523-r	slk:lemma	neslušne
 09451517-n	slk:lemma	povrch
 07193184-n	slk:lemma	otázky
-01402763-s	slk:lemma	zločinný
+01402763-a	slk:lemma	zločinný
 00420218-n	slk:lemma	hrubé zaobchádzanie s deťmi
-01537448-s	slk:lemma	stredoveký
-02382396-s	slk:lemma	protichodný
+01537448-a	slk:lemma	stredoveký
+02382396-a	slk:lemma	protichodný
 11878283-n	slk:lemma	horčica
 04332243-n	slk:lemma	cedidlo
 01577093-v	slk:lemma	ponárať
@@ -3691,7 +3691,7 @@
 01158064-n	slk:lemma	odvod
 06769670-n	slk:lemma	chyba v sadzbe
 01842367-v	slk:lemma	opúšťať
-01723648-s	slk:lemma	chladný
+01723648-a	slk:lemma	chladný
 08106934-n	slk:lemma	rad
 07258332-n	slk:lemma	referenčný bod
 01975880-n	slk:lemma	desaťnožce
@@ -3706,7 +3706,7 @@
 09085830-n	slk:lemma	Lafayette
 00282050-n	slk:lemma	posun
 14477342-n	slk:lemma	utrpenie
-01294975-s	slk:lemma	ďalší
+01294975-a	slk:lemma	ďalší
 02743547-n	slk:lemma	výtvarné umenie
 00035058-r	slk:lemma	frekventovane
 00655779-a	slk:lemma	podstatný
@@ -3720,16 +3720,16 @@
 11877860-n	slk:lemma	kvaka
 09807754-n	slk:lemma	šľachtic
 07313636-n	slk:lemma	zranenie
-01757211-s	slk:lemma	výpomocný
+01757211-a	slk:lemma	výpomocný
 04517823-n	slk:lemma	vysávač
 05766247-n	slk:lemma	interpretácia
 09477890-n	slk:lemma	mokraď
-00522885-s	slk:lemma	totálny
+00522885-a	slk:lemma	totálny
 03663069-n	slk:lemma	záchranné lano
 01166926-n	slk:lemma	pokora
 13456567-n	slk:lemma	zostup
 13126580-n	slk:lemma	korienok
-00330506-s	slk:lemma	polovičný
+00330506-a	slk:lemma	polovičný
 00366521-n	slk:lemma	rozťahovanie
 00013160-a	slk:lemma	konkrétny
 03882058-n	slk:lemma	panel
@@ -3740,10 +3740,10 @@
 05477946-n	slk:lemma	prvý hlavový nerv
 01230350-v	slk:lemma	zabodnúť
 00310386-v	slk:lemma	prosperovať
-00317727-s	slk:lemma	pokrájaný
+00317727-a	slk:lemma	pokrájaný
 02245765-v	slk:lemma	obchodovať
 00974367-v	slk:lemma	ohlasovať
-01111418-s	slk:lemma	štedrý
+01111418-a	slk:lemma	štedrý
 02411427-n	slk:lemma	Ovis
 01111375-n	slk:lemma	nájom
 04463983-n	slk:lemma	koľajnice
@@ -3805,7 +3805,7 @@
 13729236-n	slk:lemma	rozdiel
 05128870-n	slk:lemma	počet akrov
 05625879-n	slk:lemma	neskutočné miesto
-00330506-s	slk:lemma	na pol cesty
+00330506-a	slk:lemma	na pol cesty
 01280014-v	slk:lemma	zakriviť
 04044716-n	slk:lemma	rádioteleskop
 01452593-a	slk:lemma	hlučný
@@ -3830,7 +3830,7 @@
 05538625-n	slk:lemma	hlava
 00003483-r	slk:lemma	v základe
 05701944-n	slk:lemma	základný poznávací proces
-01134486-s	slk:lemma	pokojný
+01134486-a	slk:lemma	pokojný
 05893512-n	slk:lemma	základný predpoklad
 08878016-n	slk:lemma	Cambridge
 02082358-n	slk:lemma	rad Tubulidentata
@@ -3843,7 +3843,7 @@
 00084230-v	slk:lemma	liečiť
 00250484-r	slk:lemma	v jednom rade
 14489699-n	slk:lemma	blahobyt
-02341864-s	slk:lemma	prvotriedny
+02341864-a	slk:lemma	prvotriedny
 09198106-n	slk:lemma	Antarktída
 02413480-v	slk:lemma	pracovať
 02276866-v	slk:lemma	potiahnuť
@@ -3851,17 +3851,17 @@
 09380817-n	slk:lemma	rieka Ouachita
 00353782-n	slk:lemma	zmenšenie
 07893528-n	slk:lemma	šumivé víno
-02343110-s	slk:lemma	výborný
+02343110-a	slk:lemma	výborný
 02989754-a	slk:lemma	stredoveký
 03887330-n	slk:lemma	posun papiera
 04976952-n	slk:lemma	farba pleti
 04366116-n	slk:lemma	odpruženie
-00412171-s	slk:lemma	vyspelý
+00412171-a	slk:lemma	vyspelý
 13480394-n	slk:lemma	emisia elektrónov
 13348456-n	slk:lemma	spätné poistenie
 13327231-n	slk:lemma	strata
 09759069-n	slk:lemma	akademický pracovník
-00250739-s	slk:lemma	pojašený
+00250739-a	slk:lemma	pojašený
 08928193-n	slk:lemma	Keňa
 09229249-n	slk:lemma	Bristolský kanál
 13416345-n	slk:lemma	cenný papier
@@ -3871,7 +3871,7 @@
 05690269-n	slk:lemma	obštrukcia
 00514041-n	slk:lemma	špinavosť
 01194331-n	slk:lemma	vysťahovanie
-01761375-s	slk:lemma	neprístupný
+01761375-a	slk:lemma	neprístupný
 05762848-n	slk:lemma	reminiscencia
 06710546-n	slk:lemma	nepríjemné hodnotenie
 03346455-n	slk:lemma	ohnisko
@@ -3894,7 +3894,7 @@
 14478684-n	slk:lemma	úpadok
 01600333-a	slk:lemma	k severu obrátený
 00352826-v	slk:lemma	skončiť sa
-00126497-s	slk:lemma	predošlý
+00126497-a	slk:lemma	predošlý
 06196584-n	slk:lemma	dispozícia
 07141319-n	slk:lemma	spor o význam slova
 04427715-n	slk:lemma	trojdielny oblek
@@ -3917,7 +3917,7 @@
 02656390-v	slk:lemma	poskytnúť záštitu
 02462580-v	slk:lemma	hlasovať
 07223170-n	slk:lemma	fáma
-02318728-s	slk:lemma	priamy
+02318728-a	slk:lemma	priamy
 00233335-v	slk:lemma	ohraničovať
 00151521-r	slk:lemma	opreteky s časom
 09323470-n	slk:lemma	Kansas
@@ -3961,8 +3961,8 @@
 04002629-n	slk:lemma	primár
 01580467-v	slk:lemma	objať
 15154774-n	slk:lemma	časová jednotka
-01761375-s	slk:lemma	zavrhnutý
-02413390-s	slk:lemma	priesvitný
+01761375-a	slk:lemma	zavrhnutý
+02413390-a	slk:lemma	priesvitný
 15143012-n	slk:lemma	začiatok
 05436752-n	slk:lemma	cistrón
 10657165-n	slk:lemma	pointilista
@@ -3988,7 +3988,7 @@
 09762011-n	slk:lemma	obžalovaný
 13724977-n	slk:lemma	miriagram
 02578235-v	slk:lemma	klamať
-00440489-s	slk:lemma	tupý
+00440489-a	slk:lemma	tupý
 02759614-v	slk:lemma	vznietiť sa
 12996225-n	slk:lemma	podkmeň Basidiomycotina
 02156732-n	slk:lemma	štvornožec
@@ -3997,9 +3997,9 @@
 08585657-n	slk:lemma	horizont
 00066191-v	slk:lemma	zavzlykať
 09945603-n	slk:lemma	člen komunistickej strany
-02476485-s	slk:lemma	spojený
+02476485-a	slk:lemma	spojený
 06308304-n	slk:lemma	predpona
-00876204-s	slk:lemma	pomalý
+00876204-a	slk:lemma	pomalý
 09328148-n	slk:lemma	rieka Kura
 14512817-n	slk:lemma	kontext
 14407536-n	slk:lemma	tranz
@@ -4008,22 +4008,22 @@
 10477077-n	slk:lemma	gladiátor
 01096497-v	slk:lemma	mať funkciu
 05701363-n	slk:lemma	proces
-00888200-s	slk:lemma	smädný
+00888200-a	slk:lemma	smädný
 08183290-n	slk:lemma	zástup
 08568256-n	slk:lemma	dejisko
-02240275-s	slk:lemma	keprový
+02240275-a	slk:lemma	keprový
 00208210-v	slk:lemma	podráždiť
-00874226-s	slk:lemma	ostrý
+00874226-a	slk:lemma	ostrý
 01346693-v	slk:lemma	znovu začínať
 02290461-v	slk:lemma	čerpať (z niečoho)
 08271042-n	slk:lemma	galaxia
 11665781-n	slk:lemma	Magnoliopsida
 02139544-v	slk:lemma	ukázať sa
 00647094-v	slk:lemma	merať
-00340827-s	slk:lemma	predurčený na
+00340827-a	slk:lemma	predurčený na
 09203217-n	slk:lemma	Aras
 05667613-n	slk:lemma	norma
-02515214-s	slk:lemma	hrešiaci
+02515214-a	slk:lemma	hrešiaci
 00823750-n	slk:lemma	ochrana
 04871720-n	slk:lemma	priamosť
 04703424-n	slk:lemma	opacita
@@ -4036,7 +4036,7 @@
 00074038-v	slk:lemma	srať
 13988663-n	slk:lemma	nešťastie
 08748794-n	slk:lemma	Aruba
-00422168-s	slk:lemma	olejnatý
+00422168-a	slk:lemma	olejnatý
 02427103-v	slk:lemma	zriaďovať
 14103288-n	slk:lemma	srdcová slabosť
 02133435-v	slk:lemma	zdať sa
@@ -4049,7 +4049,7 @@
 13959931-n	slk:lemma	neexistencia
 01134479-n	slk:lemma	zlé riadenie
 02139544-v	slk:lemma	ukazovať
-01930004-s	slk:lemma	neutrálny
+01930004-a	slk:lemma	neutrálny
 00392093-n	slk:lemma	čerpanie
 01020356-v	slk:lemma	napísať
 01322854-v	slk:lemma	poraziť
@@ -4080,12 +4080,12 @@
 01895735-n	slk:lemma	srsť
 04960582-n	slk:lemma	čierna farba
 00494269-v	slk:lemma	izolovať
-00211564-s	slk:lemma	hladký
+00211564-a	slk:lemma	hladký
 07417405-n	slk:lemma	kríza
 02133185-v	slk:lemma	uprene pozorovať
 01531998-v	slk:lemma	pošpiniť
 06552814-n	slk:lemma	splatenie
-01267632-s	slk:lemma	divadelný gag
+01267632-a	slk:lemma	divadelný gag
 02116118-v	slk:lemma	podnietiť
 02549211-v	slk:lemma	podnecovať
 00630380-v	slk:lemma	zaoberať sa (myšlienkou)
@@ -4101,10 +4101,10 @@
 03429288-n	slk:lemma	mierka
 08794574-n	slk:lemma	Golanské Výšiny
 01651444-v	slk:lemma	zosnovať
-01372948-s	slk:lemma	láskavý
+01372948-a	slk:lemma	láskavý
 00161294-r	slk:lemma	zjavne
 02839110-n	slk:lemma	bilboard
-02059381-s	slk:lemma	riskantný
+02059381-a	slk:lemma	riskantný
 04715487-n	slk:lemma	vhodnosť
 12710917-n	slk:lemma	citrus mandarínka King
 13322938-n	slk:lemma	vstupný poplatok
@@ -4124,7 +4124,7 @@
 10055847-n	slk:lemma	nepriateľ
 00123170-v	slk:lemma	upravovať si
 13453428-n	slk:lemma	korózia
-00389310-s	slk:lemma	sivý
+00389310-a	slk:lemma	sivý
 13549672-n	slk:lemma	uvoľnenie
 00355547-n	slk:lemma	zmiernenie bolesti
 01474550-v	slk:lemma	pustiť
@@ -4132,7 +4132,7 @@
 02779435-n	slk:lemma	guľa
 00227023-r	slk:lemma	presnejšie povedané
 01963942-v	slk:lemma	skákať
-00339742-s	slk:lemma	plný sebadôvery
+00339742-a	slk:lemma	plný sebadôvery
 02599636-v	slk:lemma	vykonať
 00634276-n	slk:lemma	rozbor
 03926412-n	slk:lemma	fotografický papier
@@ -4141,13 +4141,13 @@
 02132745-v	slk:lemma	zízať
 03015254-n	slk:lemma	skriňa na bielizeň
 03483637-n	slk:lemma	záchranná brzda
-01044730-s	slk:lemma	nenútený
+01044730-a	slk:lemma	nenútený
 02637202-v	slk:lemma	prebývať
 01689379-v	slk:lemma	načrtnúť
 06026635-n	slk:lemma	vzorka
 05484355-n	slk:lemma	predný lalok
-02123007-s	slk:lemma	roztopašný
-00130518-s	slk:lemma	dopoludnia
+02123007-a	slk:lemma	roztopašný
+00130518-a	slk:lemma	dopoludnia
 05163807-n	slk:lemma	cena
 05323036-n	slk:lemma	vestibulárny orgán tela
 11561228-n	slk:lemma	rod jednoklíčnolistových ľaliovitých rastlín
@@ -4180,7 +4180,7 @@
 00794981-v	slk:lemma	rozvrhovať
 01219893-n	slk:lemma	odsudzovanie
 04486054-n	slk:lemma	slavobrána
-00200603-s	slk:lemma	majúci ostrý chrbát
+00200603-a	slk:lemma	majúci ostrý chrbát
 06664845-n	slk:lemma	etiketa
 08910668-n	slk:lemma	Islamská republika Irán
 00378365-r	slk:lemma	skutočne
@@ -4197,19 +4197,19 @@
 15293227-n	slk:lemma	obdobie mieru
 06750804-n	slk:lemma	návrh
 02957427-n	slk:lemma	záverný kameň klenby
-01234527-s	slk:lemma	vychýlený
+01234527-a	slk:lemma	vychýlený
 13504739-n	slk:lemma	karyokinéza
 01860795-v	slk:lemma	zastať
 00777806-n	slk:lemma	nepriamy podvod
-02110778-s	slk:lemma	samostatný
-00011327-s	slk:lemma	nenásytný
+02110778-a	slk:lemma	samostatný
+00011327-a	slk:lemma	nenásytný
 13154494-n	slk:lemma	vejárovitá štruktúra
 00612042-v	slk:lemma	uctiť pamiatku
 01849221-v	slk:lemma	prísť
 02548588-v	slk:lemma	plniť úlohu
-01809245-s	slk:lemma	neznesiteľný
+01809245-a	slk:lemma	neznesiteľný
 05819453-n	slk:lemma	pravda
-02316992-s	slk:lemma	plný záhybov
+02316992-a	slk:lemma	plný záhybov
 13880102-n	slk:lemma	trojuholník
 04656996-n	slk:lemma	neúčasť
 04096066-n	slk:lemma	dráha
@@ -4220,7 +4220,7 @@
 00223983-n	slk:lemma	masakrovanie
 04980463-n	slk:lemma	vôňa
 05284132-n	slk:lemma	horná čeľusť
-00218305-s	slk:lemma	ľúby
+00218305-a	slk:lemma	ľúby
 00074038-v	slk:lemma	mať stolicu
 01776727-v	slk:lemma	nepáčiť sa
 00941990-v	slk:lemma	rozprávať
@@ -4248,7 +4248,7 @@
 06575227-n	slk:lemma	užívateľské rozhranie
 08521267-n	slk:lemma	obloha
 00754280-n	slk:lemma	podvod
-00972642-s	slk:lemma	najnovší
+00972642-a	slk:lemma	najnovší
 01157517-v	slk:lemma	spotrebovávať
 07175575-n	slk:lemma	schválenie
 03772077-n	slk:lemma	katedrála
@@ -4266,7 +4266,7 @@
 05910453-n	slk:lemma	návrh
 13879947-n	slk:lemma	rovnostranný trojuholník
 09822955-n	slk:lemma	revízor účtov
-00402855-s	slk:lemma	pestrý
+00402855-a	slk:lemma	pestrý
 03017922-a	slk:lemma	vedúci
 05012272-n	slk:lemma	tepelný obsah
 09086070-n	slk:lemma	South Bend
@@ -4287,7 +4287,7 @@
 09273447-n	slk:lemma	Kanál La Manche
 03679986-n	slk:lemma	nálož
 01507175-n	slk:lemma	rod vtákov
-01842198-s	slk:lemma	neistý
+01842198-a	slk:lemma	neistý
 04893787-n	slk:lemma	úspora
 00650353-v	slk:lemma	rozoznať
 07670731-n	slk:lemma	kôra
@@ -4297,8 +4297,8 @@
 04050410-n	slk:lemma	baranidlo
 01017643-v	slk:lemma	hájiť
 00836705-v	slk:lemma	skresliť
-00448314-s	slk:lemma	na spadnutie
-00609564-s	slk:lemma	čudný
+00448314-a	slk:lemma	na spadnutie
+00609564-a	slk:lemma	čudný
 07033007-n	slk:lemma	nábožná hudba
 07290905-n	slk:lemma	vznik
 02150510-v	slk:lemma	sledovať
@@ -4310,7 +4310,7 @@
 02117534-v	slk:lemma	povzbudzovať
 01009240-v	slk:lemma	poznamenať
 01462005-v	slk:lemma	spojiť
-01723648-s	slk:lemma	vecný
+01723648-a	slk:lemma	vecný
 00394803-n	slk:lemma	odstraňovanie
 00376106-v	slk:lemma	roztopiť sa
 00798959-n	slk:lemma	reklamná kampaň
@@ -4330,23 +4330,23 @@
 04551375-n	slk:lemma	výbušná hlavica
 00894738-v	slk:lemma	vyjasniť
 14856263-n	slk:lemma	odpadový materiál
-00846625-s	slk:lemma	nominovaný
+00846625-a	slk:lemma	nominovaný
 05896618-n	slk:lemma	planá nádej
 00858781-v	slk:lemma	zavolať na slávu
 01523105-v	slk:lemma	naviť sa
-00746451-s	slk:lemma	nepochopiteľný
+00746451-a	slk:lemma	nepochopiteľný
 02045043-v	slk:lemma	otočiť sa
 00419908-n	slk:lemma	týranie
 01434278-v	slk:lemma	odvážať si
 00871942-v	slk:lemma	predpovedať
-01074335-s	slk:lemma	soľonosný
+01074335-a	slk:lemma	soľonosný
 05791602-n	slk:lemma	želanie
 01902783-v	slk:lemma	priletieť po vetri
 07006119-n	slk:lemma	divadlo
 01041061-v	slk:lemma	byť ticho
 03429914-n	slk:lemma	gáza
 06733682-n	slk:lemma	pohrozenie
-01203986-s	slk:lemma	rozvrstvený
+01203986-a	slk:lemma	rozvrstvený
 06781383-n	slk:lemma	komédia
 07566340-n	slk:lemma	potravina
 10782940-n	slk:lemma	víťaz
@@ -4375,7 +4375,7 @@
 04243727-n	slk:lemma	rozširujúci slot
 14176895-n	slk:lemma	mykóza
 01020005-v	slk:lemma	zaznamenať
-01909421-s	slk:lemma	neočistený
+01909421-a	slk:lemma	neočistený
 01195804-v	slk:lemma	zmárniť
 05602835-n	slk:lemma	líce
 05952490-n	slk:lemma	viera v nadprirodzeno
@@ -4402,7 +4402,7 @@
 00649482-n	slk:lemma	spektrálna analýza
 01814266-v	slk:lemma	doliehať
 09606009-n	slk:lemma	dobrodruh
-02339577-s	slk:lemma	predný
+02339577-a	slk:lemma	predný
 01188537-n	slk:lemma	odsúdenie v neprítomnosti
 06738823-n	slk:lemma	definovaný pojem
 09754152-n	slk:lemma	abbé
@@ -4422,7 +4422,7 @@
 02069355-a	slk:lemma	iný
 07541760-n	slk:lemma	šťastie
 00041954-r	slk:lemma	obyčajne
-01789481-s	slk:lemma	bodkovaný
+01789481-a	slk:lemma	bodkovaný
 08684769-n	slk:lemma	zenit
 04048075-n	slk:lemma	železničná trať
 07557165-n	slk:lemma	pochúťka
@@ -4438,7 +4438,7 @@
 01846320-v	slk:lemma	viesť loď
 01924590-n	slk:lemma	kmeň ploskavce
 01523520-v	slk:lemma	odmotať sa
-02387413-s	slk:lemma	územčistý
+02387413-a	slk:lemma	územčistý
 00805376-v	slk:lemma	dohodnúť sa
 14964129-n	slk:lemma	nukleová kyselina
 01697628-v	slk:lemma	črtať
@@ -4446,10 +4446,10 @@
 00087423-n	slk:lemma	podpora
 00258530-n	slk:lemma	para
 05773049-n	slk:lemma	odôvodnenie
-00900071-s	slk:lemma	skrytý
+00900071-a	slk:lemma	skrytý
 00222479-r	slk:lemma	pozadu
 00844298-v	slk:lemma	sťažovať si
-02325984-s	slk:lemma	slabý
+02325984-a	slk:lemma	slabý
 00400083-n	slk:lemma	konverzia
 02629535-v	slk:lemma	zahŕňať
 15074962-n	slk:lemma	priesvitný papier
@@ -4463,7 +4463,7 @@
 01130169-v	slk:lemma	držať stráž
 01172114-v	slk:lemma	popíjať si
 00953216-v	slk:lemma	vyrozprávať
-00228485-s	slk:lemma	nedeľný
+00228485-a	slk:lemma	nedeľný
 03876519-n	slk:lemma	kresba
 04199027-n	slk:lemma	topánka
 05893916-n	slk:lemma	chybný záver
@@ -4487,7 +4487,7 @@
 04933544-n	slk:lemma	zloženie
 13320168-n	slk:lemma	poplatok
 03325088-n	slk:lemma	pípa
-01441271-s	slk:lemma	dlhotrvajúci
+01441271-a	slk:lemma	dlhotrvajúci
 09126305-n	slk:lemma	Severná Karolína
 07674001-n	slk:lemma	kanolový olej
 00673456-a	slk:lemma	ručne vyrobený
@@ -4495,7 +4495,7 @@
 09381048-n	slk:lemma	rieka Ouse
 03011521-n	slk:lemma	šachovnica
 07199922-n	slk:lemma	odpoveď
-01136248-s	slk:lemma	zle naladený
+01136248-a	slk:lemma	zle naladený
 05476094-n	slk:lemma	komisurálna cesta
 06611376-n	slk:lemma	volovina
 03520811-n	slk:lemma	prekážka
@@ -4512,7 +4512,7 @@
 05426243-n	slk:lemma	membrána
 00262596-n	slk:lemma	ozdobovanie sa
 05514905-n	slk:lemma	mužské genitálie
-00721371-s	slk:lemma	sporný
+00721371-a	slk:lemma	sporný
 00858568-v	slk:lemma	volať na slávu
 00003483-r	slk:lemma	v podstate
 14440137-n	slk:lemma	potupa
@@ -4526,19 +4526,19 @@
 03484083-n	slk:lemma	nákupný vozík
 05157406-n	slk:lemma	náskok
 01698271-v	slk:lemma	vytvoriť
-01263013-s	slk:lemma	surový
+01263013-a	slk:lemma	surový
 00120223-r	slk:lemma	pritom
 00970249-a	slk:lemma	obyčajný
 09890749-n	slk:lemma	uchádzač
 02189168-v	slk:lemma	vypočúvať (tajne)
 00049889-r	slk:lemma	hneď hneď
 00757544-v	slk:lemma	vzdať sa povinnosti
-01403760-s	slk:lemma	protizákonný
+01403760-a	slk:lemma	protizákonný
 10052694-n	slk:lemma	vyslanec
 04946877-n	slk:lemma	štruktúra
 01280488-v	slk:lemma	zohýbať
 13363893-n	slk:lemma	trustový fond
-00179315-s	slk:lemma	panovnícky
+00179315-a	slk:lemma	panovnícky
 04591713-n	slk:lemma	vínna fľaša
 00223500-v	slk:lemma	zoslabiť
 01613807-n	slk:lemma	mladý orol
@@ -4564,7 +4564,7 @@
 03926575-n	slk:lemma	obrázok
 01236947-n	slk:lemma	krvná pomsta
 08900535-n	slk:lemma	Bharat
-00157268-s	slk:lemma	nenápadný
+00157268-a	slk:lemma	nenápadný
 05177285-n	slk:lemma	oprávnenie
 08999482-n	slk:lemma	Juhoafrická republika
 06443922-n	slk:lemma	List apoštola Pavla Galaťanom
@@ -4577,7 +4577,7 @@
 06410391-n	slk:lemma	kritika
 02555387-a	slk:lemma	obsahujúci vodu
 08436759-n	slk:lemma	rastlinstvo
-00758800-s	slk:lemma	mierny
+00758800-a	slk:lemma	mierny
 07570720-n	slk:lemma	výživa
 06748969-n	slk:lemma	predvídanie
 00618451-v	slk:lemma	určiť
@@ -4600,7 +4600,7 @@
 01177703-n	slk:lemma	demonštrácia
 08641113-n	slk:lemma	susedstvo
 10257084-n	slk:lemma	liberál
-01206318-s	slk:lemma	náhorný
+01206318-a	slk:lemma	náhorný
 15225249-n	slk:lemma	školský rok
 12267841-n	slk:lemma	pohárik
 04879658-n	slk:lemma	subverzia
@@ -4610,13 +4610,13 @@
 03974769-n	slk:lemma	hlaveň zbrane
 01342529-n	slk:lemma	rad živočíchov
 14391660-n	slk:lemma	mánia
-02179968-s	slk:lemma	srdečný
+02179968-a	slk:lemma	srdečný
 00422090-v	slk:lemma	zjaviť sa
 02199590-v	slk:lemma	dávať
 01503061-n	slk:lemma	vták
-00750054-s	slk:lemma	pohodlný
+00750054-a	slk:lemma	pohodlný
 00431396-r	slk:lemma	pekne
-00354934-s	slk:lemma	premenený
+00354934-a	slk:lemma	premenený
 02731061-a	slk:lemma	fosílny
 02296153-v	slk:lemma	vštepiť
 05686481-n	slk:lemma	poznávací činiteľ
@@ -4629,7 +4629,7 @@
 09610405-n	slk:lemma	človek z ľudu
 00008007-r	slk:lemma	kompletne
 00765649-v	slk:lemma	naliehať
-02071973-s	slk:lemma	analogický
+02071973-a	slk:lemma	analogický
 00953216-v	slk:lemma	rozprávať
 07044543-n	slk:lemma	fantázia
 02345048-v	slk:lemma	ukoristiť
@@ -4648,11 +4648,11 @@
 05615869-n	slk:lemma	opatrnosť
 00610167-v	slk:lemma	zabudnúť
 06740644-n	slk:lemma	obrana
-00309740-s	slk:lemma	zaručený
+00309740-a	slk:lemma	zaručený
 09206375-n	slk:lemma	rieka Arkansas
 00946105-v	slk:lemma	uvádzať
 10654015-n	slk:lemma	zapisovateľ
-01284212-s	slk:lemma	dramatický
+01284212-a	slk:lemma	dramatický
 03542860-n	slk:lemma	hotelová izba
 14008806-n	slk:lemma	účinnosť
 13561896-n	slk:lemma	stochastický proces
@@ -4662,7 +4662,7 @@
 03673971-n	slk:lemma	spojenie
 08113443-n	slk:lemma	duchovenstvo
 00047317-v	slk:lemma	vyskúšať si
-00179315-s	slk:lemma	vládnuci
+00179315-a	slk:lemma	vládnuci
 00356954-v	slk:lemma	vlniť
 00054750-r	slk:lemma	muž proti mužovi
 00590390-a	slk:lemma	napadnuteľný
@@ -4670,9 +4670,9 @@
 00582388-n	slk:lemma	práca
 04680285-n	slk:lemma	označenie
 09147046-n	slk:lemma	UT
-00590163-s	slk:lemma	rozladený
+00590163-a	slk:lemma	rozladený
 00947719-n	slk:lemma	chybné používanie
-00541935-s	slk:lemma	pridelený
+00541935-a	slk:lemma	pridelený
 09925592-n	slk:lemma	sťažovateľ
 01527420-a	slk:lemma	kovový
 06561942-n	slk:lemma	obvinenie
@@ -4682,10 +4682,10 @@
 02373093-n	slk:lemma	rad nepárnokopytníky
 02727825-n	slk:lemma	prístroj
 13148602-n	slk:lemma	Piperales
-01702543-s	slk:lemma	podobný listu
+01702543-a	slk:lemma	podobný listu
 08507558-n	slk:lemma	pôvod
 02499629-v	slk:lemma	potrestať
-01144102-s	slk:lemma	pálčivý
+01144102-a	slk:lemma	pálčivý
 02545272-v	slk:lemma	hazardovať
 04675193-n	slk:lemma	typ pleti
 00112393-r	slk:lemma	práve
@@ -4695,7 +4695,7 @@
 06459681-n	slk:lemma	Tobit
 14918023-n	slk:lemma	tlačiarenská čerň
 00431826-v	slk:lemma	zmenšiť sa
-01649720-s	slk:lemma	nedospelý
+01649720-a	slk:lemma	nedospelý
 15148295-n	slk:lemma	dospievanie
 05621439-n	slk:lemma	prefíkanosť
 14032100-n	slk:lemma	červený poplach
@@ -4712,21 +4712,21 @@
 00105333-v	slk:lemma	vydať
 15155220-n	slk:lemma	dvadsaťštyri hodín
 04515991-n	slk:lemma	pisoár
-01439784-s	slk:lemma	nekonečný
+01439784-a	slk:lemma	nekonečný
 08836165-n	slk:lemma	Autralázia
 01419473-v	slk:lemma	zamiešať
 02777927-n	slk:lemma	balkón
 08114861-n	slk:lemma	odvetvie
-00876204-s	slk:lemma	malátny
+00876204-a	slk:lemma	malátny
 06613686-n	slk:lemma	film
-01898722-s	slk:lemma	uvážlivý
+01898722-a	slk:lemma	uvážlivý
 01219893-n	slk:lemma	podceňovanie
 06492939-n	slk:lemma	jedálny lístok
 07505871-n	slk:lemma	odstup
 03433877-n	slk:lemma	generátor
 08615638-n	slk:lemma	parkovacie miesto
-02038994-s	slk:lemma	statný
-02400628-s	slk:lemma	colný
+02038994-a	slk:lemma	statný
+02400628-a	slk:lemma	colný
 01514655-v	slk:lemma	vypustiť
 02647497-v	slk:lemma	pretrvávať
 10103485-n	slk:lemma	cudzinec
@@ -4738,7 +4738,7 @@
 10214637-n	slk:lemma	vynálezca
 15266685-n	slk:lemma	polovica
 04592099-n	slk:lemma	pohár na víno
-00827743-s	slk:lemma	juhovýchodný
+00827743-a	slk:lemma	juhovýchodný
 02236124-v	slk:lemma	prijímať
 01385330-n	slk:lemma	ektoparazit
 14844693-n	slk:lemma	pôda
@@ -4766,7 +4766,7 @@
 00258549-r	slk:lemma	dnu
 00133668-n	slk:lemma	facka
 03394649-n	slk:lemma	zasklené dvere
-01402763-s	slk:lemma	kriminálny
+01402763-a	slk:lemma	kriminálny
 01684899-v	slk:lemma	maľovať
 01149911-n	slk:lemma	stláčanie
 04325208-n	slk:lemma	ohrada
@@ -4790,8 +4790,8 @@
 00751567-v	slk:lemma	prinútiť
 00023868-v	slk:lemma	upadať do bezvedomia
 02590340-v	slk:lemma	obsadiť
-01392249-s	slk:lemma	nepatrný
-00974697-s	slk:lemma	malomeštiacky
+01392249-a	slk:lemma	nepatrný
+00974697-a	slk:lemma	malomeštiacky
 14190736-n	slk:lemma	pyémia
 01867295-a	slk:lemma	reprodukčný
 09342937-n	slk:lemma	Loire
@@ -4806,7 +4806,7 @@
 01692786-a	slk:lemma	izbový
 00385649-n	slk:lemma	rozpojenie
 09851575-n	slk:lemma	snúbenec
-00032733-s	slk:lemma	vrtký
+00032733-a	slk:lemma	vrtký
 06081833-n	slk:lemma	neuroveda
 04047401-n	slk:lemma	zábradlie
 00356258-v	slk:lemma	meniť povrch
@@ -4821,14 +4821,14 @@
 00250484-r	slk:lemma	v rovnakom rade
 15295045-n	slk:lemma	vrchol
 00799798-v	slk:lemma	rušiť
-02227946-s	slk:lemma	technický
+02227946-a	slk:lemma	technický
 03610992-n	slk:lemma	šatka
 11911591-n	slk:lemma	čeľaď Compositae
 00908621-v	slk:lemma	udržať v chode
 02294436-v	slk:lemma	rozdeľovať
 08251877-n	slk:lemma	strana
 02297142-v	slk:lemma	poskytovať
-02500179-s	slk:lemma	falošný
+02500179-a	slk:lemma	falošný
 00082308-v	slk:lemma	povoliť
 09178999-n	slk:lemma	motív
 03010473-n	slk:lemma	podvozok
@@ -4862,12 +4862,12 @@
 07486628-n	slk:lemma	prianie
 09438554-n	slk:lemma	rieka Snake
 01233993-v	slk:lemma	pokryť
-00013662-s	slk:lemma	skutočný
+00013662-a	slk:lemma	skutočný
 08364143-n	slk:lemma	kapitalizmus
 05216365-n	slk:lemma	fyzická konštitúcia
 04082886-n	slk:lemma	meracia mriežka
-00733297-s	slk:lemma	vytúžený
-01710543-s	slk:lemma	dlžný
+00733297-a	slk:lemma	vytúžený
+01710543-a	slk:lemma	dlžný
 03592773-n	slk:lemma	záves
 01185981-v	slk:lemma	pohostiť sa
 01639714-v	slk:lemma	nakresliť
@@ -4875,7 +4875,7 @@
 08131530-n	slk:lemma	Ministerstvo obrany USA
 14865800-n	slk:lemma	kysličník železitý
 01799484-v	slk:lemma	nesplniť očakávania
-01126291-s	slk:lemma	ohavný
+01126291-a	slk:lemma	ohavný
 09080273-n	slk:lemma	ostrov Molokai
 00762355-a	slk:lemma	nepriamy
 02123903-v	slk:lemma	spôsobiť povšimnutie
@@ -4892,7 +4892,7 @@
 09775663-n	slk:lemma	advokát
 01568630-v	slk:lemma	zakrývať
 01570935-v	slk:lemma	uškrtiť
-00012689-s	slk:lemma	ideálny
+00012689-a	slk:lemma	ideálny
 04110178-n	slk:lemma	ružicové okno
 06134716-n	slk:lemma	strojárske inžinierstvo
 01071474-v	slk:lemma	posielať
@@ -4903,19 +4903,19 @@
 00232936-r	slk:lemma	preč
 06598915-n	slk:lemma	správa
 02661252-v	slk:lemma	odchyľovať sa
-01789117-s	slk:lemma	spracovaný z mramoru
-02097480-s	slk:lemma	atraktívny
+01789117-a	slk:lemma	spracovaný z mramoru
+02097480-a	slk:lemma	atraktívny
 00379993-n	slk:lemma	šum
 05492259-n	slk:lemma	záhyb
 09223725-n	slk:lemma	poťah
 13808708-n	slk:lemma	meronymia
-00792202-s	slk:lemma	prvý
+00792202-a	slk:lemma	prvý
 09321694-n	slk:lemma	Jebel Musa, Abila, Abyla
 00231557-v	slk:lemma	dorastať
 07540424-n	slk:lemma	nespokojnosť
 13346773-n	slk:lemma	zdravotné poistenie
 12707432-n	slk:lemma	rod citrusov
-01378429-s	slk:lemma	ocenený
+01378429-a	slk:lemma	ocenený
 00205891-n	slk:lemma	trest
 02074915-n	slk:lemma	mäsožravce
 00245289-v	slk:lemma	uhasiť
@@ -4924,17 +4924,17 @@
 09091774-n	slk:lemma	Morgan City
 00542149-n	slk:lemma	danse macabre
 00323856-v	slk:lemma	dusiť
-00906099-s	slk:lemma	chválorečnícky
+00906099-a	slk:lemma	chválorečnícky
 03234306-n	slk:lemma	kresba
 04190747-n	slk:lemma	kryt
 00008997-r	slk:lemma	úplne
 15090742-n	slk:lemma	B-vitamín
 08245425-n	slk:lemma	mafia
-02065665-s	slk:lemma	rôzny
+02065665-a	slk:lemma	rôzny
 05829342-n	slk:lemma	pozitívny podnet
 02641463-v	slk:lemma	zadržiavať
 00621058-v	slk:lemma	osvetľovať
-02542148-s	slk:lemma	postihnutý
+02542148-a	slk:lemma	postihnutý
 02467662-v	slk:lemma	odrezať
 07492516-n	slk:lemma	pohoda
 10557854-n	slk:lemma	vzdelanec
@@ -4945,7 +4945,7 @@
 07321772-n	slk:lemma	zjavenie sa
 00006105-r	slk:lemma	prevažne
 13417071-n	slk:lemma	akcia
-02512641-s	slk:lemma	agresívny
+02512641-a	slk:lemma	agresívny
 09266052-n	slk:lemma	rieka Detroit
 00688768-v	slk:lemma	prehodnotiť
 13790912-n	slk:lemma	opora
@@ -4961,7 +4961,7 @@
 00806502-v	slk:lemma	schvaľovať
 12922763-n	slk:lemma	krotón
 02976641-n	slk:lemma	kartáčová strela
-00796715-s	slk:lemma	javiskový
+00796715-a	slk:lemma	javiskový
 00593613-n	slk:lemma	inšpektorstvo
 09289709-n	slk:lemma	kvapka
 00709205-v	slk:lemma	potrebovať (niekoho)
@@ -4969,11 +4969,11 @@
 03164605-n	slk:lemma	pohovka
 04340935-n	slk:lemma	citadela
 00863049-a	slk:lemma	aplikovaný
-00304144-s	slk:lemma	divoký
+00304144-a	slk:lemma	divoký
 08600760-n	slk:lemma	zenit
 06733939-n	slk:lemma	dôkazový materiál
-01344171-s	slk:lemma	fascinujúci
-02279900-s	slk:lemma	smelý
+01344171-a	slk:lemma	fascinujúci
+02279900-a	slk:lemma	smelý
 01411085-v	slk:lemma	potrestať bičom
 03918480-n	slk:lemma	osobný počítač
 06630017-n	slk:lemma	privítanie
@@ -4988,7 +4988,7 @@
 09241247-n	slk:lemma	kanál
 02697120-v	slk:lemma	ohrozovať
 00187028-r	slk:lemma	pekne
-02387413-s	slk:lemma	podsaditý
+02387413-a	slk:lemma	podsaditý
 03695122-n	slk:lemma	sústava mazania
 13841213-n	slk:lemma	reciprocita
 07454758-n	slk:lemma	promócia
@@ -5000,9 +5000,9 @@
 06725680-n	slk:lemma	architektúra siete
 13403025-n	slk:lemma	zaťaženie
 03325088-n	slk:lemma	kohútik
-02110778-s	slk:lemma	rozdelený
+02110778-a	slk:lemma	rozdelený
 07651454-n	slk:lemma	jedlo z vnútorností
-00968010-s	slk:lemma	divný
+00968010-a	slk:lemma	divný
 01787106-v	slk:lemma	nazúriť sa
 01768402-n	slk:lemma	podkmeň klepietkavce
 06599788-n	slk:lemma	námet
@@ -5010,7 +5010,7 @@
 00444519-a	slk:lemma	blízko
 02578235-v	slk:lemma	zavádzať
 02451679-v	slk:lemma	spomaľovať
-01568684-s	slk:lemma	globálny
+01568684-a	slk:lemma	globálny
 01214265-v	slk:lemma	zobrať si
 00992102-n	slk:lemma	prípravná paľba
 05540407-n	slk:lemma	lebka
@@ -5021,7 +5021,7 @@
 02685153-a	slk:lemma	nebeský
 00597915-v	slk:lemma	osvojovať si
 00199659-v	slk:lemma	napraviť
-01009206-s	slk:lemma	počiatočný
+01009206-a	slk:lemma	počiatočný
 02422026-v	slk:lemma	oslobodzovať
 00059854-r	slk:lemma	narastajúcou mierou
 06432376-n	slk:lemma	Kniha Genesis
@@ -5033,7 +5033,7 @@
 02063018-v	slk:lemma	nachýliť sa
 10561222-n	slk:lemma	potomok
 00705227-v	slk:lemma	mávať za cieľ
-00505853-s	slk:lemma	neprekonateľný
+00505853-a	slk:lemma	neprekonateľný
 09005611-n	slk:lemma	Kursk
 00946105-v	slk:lemma	vymenúvať
 01714208-v	slk:lemma	predviesť
@@ -5092,7 +5092,7 @@
 02208903-v	slk:lemma	prenajať si
 09323470-n	slk:lemma	rieka Kaw
 09463362-n	slk:lemma	rieka Tunguska
-02578894-s	slk:lemma	kláštornícky
+02578894-a	slk:lemma	kláštornícky
 00660730-v	slk:lemma	odhadnúť nižšie
 15157225-n	slk:lemma	Deň
 03359950-n	slk:lemma	defektná pneumatika
@@ -5109,7 +5109,7 @@
 02641012-a	slk:lemma	strieborný
 09734885-n	slk:lemma	Turkyňa
 07492516-n	slk:lemma	komfort
-01252714-s	slk:lemma	mrazivý
+01252714-a	slk:lemma	mrazivý
 09261138-n	slk:lemma	Cumberland
 07531713-n	slk:lemma	uspokojenie
 00252169-n	slk:lemma	čistenie za sucha
@@ -5138,7 +5138,7 @@
 02768579-v	slk:lemma	pariť sa
 02728440-n	slk:lemma	oblek
 02281093-v	slk:lemma	napĺňať zásobami
-00157268-s	slk:lemma	tajnostkársky
+00157268-a	slk:lemma	tajnostkársky
 08651832-n	slk:lemma	ulička
 01404389-v	slk:lemma	odrážať
 05496990-n	slk:lemma	diencefalon
@@ -5180,11 +5180,11 @@
 05630277-n	slk:lemma	podsvetie
 00206479-r	slk:lemma	súrne
 00679389-v	slk:lemma	uprednostňovať
-00438909-s	slk:lemma	prezieravý
+00438909-a	slk:lemma	prezieravý
 01577093-v	slk:lemma	potopiť
-02368566-s	slk:lemma	sladkastý
+02368566-a	slk:lemma	sladkastý
 02026086-v	slk:lemma	vyprevadiť
-01874331-s	slk:lemma	neporiadny
+01874331-a	slk:lemma	neporiadny
 06759349-n	slk:lemma	zámienka
 15246853-n	slk:lemma	minútka
 02670398-v	slk:lemma	slúžiť
@@ -5215,18 +5215,18 @@
 11667112-n	slk:lemma	Magnoliidae
 08440630-n	slk:lemma	samovláda
 06779310-n	slk:lemma	anekdota
-02068730-s	slk:lemma	vyššie uvedený
+02068730-a	slk:lemma	vyššie uvedený
 02590340-v	slk:lemma	osídliť
 03795580-n	slk:lemma	prenosná bariéra
 06784003-n	slk:lemma	problém
 02983357-n	slk:lemma	povodie
-02182562-s	slk:lemma	neúprimný
+02182562-a	slk:lemma	neúprimný
 00896497-v	slk:lemma	potvrdzovať (súdne)
-00930765-s	slk:lemma	nepredvídaný
-00507292-s	slk:lemma	bezcitný
+00930765-a	slk:lemma	nepredvídaný
+00507292-a	slk:lemma	bezcitný
 03025590-a	slk:lemma	alpský
 00845909-v	slk:lemma	uvaľovať hanbu
-02113191-s	slk:lemma	hygienický
+02113191-a	slk:lemma	hygienický
 01409581-a	slk:lemma	rovnaký
 01051331-n	slk:lemma	poloha
 01338663-v	slk:lemma	pokryť škridlicami
@@ -5252,7 +5252,7 @@
 08732116-n	slk:lemma	Kolumbia
 14949227-n	slk:lemma	ložisko
 01568630-v	slk:lemma	udúšať
-00608791-s	slk:lemma	výstredný
+00608791-a	slk:lemma	výstredný
 01462005-v	slk:lemma	zmiešať sa
 05861855-n	slk:lemma	polynóm
 05280998-n	slk:lemma	os sphenoidale
@@ -5260,15 +5260,15 @@
 06831284-n	slk:lemma	béčko
 02210855-v	slk:lemma	zaobstarať si
 02141973-v	slk:lemma	pochvaľovať
-01961205-s	slk:lemma	občasný
+01961205-a	slk:lemma	občasný
 05924920-n	slk:lemma	kritérium
 03573005-n	slk:lemma	duša pneumatiky
 05925366-n	slk:lemma	vzor
-02397496-s	slk:lemma	pikantný
+02397496-a	slk:lemma	pikantný
 01722529-a	slk:lemma	rodičovský
 04942869-n	slk:lemma	dispozícia
 09612848-n	slk:lemma	konzument
-01378429-s	slk:lemma	pochopený
+01378429-a	slk:lemma	pochopený
 02632838-v	slk:lemma	chýbať
 14686352-n	slk:lemma	fosílne palivo
 00333366-n	slk:lemma	agitácia
@@ -5277,7 +5277,7 @@
 00249164-r	slk:lemma	vnútri
 04656996-n	slk:lemma	nezúčastnenosť
 01635432-v	slk:lemma	usudzovať
-00971506-s	slk:lemma	módny
+00971506-a	slk:lemma	módny
 00696852-v	slk:lemma	prechádzať si
 08340153-n	slk:lemma	Informačná služba USA
 08893223-n	slk:lemma	Hebridy
@@ -5298,9 +5298,9 @@
 05302499-n	slk:lemma	ústna dutina
 10292052-n	slk:lemma	pracháč
 04763925-n	slk:lemma	špecialita
-00082034-s	slk:lemma	pevný
+00082034-a	slk:lemma	pevný
 08415272-n	slk:lemma	malá porota
-01591394-s	slk:lemma	cisársky
+01591394-a	slk:lemma	cisársky
 02473981-v	slk:lemma	autorizovať
 03306385-n	slk:lemma	expres
 02712443-v	slk:lemma	predísť
@@ -5326,7 +5326,7 @@
 08504594-n	slk:lemma	pustina
 04516672-n	slk:lemma	potreby pre domácnosť
 03600806-n	slk:lemma	marihuana
-00830051-s	slk:lemma	erudovaný
+00830051-a	slk:lemma	erudovaný
 01278427-v	slk:lemma	zvrásniť
 01296462-v	slk:lemma	spojiť
 00869126-v	slk:lemma	poprieť
@@ -5346,8 +5346,8 @@
 02707188-n	slk:lemma	anaglyf
 05833252-n	slk:lemma	bremeno
 00769092-n	slk:lemma	podvod
-02250430-s	slk:lemma	pustý
-01677200-s	slk:lemma	strašný
+02250430-a	slk:lemma	pustý
+01677200-a	slk:lemma	strašný
 07007945-n	slk:lemma	dramatická hra
 01209135-v	slk:lemma	postihnúť
 04380617-n	slk:lemma	obrus
@@ -5363,7 +5363,7 @@
 02752311-n	slk:lemma	atletické vybavenie
 00876332-v	slk:lemma	navrhovať
 01876530-v	slk:lemma	pohybovať sa sem a tam
-00425313-s	slk:lemma	hrubý
+00425313-a	slk:lemma	hrubý
 00797430-v	slk:lemma	odmietať
 02069551-v	slk:lemma	liať
 08834123-n	slk:lemma	Tasmánia
@@ -5395,7 +5395,7 @@
 00593613-n	slk:lemma	funkcia inšpektora
 13868944-n	slk:lemma	vlnitosť
 05108947-n	slk:lemma	zvyšovanie
-01757608-s	slk:lemma	predbežný
+01757608-a	slk:lemma	predbežný
 13459322-n	slk:lemma	obranná reakcia
 05999134-n	slk:lemma	oblasť
 08505018-n	slk:lemma	buš
@@ -5403,12 +5403,12 @@
 08797619-n	slk:lemma	Múr nárekov
 00528339-v	slk:lemma	ťahať z vody
 09424865-n	slk:lemma	rieka Savannah
-02401288-s	slk:lemma	nezdanený
+02401288-a	slk:lemma	nezdanený
 03400972-n	slk:lemma	palivový filter
-00567860-s	slk:lemma	izolovaný
+00567860-a	slk:lemma	izolovaný
 05282433-n	slk:lemma	zuby
-01263445-s	slk:lemma	surový
-02104727-s	slk:lemma	citlivý na svetlo
+01263445-a	slk:lemma	surový
+02104727-a	slk:lemma	citlivý na svetlo
 06889330-n	slk:lemma	ostentatívnosť
 09326662-n	slk:lemma	pahorok
 00214951-v	slk:lemma	zmočiť si
@@ -5420,9 +5420,9 @@
 08964810-n	slk:lemma	Malajzijský poloostrov
 01010118-v	slk:lemma	vyhlasovať
 01528069-v	slk:lemma	upevňovať
-00907400-s	slk:lemma	pohŕdavý
+00907400-a	slk:lemma	pohŕdavý
 03093574-n	slk:lemma	spotrebný tovar
-00516231-s	slk:lemma	celučičký
+00516231-a	slk:lemma	celučičký
 04076533-n	slk:lemma	kópia
 11264002-n	slk:lemma	policajt
 15241186-n	slk:lemma	lovecká sezóna
@@ -5440,12 +5440,12 @@
 02578510-v	slk:lemma	zachovávať
 02778669-n	slk:lemma	lopta
 02410855-v	slk:lemma	pracovať
-00122844-s	slk:lemma	rezultatívny
-02516148-s	slk:lemma	zrakový
+00122844-a	slk:lemma	rezultatívny
+02516148-a	slk:lemma	zrakový
 00909363-a	slk:lemma	dysforický
 03816136-n	slk:lemma	ihla
 01651293-v	slk:lemma	začínať
-01941604-s	slk:lemma	pravdivý
+01941604-a	slk:lemma	pravdivý
 00032803-r	slk:lemma	veľmi
 02629390-v	slk:lemma	vopred zabraňovať
 14758842-n	slk:lemma	zvieracia koža
@@ -5456,13 +5456,13 @@
 08487504-n	slk:lemma	ASEAN
 00032863-r	slk:lemma	od toho času
 03473966-n	slk:lemma	háb
-00798491-s	slk:lemma	opitý
+00798491-a	slk:lemma	opitý
 10308066-n	slk:lemma	nečlen
 13252293-n	slk:lemma	panstvo
 00679147-a	slk:lemma	zničený
-02500179-s	slk:lemma	klamný
+02500179-a	slk:lemma	klamný
 08180944-n	slk:lemma	pracovná sila
-01388062-s	slk:lemma	impozantný
+01388062-a	slk:lemma	impozantný
 00020142-r	slk:lemma	neprestajne
 00217152-v	slk:lemma	rozvodňovať
 02420232-v	slk:lemma	hospodáriť
@@ -5471,7 +5471,7 @@
 15256915-n	slk:lemma	hra
 01569549-a	slk:lemma	existujúci medzi štátmi federácie
 07721942-n	slk:lemma	štipľavá červená paprika
-01880918-s	slk:lemma	nevhodný
+01880918-a	slk:lemma	nevhodný
 01106670-v	slk:lemma	predísť
 00073897-r	slk:lemma	zväčša
 00432689-n	slk:lemma	voľnočasová aktivita
@@ -5488,7 +5488,7 @@
 02469588-n	slk:lemma	primáty
 00421691-v	slk:lemma	vytrácať sa
 00151689-v	slk:lemma	redukovať
-00370267-s	slk:lemma	belasý
+00370267-a	slk:lemma	belasý
 00031820-v	slk:lemma	zasmiať sa
 00123170-v	slk:lemma	upravovať sa
 06292000-n	slk:lemma	slovo v záhlaví
@@ -5507,7 +5507,7 @@
 02469914-n	slk:lemma	primát
 10077593-n	slk:lemma	obdivovateľ
 01994442-v	slk:lemma	odtiahnuť
-01516346-s	slk:lemma	zapletený
+01516346-a	slk:lemma	zapletený
 02427103-v	slk:lemma	zriadiť
 14440875-n	slk:lemma	úpadok
 01469770-v	slk:lemma	pozvať
@@ -5522,8 +5522,8 @@
 03545150-n	slk:lemma	dom
 08963369-n	slk:lemma	Malajzia
 00769092-n	slk:lemma	defraudácia
-01421368-s	slk:lemma	literárny
-01973311-s	slk:lemma	pridružený
+01421368-a	slk:lemma	literárny
+01973311-a	slk:lemma	pridružený
 00158503-v	slk:lemma	pozdvihnúť
 00847478-v	slk:lemma	pochovať (prenesene, expresívne)
 01418536-v	slk:lemma	premiešať
@@ -5537,7 +5537,7 @@
 00431552-n	slk:lemma	koníček
 03511786-n	slk:lemma	päta
 15269996-n	slk:lemma	časová konštanta
-01754873-s	slk:lemma	pretrvávajúci
+01754873-a	slk:lemma	pretrvávajúci
 02265231-v	slk:lemma	zaznamenať
 00359135-n	slk:lemma	skrátenie
 01400562-a	slk:lemma	dovolený
@@ -5557,15 +5557,15 @@
 00406243-v	slk:lemma	pripraviť sa
 05314075-n	slk:lemma	kútik
 13990675-n	slk:lemma	vina
-01383394-s	slk:lemma	hojný
+01383394-a	slk:lemma	hojný
 09175322-n	slk:lemma	Galeras
 01845627-n	slk:lemma	kačicovité
-00228645-s	slk:lemma	optimálny
+00228645-a	slk:lemma	optimálny
 01382083-v	slk:lemma	oberať
 10018861-n	slk:lemma	distribútor
 02402825-v	slk:lemma	vyhodiť
 10276238-n	slk:lemma	vynikajúca osobnosť
-00900071-s	slk:lemma	záhadný
+00900071-a	slk:lemma	záhadný
 00885925-v	slk:lemma	vyhovovať niekomu
 04438304-n	slk:lemma	časomiera
 03588414-n	slk:lemma	položka
@@ -5581,7 +5581,7 @@
 09750282-n	slk:lemma	Papuánka
 01117723-n	slk:lemma	predaj
 13948136-n	slk:lemma	spoločenské postavenie
-01383582-s	slk:lemma	galaktický
+01383582-a	slk:lemma	galaktický
 03058107-n	slk:lemma	plášť
 09625401-n	slk:lemma	občan
 06546633-n	slk:lemma	prevod
@@ -5593,16 +5593,16 @@
 01523986-v	slk:lemma	omotať
 00512186-v	slk:lemma	vypnúť
 04366116-n	slk:lemma	suspenzia
-01131454-s	slk:lemma	odporný
+01131454-a	slk:lemma	odporný
 11902200-n	slk:lemma	divoký mak
 06390962-n	slk:lemma	koncept
 06436939-n	slk:lemma	Jób
 01605119-n	slk:lemma	čeľaď jastrabovité
-02433975-s	slk:lemma	prepracovaný
+02433975-a	slk:lemma	prepracovaný
 00798717-v	slk:lemma	popierať pod prísahou
 01814266-v	slk:lemma	zaťažovať
 07548978-n	slk:lemma	rozhorčenie
-01050088-s	slk:lemma	katastrofálny
+01050088-a	slk:lemma	katastrofálny
 06818970-n	slk:lemma	písmeno
 03770085-n	slk:lemma	miniauto
 00181748-r	slk:lemma	pohotovo
@@ -5613,7 +5613,7 @@
 09932336-n	slk:lemma	kočiš
 13250542-n	slk:lemma	peňažný majetok
 08221897-n	slk:lemma	publikum
-01062393-s	slk:lemma	autonómny
+01062393-a	slk:lemma	autonómny
 02405252-v	slk:lemma	vyšachovať
 02608347-v	slk:lemma	začať sa
 01809321-v	slk:lemma	zdolávať
@@ -5623,7 +5623,7 @@
 01517921-a	slk:lemma	civilný
 09031653-n	slk:lemma	Švajčiarsko
 13761801-n	slk:lemma	malé množstvo
-01580775-s	slk:lemma	nepostrádateľný
+01580775-a	slk:lemma	nepostrádateľný
 11434899-n	slk:lemma	chaos
 00278418-a	slk:lemma	nepremostiteľný
 07635827-n	slk:lemma	maslový keks
@@ -5641,7 +5641,7 @@
 08214083-n	slk:lemma	prápor
 00067274-v	slk:lemma	plakať
 07410207-n	slk:lemma	úder
-02418093-s	slk:lemma	prichádzajúci do úvahy
+02418093-a	slk:lemma	prichádzajúci do úvahy
 01571744-v	slk:lemma	škrtiť
 14439149-n	slk:lemma	zlá povesť
 07458453-n	slk:lemma	závod
@@ -5652,7 +5652,7 @@
 02061495-v	slk:lemma	mrštiť sa
 06779310-n	slk:lemma	smiešna historka
 07017534-n	slk:lemma	špeciál
-01973311-s	slk:lemma	pripojený
+01973311-a	slk:lemma	pripojený
 00813978-v	slk:lemma	prejednať (niečo)
 07314838-n	slk:lemma	katastrofa
 06898352-n	slk:lemma	programovací jazyk
@@ -5671,7 +5671,7 @@
 02679899-v	slk:lemma	udržať v chode
 01346693-v	slk:lemma	znovu začať
 00263000-n	slk:lemma	výzdoba
-00325995-s	slk:lemma	opatrný
+00325995-a	slk:lemma	opatrný
 08507558-n	slk:lemma	koreň
 10503247-n	slk:lemma	podvodník
 00023271-n	slk:lemma	vedomosť
@@ -5699,7 +5699,7 @@
 02342800-v	slk:lemma	dariť sa
 12707781-n	slk:lemma	citrónovník
 01233993-v	slk:lemma	zastrešovať
-00297598-s	slk:lemma	buržoázny
+00297598-a	slk:lemma	buržoázny
 01718867-a	slk:lemma	nepriamy
 02733524-n	slk:lemma	klenba
 06832356-n	slk:lemma	L
@@ -5721,8 +5721,8 @@
 01153486-v	slk:lemma	odplácať sa
 00962447-v	slk:lemma	hovorievať
 09429387-n	slk:lemma	časť
-00803432-s	slk:lemma	ostrý
-01947741-s	slk:lemma	kultivovaný
+00803432-a	slk:lemma	ostrý
+01947741-a	slk:lemma	kultivovaný
 08378180-n	slk:lemma	hierarchia údajov
 10617193-n	slk:lemma	špiceľ
 03307274-n	slk:lemma	externé dvere
@@ -5731,7 +5731,7 @@
 01111028-v	slk:lemma	dosahovať
 00124611-r	slk:lemma	právne
 02131418-n	slk:lemma	medveďovité
-00357556-s	slk:lemma	príznačný
+00357556-a	slk:lemma	príznačný
 00809654-v	slk:lemma	vyhýbať sa
 07365849-n	slk:lemma	zastavenie
 00575741-n	slk:lemma	úloha
@@ -5747,20 +5747,20 @@
 00062582-v	slk:lemma	zavárať
 10589785-n	slk:lemma	lodný maklér
 02542280-v	slk:lemma	vyhovieť
-00425313-s	slk:lemma	sprostý
+00425313-a	slk:lemma	sprostý
 02208903-v	slk:lemma	brať do árendy
 08744236-n	slk:lemma	Ciudad de Mexico
-01674134-s	slk:lemma	dohodnutý
-00864461-s	slk:lemma	pracujúci
+01674134-a	slk:lemma	dohodnutý
+00864461-a	slk:lemma	pracujúci
 00423471-r	slk:lemma	jasne
 00419375-v	slk:lemma	uvoľňovať
-01730444-s	slk:lemma	nedávny
+01730444-a	slk:lemma	nedávny
 00075021-v	slk:lemma	zodrať sa
 06755776-n	slk:lemma	hraničná podmienka
 00800930-v	slk:lemma	nebrať do úvahy
 01319874-a	slk:lemma	čestný
 00050641-a	slk:lemma	určený niekomu
-00127543-s	slk:lemma	po sebe idúci
+00127543-a	slk:lemma	po sebe idúci
 01488038-n	slk:lemma	žralok ozrutný
 07314838-n	slk:lemma	nešťastie
 02108026-v	slk:lemma	zakúšať
@@ -5775,7 +5775,7 @@
 07041688-n	slk:lemma	kvarteto
 04392526-n	slk:lemma	kazetový prehrávač
 05510907-n	slk:lemma	trakt
-01840880-s	slk:lemma	sprostý
+01840880-a	slk:lemma	sprostý
 05560787-n	slk:lemma	noha
 05410315-n	slk:lemma	gonádotropín
 00013615-v	slk:lemma	pôsobiť
@@ -5790,11 +5790,11 @@
 15245515-n	slk:lemma	čas
 00318735-n	slk:lemma	transport
 01661091-n	slk:lemma	stavovec triedy Reptilia
-02302187-s	slk:lemma	pravidelný
-01649720-s	slk:lemma	mladistvý
+02302187-a	slk:lemma	pravidelný
+01649720-a	slk:lemma	mladistvý
 10780632-n	slk:lemma	manželka
 02812631-n	slk:lemma	krídlo
-01625893-s	slk:lemma	hnusný
+01625893-a	slk:lemma	hnusný
 03541091-n	slk:lemma	nemocničná izba
 00406243-v	slk:lemma	chystať
 03240892-n	slk:lemma	vŕtací stroj
@@ -5802,7 +5802,7 @@
 00163233-n	slk:lemma	odhodlanie
 07497473-n	slk:lemma	zaľúbenie
 03145147-n	slk:lemma	hodiny s kukučkou
-01014953-s	slk:lemma	stredový
+01014953-a	slk:lemma	stredový
 02379198-v	slk:lemma	odstúpiť z funkcie
 08258523-n	slk:lemma	Komunistická strana
 03453162-n	slk:lemma	statok
@@ -5814,12 +5814,12 @@
 04243941-n	slk:lemma	automat na mince
 06224657-n	slk:lemma	paganizmus
 01090446-n	slk:lemma	merkantilizmus
-01886139-s	slk:lemma	odolný voči búrke
+01886139-a	slk:lemma	odolný voči búrke
 06675122-n	slk:lemma	zdroj
 05617606-n	slk:lemma	inteligencia
 01682229-a	slk:lemma	zorientovaný
 00769834-v	slk:lemma	obracať na vieru
-01936528-s	slk:lemma	pomyselný
+01936528-a	slk:lemma	pomyselný
 14141490-n	slk:lemma	týfus
 09887850-n	slk:lemma	návštevník
 08132323-n	slk:lemma	LABLINK
@@ -5834,7 +5834,7 @@
 10346015-n	slk:lemma	nacionalista
 00303940-v	slk:lemma	rozširovať
 07466832-n	slk:lemma	finále
-01950198-s	slk:lemma	neohrabaný
+01950198-a	slk:lemma	neohrabaný
 14449126-n	slk:lemma	potreba
 00884466-n	slk:lemma	kurz
 03112099-n	slk:lemma	chodbička
@@ -5842,7 +5842,7 @@
 01064151-v	slk:lemma	diskutovať
 15229300-n	slk:lemma	začiatok operácie
 09892693-n	slk:lemma	hlavný pilot
-00646117-s	slk:lemma	skvelý
+00646117-a	slk:lemma	skvelý
 03834604-n	slk:lemma	atómová zbraň
 14857497-n	slk:lemma	odpadky
 05830527-n	slk:lemma	ujma
@@ -5866,12 +5866,12 @@
 06691989-n	slk:lemma	pochvala
 05379039-n	slk:lemma	vretenová žila
 10423589-n	slk:lemma	filozof
-00764484-s	slk:lemma	úprimný
+00764484-a	slk:lemma	úprimný
 13352464-n	slk:lemma	prvá hypotéka
 01476483-v	slk:lemma	hatiť
 01642924-v	slk:lemma	uskutočniť
 02871631-n	slk:lemma	brvno
-01126841-s	slk:lemma	úbohý
+01126841-a	slk:lemma	úbohý
 01691057-v	slk:lemma	písať
 09363620-n	slk:lemma	rieka Murrumbidgee
 00224901-v	slk:lemma	oslabovať
@@ -5907,7 +5907,7 @@
 02738741-n	slk:lemma	helma
 00352826-v	slk:lemma	uzavrieť
 05685363-n	slk:lemma	rozpaky
-01871473-s	slk:lemma	výhodný
+01871473-a	slk:lemma	výhodný
 09366017-n	slk:lemma	priehlbeň
 01180351-v	slk:lemma	podať
 00766234-n	slk:lemma	trestný čin
@@ -5934,7 +5934,7 @@
 13908021-n	slk:lemma	vrúbok
 08512259-n	slk:lemma	hranice
 02189168-v	slk:lemma	odpočúvať
-00624913-s	slk:lemma	poriadny
+00624913-a	slk:lemma	poriadny
 05802185-n	slk:lemma	kalkulácia
 13163803-n	slk:lemma	konár
 00121366-n	slk:lemma	prenos
@@ -5943,12 +5943,12 @@
 07208338-n	slk:lemma	námietka
 02218173-v	slk:lemma	zbierať
 02991302-n	slk:lemma	cela
-01439496-s	slk:lemma	odolný
+01439496-a	slk:lemma	odolný
 02656390-v	slk:lemma	poskytovať záštitu
 02754096-a	slk:lemma	právnický
 01873294-v	slk:lemma	odtisnúť
 00799798-v	slk:lemma	anulovať
-01028163-s	slk:lemma	flexibilný
+01028163-a	slk:lemma	flexibilný
 02755352-n	slk:lemma	spoj
 00925490-v	slk:lemma	diviť sa
 02894605-n	slk:lemma	hať
@@ -5989,14 +5989,14 @@
 02023600-v	slk:lemma	zísť sa
 09473808-n	slk:lemma	rieka Wabash
 00621734-v	slk:lemma	vyvádzať z miery
-01892506-s	slk:lemma	pyšný na
+01892506-a	slk:lemma	pyšný na
 09826204-n	slk:lemma	pilot
 00579712-v	slk:lemma	podrobiť
 02728763-n	slk:lemma	prívesok
 08960987-n	slk:lemma	Luxembursko
 00654625-v	slk:lemma	prebrať
 15162210-n	slk:lemma	náboženská slávnosť
-02333976-s	slk:lemma	sklamaný
+02333976-a	slk:lemma	sklamaný
 01061945-n	slk:lemma	oprávnenie
 02202384-v	slk:lemma	ponechať si
 08163273-n	slk:lemma	legislatíva
@@ -6008,7 +6008,7 @@
 00231887-n	slk:lemma	vypovedanie
 04100174-n	slk:lemma	tyčka
 05872742-n	slk:lemma	základy
-02390724-s	slk:lemma	šalejúci
+02390724-a	slk:lemma	šalejúci
 02204692-v	slk:lemma	vlastniť
 02700867-v	slk:lemma	držať
 14234436-n	slk:lemma	polyp
@@ -6020,7 +6020,7 @@
 01787106-v	slk:lemma	naštvať sa
 09606527-n	slk:lemma	pozoruhodný človek
 02872529-n	slk:lemma	zosilňovač
-01374183-s	slk:lemma	hrubý
+01374183-a	slk:lemma	hrubý
 13370014-n	slk:lemma	rezervný fond
 02614181-v	slk:lemma	byť
 01961510-v	slk:lemma	brázdiť vodu plutvou
@@ -6036,7 +6036,7 @@
 02565491-v	slk:lemma	predchádzať (časovo)
 01061945-n	slk:lemma	požiadavka
 07498210-n	slk:lemma	záľuba
-00727113-s	slk:lemma	závislý od
+00727113-a	slk:lemma	závislý od
 00586598-v	slk:lemma	potláčať
 00340239-a	slk:lemma	zaručený
 02620213-v	slk:lemma	padnúť
@@ -6048,31 +6048,31 @@
 07018931-n	slk:lemma	hra
 07137733-n	slk:lemma	diskusia
 15161631-n	slk:lemma	sviatočný deň
-00803275-s	slk:lemma	prudký
+00803275-a	slk:lemma	prudký
 10252222-n	slk:lemma	lektor
 05692910-n	slk:lemma	vplyv
 01523908-n	slk:lemma	rad spevavce
 14500341-n	slk:lemma	bordel
-01917594-s	slk:lemma	zvláštny
+01917594-a	slk:lemma	zvláštny
 07338681-n	slk:lemma	náraz
 02051694-v	slk:lemma	minúť
 14415518-n	slk:lemma	izolácia
 00251780-n	slk:lemma	kefovanie
 02638960-n	slk:lemma	Amia
 00252019-v	slk:lemma	rozvinúť sa
-01481812-s	slk:lemma	spojený
+01481812-a	slk:lemma	spojený
 11508382-n	slk:lemma	sneh
 01086945-n	slk:lemma	sociálna starostlivosť
 08523483-n	slk:lemma	oko
 13267014-n	slk:lemma	príspevok
 01919391-v	slk:lemma	pochodovať
 03876519-n	slk:lemma	obrázok
-00279092-s	slk:lemma	trblietajúci sa
+00279092-a	slk:lemma	trblietajúci sa
 03645577-n	slk:lemma	latinská plachta
 03327234-n	slk:lemma	plot
 00036935-r	slk:lemma	definitívne
 13624873-n	slk:lemma	kubík
-01459755-s	slk:lemma	nádherný
+01459755-a	slk:lemma	nádherný
 00677544-v	slk:lemma	preberať
 02061495-v	slk:lemma	rýchlo bežať
 02933990-n	slk:lemma	káblová televízia
@@ -6081,16 +6081,16 @@
 01217043-v	slk:lemma	podoprieť
 01219004-v	slk:lemma	podoprieť
 04589745-n	slk:lemma	okenná tabuľa
-00014490-s	slk:lemma	hojný
-01750386-s	slk:lemma	úplný
+00014490-a	slk:lemma	hojný
+01750386-a	slk:lemma	úplný
 00214951-v	slk:lemma	vlhnúť
-01320474-s	slk:lemma	nevinný
+01320474-a	slk:lemma	nevinný
 02725596-n	slk:lemma	Antonine Wall
 04033082-n	slk:lemma	nábrežie
 02163746-v	slk:lemma	zbadať
 01090335-v	slk:lemma	hádať sa
 14285662-n	slk:lemma	ublíženie
-00361125-s	slk:lemma	mravný
+00361125-a	slk:lemma	mravný
 02548588-v	slk:lemma	pomáhať
 02148788-v	slk:lemma	prezentovať
 03021866-a	slk:lemma	pripomínajúci ker
@@ -6110,7 +6110,7 @@
 00065822-r	slk:lemma	nakoniec
 00613683-v	slk:lemma	nechať
 05377665-n	slk:lemma	vratná žila
-00783840-s	slk:lemma	všeobecný
+00783840-a	slk:lemma	všeobecný
 07330560-n	slk:lemma	kismet
 13375604-n	slk:lemma	úverový účet
 02650552-v	slk:lemma	sídliť
@@ -6121,7 +6121,7 @@
 08212347-n	slk:lemma	pracovná sila
 03550153-n	slk:lemma	barak
 14446652-n	slk:lemma	nepohodlie
-01580775-s	slk:lemma	nutný
+01580775-a	slk:lemma	nutný
 03795580-n	slk:lemma	posuvná bariéra
 07840804-n	slk:lemma	vajcia
 00030358-n	slk:lemma	akt
@@ -6148,7 +6148,7 @@
 00181748-r	slk:lemma	s vervou
 07447641-n	slk:lemma	zábava
 00231567-n	slk:lemma	zrušiť
-01394075-s	slk:lemma	drobný
+01394075-a	slk:lemma	drobný
 00666510-v	slk:lemma	doložiť dokumentmi
 08274565-n	slk:lemma	zástup
 15238169-n	slk:lemma	obdobie rastu
@@ -6170,15 +6170,15 @@
 02730326-v	slk:lemma	narážať (na prekážku)
 14435445-n	slk:lemma	význačné postavenie
 01177703-n	slk:lemma	manifestácia
-01564603-s	slk:lemma	uprený (pohľad)
+01564603-a	slk:lemma	uprený (pohľad)
 00147091-n	slk:lemma	zhluk
-01572171-s	slk:lemma	zafarbený
+01572171-a	slk:lemma	zafarbený
 13721387-n	slk:lemma	dlhá tona
 12123050-n	slk:lemma	rod Hordeum
 01146993-n	slk:lemma	dočasné obmedzenie pohybu väzňov
 00512186-v	slk:lemma	vyradiť
 14059928-n	slk:lemma	ochorenie žliaz
-01945350-s	slk:lemma	neoprávnený
+01945350-a	slk:lemma	neoprávnený
 02421374-v	slk:lemma	dať slobodu
 02431122-n	slk:lemma	jeleň lesný
 14687633-n	slk:lemma	kerosén
@@ -6188,11 +6188,11 @@
 06167328-n	slk:lemma	filozofická teória
 06941644-n	slk:lemma	indoeurópsky jazyk
 00422090-v	slk:lemma	prísť
-00542359-s	slk:lemma	riedky
+00542359-a	slk:lemma	riedky
 08956760-n	slk:lemma	Laoská ľudovodemokratická republika
 01852174-a	slk:lemma	prvotný
 10000787-n	slk:lemma	delegát
-00595299-s	slk:lemma	stály
+00595299-a	slk:lemma	stály
 05893261-n	slk:lemma	nevyhnutná podmienka
 06443163-n	slk:lemma	List apoštola Pavla Rimanom
 09351647-n	slk:lemma	rieka Merrimack
@@ -6200,7 +6200,7 @@
 09264116-n	slk:lemma	Delaware
 02506546-v	slk:lemma	prikázať
 03387653-n	slk:lemma	zlieváreň
-01009206-s	slk:lemma	prvý
+01009206-a	slk:lemma	prvý
 00622384-v	slk:lemma	privádzať do rozpakov
 00544549-v	slk:lemma	povyšovať
 02657219-v	slk:lemma	súhlasiť
@@ -6211,13 +6211,13 @@
 00992041-v	slk:lemma	naznačovať
 00095329-n	slk:lemma	náhrada
 02613487-v	slk:lemma	obetovať
-01497245-s	slk:lemma	obsažný
+01497245-a	slk:lemma	obsažný
 07286014-n	slk:lemma	predzvesť
 00258854-n	slk:lemma	náprava
 05168261-n	slk:lemma	závažnosť
 10421016-n	slk:lemma	faraón
 13951215-n	slk:lemma	nízky status
-00698586-s	slk:lemma	odvodený
+00698586-a	slk:lemma	odvodený
 02121234-n	slk:lemma	rod mačky
 01033184-n	slk:lemma	liturgia
 08056601-n	slk:lemma	kolektív
@@ -6245,7 +6245,7 @@
 04948241-n	slk:lemma	drsnosť
 09321180-n	slk:lemma	rieka James
 02994858-n	slk:lemma	telefónna centrála
-00604978-s	slk:lemma	priaznivý
+00604978-a	slk:lemma	priaznivý
 00070965-n	slk:lemma	omyl
 05339357-n	slk:lemma	krčná artéria
 13999663-n	slk:lemma	pozastavenie
@@ -6256,7 +6256,7 @@
 01850315-v	slk:lemma	posunúť
 03797548-n	slk:lemma	policajná fotografia
 07013736-n	slk:lemma	slovný reťazec
-00522463-s	slk:lemma	vyčerpávajúci
+00522463-a	slk:lemma	vyčerpávajúci
 00022099-v	slk:lemma	prebrať (z bezvedomia)
 07516756-n	slk:lemma	hnev
 00813978-v	slk:lemma	prejednávať (niečo)
@@ -6274,7 +6274,7 @@
 03455033-n	slk:lemma	hrobka
 03848729-n	slk:lemma	otvor
 05118437-n	slk:lemma	nemiernosť
-02502578-s	slk:lemma	zbytočný
+02502578-a	slk:lemma	zbytočný
 12143676-n	slk:lemma	kukurica
 02653706-v	slk:lemma	prislúchať
 01663749-v	slk:lemma	upiecť
@@ -6289,7 +6289,7 @@
 08388074-n	slk:lemma	niekoľko
 04357121-n	slk:lemma	posuvná strecha
 03791235-n	slk:lemma	motorové vozidlo
-01996875-s	slk:lemma	zodpovedajúci sa
+01996875-a	slk:lemma	zodpovedajúci sa
 15266164-n	slk:lemma	štartovací bod
 02063018-v	slk:lemma	nakloniť
 14849789-n	slk:lemma	šmirgľové plátno
@@ -6297,7 +6297,7 @@
 05645597-n	slk:lemma	hlúposť
 00038625-r	slk:lemma	celkom správne
 00670261-v	slk:lemma	vyhodnotiť
-00922840-s	slk:lemma	všedný
+00922840-a	slk:lemma	všedný
 10521662-n	slk:lemma	zapisovateľ
 11900986-n	slk:lemma	rod Papaver
 00377002-v	slk:lemma	zhorieť
@@ -6309,10 +6309,10 @@
 09144851-n	slk:lemma	Houston
 00048739-r	slk:lemma	okamžite
 05938795-n	slk:lemma	model
-00294579-s	slk:lemma	lenivý
+00294579-a	slk:lemma	lenivý
 09746536-n	slk:lemma	obyvateľ Wisconsinu
 01177327-n	slk:lemma	odboj
-00712877-s	slk:lemma	naliehavý
+00712877-a	slk:lemma	naliehavý
 07531713-n	slk:lemma	potešenie
 08858529-n	slk:lemma	Britská východná Afrika
 07663592-n	slk:lemma	hovädzie mäso
@@ -6322,7 +6322,7 @@
 00194645-n	slk:lemma	prechod na metrickú sústavu
 06460524-n	slk:lemma	Kniha múdrostí
 02225492-v	slk:lemma	uchovať
-00609564-s	slk:lemma	neobvyklý
+00609564-a	slk:lemma	neobvyklý
 13144303-n	slk:lemma	čeľaď Vitaceae
 03457902-n	slk:lemma	lesná škôlka
 04760771-n	slk:lemma	telesná existencia
@@ -6330,7 +6330,7 @@
 01170687-v	slk:lemma	sŕkať
 11986091-n	slk:lemma	rod Lactuca
 05593476-n	slk:lemma	ulna
-01729566-s	slk:lemma	bývalý
+01729566-a	slk:lemma	bývalý
 03260504-n	slk:lemma	dynamo
 00161932-r	slk:lemma	na verejnosti
 13288206-n	slk:lemma	ukončiteľný úrok
@@ -6349,7 +6349,7 @@
 01794340-a	slk:lemma	efektný
 12663023-n	slk:lemma	Arabica káva
 01278427-v	slk:lemma	zvraštiť sa
-01288895-s	slk:lemma	rozvinutý
+01288895-a	slk:lemma	rozvinutý
 01998793-v	slk:lemma	dostihnúť
 01522276-v	slk:lemma	namotať sa
 03221720-n	slk:lemma	dvere
@@ -6362,7 +6362,7 @@
 10247358-n	slk:lemma	dievčina
 14494893-n	slk:lemma	byť čistotný
 00140967-v	slk:lemma	meniť tvar
-02361848-s	slk:lemma	presvedčiteľný
+02361848-a	slk:lemma	presvedčiteľný
 09456614-n	slk:lemma	pobrežné vody
 06586471-n	slk:lemma	linka
 00126837-r	slk:lemma	technicky
@@ -6395,7 +6395,7 @@
 00690933-n	slk:lemma	plastická operácia konečníka
 01523986-v	slk:lemma	vinúť
 05333777-n	slk:lemma	cieva
-02327315-s	slk:lemma	hádavý
+02327315-a	slk:lemma	hádavý
 01925372-a	slk:lemma	racionálny
 10195487-n	slk:lemma	hypochonder
 00087188-r	slk:lemma	rovno
@@ -6409,19 +6409,19 @@
 00151689-v	slk:lemma	znižovať
 00006105-r	slk:lemma	obvykle
 00381680-n	slk:lemma	zjednocovanie
-01728919-s	slk:lemma	minulý
+01728919-a	slk:lemma	minulý
 00343334-v	slk:lemma	zopakovať sa
 00902932-v	slk:lemma	želať
 00893435-v	slk:lemma	ospravedlňovať
 00717358-v	slk:lemma	dať odpoveď
-00371945-s	slk:lemma	bronzový
+00371945-a	slk:lemma	bronzový
 14202996-n	slk:lemma	nádor
 00986938-n	slk:lemma	strieľanie
 00193130-v	slk:lemma	dodať odvahy
 02480803-v	slk:lemma	objednať si
 07194950-n	slk:lemma	krížový výsluch
 09272595-n	slk:lemma	Elizabeth
-01525320-s	slk:lemma	pevný
+01525320-a	slk:lemma	pevný
 02423762-v	slk:lemma	naplniť fľaše
 05447599-n	slk:lemma	kostná bunka
 02477334-v	slk:lemma	anulovať
@@ -6446,12 +6446,12 @@
 01975138-a	slk:lemma	príslušný
 07553301-n	slk:lemma	sympatia
 01849221-v	slk:lemma	prichádzať
-02418412-s	slk:lemma	možný
+02418412-a	slk:lemma	možný
 03163798-n	slk:lemma	prevodník dát
 08208560-n	slk:lemma	skupina
 10004804-n	slk:lemma	príslušník
 00860611-a	slk:lemma	ideálny
-01482551-s	slk:lemma	rozvedený
+01482551-a	slk:lemma	rozvedený
 06133503-n	slk:lemma	strojový preklad
 02478701-v	slk:lemma	formálne schváliť
 05541645-n	slk:lemma	temenná kosť
@@ -6459,7 +6459,7 @@
 04890112-n	slk:lemma	učenosť
 13023292-n	slk:lemma	podkmeň Ascomycota
 10182190-n	slk:lemma	bezdomovec
-01515280-s	slk:lemma	činný
+01515280-a	slk:lemma	činný
 13337471-n	slk:lemma	emisia dlhopisov
 00579712-v	slk:lemma	podriaďovať
 04746430-n	slk:lemma	analógia
@@ -6494,7 +6494,7 @@
 00594580-n	slk:lemma	hodnosť poručíka
 00791134-v	slk:lemma	povolať
 02929901-a	slk:lemma	racionálny
-00016647-s	slk:lemma	zelenajúci sa
+00016647-a	slk:lemma	zelenajúci sa
 15294607-n	slk:lemma	inkubačná doba
 02061495-v	slk:lemma	rýchlo utiecť
 14698000-n	slk:lemma	sedimentárna hornina
@@ -6505,7 +6505,7 @@
 02141973-v	slk:lemma	vyťahovať sa
 01393714-v	slk:lemma	odmiesť
 00187120-r	slk:lemma	pohodlne
-00412171-s	slk:lemma	moderný
+00412171-a	slk:lemma	moderný
 14452294-n	slk:lemma	prebytok
 04051705-n	slk:lemma	stúpajúci oblúk
 15200314-n	slk:lemma	Narodeniny Kanady
@@ -6523,21 +6523,21 @@
 02766390-v	slk:lemma	zatrblietať sa
 08299307-n	slk:lemma	Medzinárodný súdny dvor
 00318035-n	slk:lemma	odovzdanie
-01573238-s	slk:lemma	falošný
+01573238-a	slk:lemma	falošný
 00192659-v	slk:lemma	dávať viac šťavy
 01029642-v	slk:lemma	nazvať
 04403413-n	slk:lemma	transfokátor
 00928751-n	slk:lemma	územné plánovanie
 01026095-v	slk:lemma	označiť
-01450178-s	slk:lemma	nezvestný
+01450178-a	slk:lemma	nezvestný
 01132472-n	slk:lemma	minimálna starostlivosť
 00013160-a	slk:lemma	hmotný
 13765624-n	slk:lemma	škatuľa
 13903576-n	slk:lemma	periféria
-01523249-s	slk:lemma	riaditeľný
+01523249-a	slk:lemma	riaditeľný
 00597216-v	slk:lemma	opakovať si
 00188779-r	slk:lemma	zanietene
-01115635-s	slk:lemma	dôveryhodný
+01115635-a	slk:lemma	dôveryhodný
 06437137-n	slk:lemma	Kniha Žalmov
 10147710-n	slk:lemma	obchodník so zmiešaným tovarom
 03291551-n	slk:lemma	zákopové postavenie
@@ -6560,13 +6560,13 @@
 01166093-v	slk:lemma	použiť
 00722232-v	slk:lemma	upriamovať (pozornosť)
 05896059-n	slk:lemma	ilúzia
-01933731-s	slk:lemma	ozajstný
+01933731-a	slk:lemma	ozajstný
 15272029-n	slk:lemma	omeškanie
 00609100-v	slk:lemma	nespomínať si
 06453849-n	slk:lemma	Nová zmluva
 00745499-v	slk:lemma	žiadať o
 13458571-n	slk:lemma	zníženie
-02477211-s	slk:lemma	spárovaný
+02477211-a	slk:lemma	spárovaný
 05584928-n	slk:lemma	zápästie
 00384620-v	slk:lemma	opraviť
 00266812-r	slk:lemma	bezpochyby
@@ -6593,7 +6593,7 @@
 02959942-n	slk:lemma	vozeň
 02028366-v	slk:lemma	plynúť
 00426757-n	slk:lemma	neokolonializmus
-00798491-s	slk:lemma	opilecký
+00798491-a	slk:lemma	opilecký
 10165109-n	slk:lemma	záchranár
 07185325-n	slk:lemma	požiadavka
 00069295-v	slk:lemma	vylučovať
@@ -6606,29 +6606,29 @@
 14799244-n	slk:lemma	brúsny materiál
 13353858-n	slk:lemma	majetok
 10249011-n	slk:lemma	vyznamenaný cenou
-01921466-s	slk:lemma	hrmotný
+01921466-a	slk:lemma	hrmotný
 09937056-n	slk:lemma	študent
-00990855-s	slk:lemma	útly
+00990855-a	slk:lemma	útly
 01021420-v	slk:lemma	dohodnúť (definitívne)
 11605708-n	slk:lemma	Coniferopsida
 04645943-n	slk:lemma	nechuť
 13742358-n	slk:lemma	nič
-00011327-s	slk:lemma	hltavý
+00011327-a	slk:lemma	hltavý
 00057486-n	slk:lemma	odchod
 00958334-v	slk:lemma	zopakovať
 01953810-v	slk:lemma	prepravovať sa
 09771435-n	slk:lemma	milovník
-00028471-s	slk:lemma	všeobecne považovaný
+00028471-a	slk:lemma	všeobecne považovaný
 13977366-n	slk:lemma	narušenie poriadku
 03864542-n	slk:lemma	vrchná plošina
-00660809-s	slk:lemma	3D
+00660809-a	slk:lemma	3D
 01067362-n	slk:lemma	váhanie
 06717170-n	slk:lemma	pohŕdanie
 11428379-n	slk:lemma	lúč
 06820023-n	slk:lemma	horný index
-00527188-s	slk:lemma	svetový
+00527188-a	slk:lemma	svetový
 02531625-v	slk:lemma	preskúmavať
-00298293-s	slk:lemma	kolektívny
+00298293-a	slk:lemma	kolektívny
 00160659-r	slk:lemma	tesne
 04287153-n	slk:lemma	odtok
 01150559-v	slk:lemma	zamerať
@@ -6641,7 +6641,7 @@
 05692419-n	slk:lemma	určujúci faktor
 09979589-n	slk:lemma	posudzovateľ
 00672277-v	slk:lemma	posúdiť
-00444984-s	slk:lemma	susedný
+00444984-a	slk:lemma	susedný
 00157950-v	slk:lemma	zvyšovať sa
 13904506-n	slk:lemma	pokles
 01774426-v	slk:lemma	hnusiť sa
@@ -6658,22 +6658,22 @@
 02471091-a	slk:lemma	povrchový
 01568630-v	slk:lemma	potláčať
 09620078-n	slk:lemma	naturalizovaný cudzinec
-00405879-s	slk:lemma	bledý
+00405879-a	slk:lemma	bledý
 00273601-n	slk:lemma	ústup
-01618376-s	slk:lemma	zjavný
+01618376-a	slk:lemma	zjavný
 01296462-v	slk:lemma	pripojiť
 07996689-n	slk:lemma	súprava
-01569366-s	slk:lemma	nadnárodný
+01569366-a	slk:lemma	nadnárodný
 00243373-n	slk:lemma	inaugurácia
 00892861-n	slk:lemma	prednáška
 02027612-v	slk:lemma	prihrnúť sa
 09057311-n	slk:lemma	AZ
 00159396-n	slk:lemma	korupcia
 01819147-v	slk:lemma	znechutiť
-00115777-s	slk:lemma	nahnevaný
+00115777-a	slk:lemma	nahnevaný
 00598318-n	slk:lemma	štátny úrad
 02151625-n	slk:lemma	krídlo
-01110470-s	slk:lemma	chránený autorským právom
+01110470-a	slk:lemma	chránený autorským právom
 02459173-v	slk:lemma	ubytovať
 00035718-r	slk:lemma	pomerne
 10269458-n	slk:lemma	nájomník
@@ -6691,12 +6691,12 @@
 02723016-v	slk:lemma	vystrájať
 01810447-v	slk:lemma	rozhorčovať
 10658501-n	slk:lemma	chovateľ dobytka
-00915321-s	slk:lemma	dokonalý
+00915321-a	slk:lemma	dokonalý
 11664929-n	slk:lemma	Angiospermae
 02416030-v	slk:lemma	dofušovať
 14946424-n	slk:lemma	kyselina maleínová
 00177483-r	slk:lemma	slabo
-00566342-s	slk:lemma	priľahlý
+00566342-a	slk:lemma	priľahlý
 00217956-v	slk:lemma	navlhčovať
 08853741-n	slk:lemma	Brazílska federatívna republika
 00945401-n	slk:lemma	hľadanie
@@ -6704,12 +6704,12 @@
 00357023-n	slk:lemma	stláčanie
 00767826-n	slk:lemma	útok
 08180190-n	slk:lemma	jednoduchí ľudia
-01322323-s	slk:lemma	trestuhodný
-00179190-s	slk:lemma	blahorečený
+01322323-a	slk:lemma	trestuhodný
+00179190-a	slk:lemma	blahorečený
 01177033-n	slk:lemma	odpor
-01154030-s	slk:lemma	mäkký
+01154030-a	slk:lemma	mäkký
 01405044-v	slk:lemma	udierať
-01443097-s	slk:lemma	momentálny
+01443097-a	slk:lemma	momentálny
 01410606-a	slk:lemma	rovnaký
 00679389-v	slk:lemma	vyberať
 02432983-n	slk:lemma	los
@@ -6745,7 +6745,7 @@
 01144355-n	slk:lemma	rozvrhovanie
 05646039-n	slk:lemma	hlupáctvo
 06832680-n	slk:lemma	óčko
-01936528-s	slk:lemma	neskutočný
+01936528-a	slk:lemma	neskutočný
 00317207-n	slk:lemma	zásielka
 07181713-n	slk:lemma	konfrontácia
 06600684-n	slk:lemma	digresia, odbočenie
@@ -6770,7 +6770,7 @@
 03959701-n	slk:lemma	brnenie
 06513366-n	slk:lemma	žiadosť
 00021265-n	slk:lemma	pokrm
-01580775-s	slk:lemma	žiadaný
+01580775-a	slk:lemma	žiadaný
 01989053-v	slk:lemma	padať
 10207831-n	slk:lemma	pýtajúci sa
 05486920-n	slk:lemma	oblasť vonkajšieho obalu
@@ -6797,15 +6797,15 @@
 00212414-v	slk:lemma	zachovať sa
 10089615-n	slk:lemma	podfukár
 07035420-n	slk:lemma	nábožná pieseň
-00027599-s	slk:lemma	akceptovaný
+00027599-a	slk:lemma	akceptovaný
 09774266-n	slk:lemma	špecialista
 14081375-n	slk:lemma	útok
 02768579-v	slk:lemma	vydávať paru
-01729819-s	slk:lemma	bývalý
+01729819-a	slk:lemma	bývalý
 04287747-n	slk:lemma	striekacia pištoľ
 04950026-n	slk:lemma	optika
 05714894-n	slk:lemma	puch
-01282510-s	slk:lemma	(slang.) úžasný
+01282510-a	slk:lemma	(slang.) úžasný
 04316646-n	slk:lemma	korma
 00614829-v	slk:lemma	zabudnúť
 01811736-v	slk:lemma	vzpružiť
@@ -6815,8 +6815,8 @@
 00699815-v	slk:lemma	stanoviť
 00921072-v	slk:lemma	podozrievať
 00691330-n	slk:lemma	rizotómia
-02038126-s	slk:lemma	silný ako býk
-00523867-s	slk:lemma	autonómny
+02038126-a	slk:lemma	silný ako býk
+00523867-a	slk:lemma	autonómny
 06877990-n	slk:lemma	úškľabok
 01412346-v	slk:lemma	premôcť
 15236859-n	slk:lemma	jeseň
@@ -6843,14 +6843,14 @@
 03445120-n	slk:lemma	zlatá baňa
 10368414-n	slk:lemma	čudák
 01564144-v	slk:lemma	zruinovať
-02577454-s	slk:lemma	ekonomický
+02577454-a	slk:lemma	ekonomický
 03109881-n	slk:lemma	roh
 00144778-n	slk:lemma	pohladkanie
 07575510-n	slk:lemma	čas na olovrant
 09718092-n	slk:lemma	Jamajčan
 05128519-n	slk:lemma	plocha
 08703454-n	slk:lemma	islamský štát Afganistan
-01874331-s	slk:lemma	diletantský
+01874331-a	slk:lemma	diletantský
 01015244-v	slk:lemma	doložiť
 08849753-n	slk:lemma	Belgické kráľovstvo
 08050678-n	slk:lemma	vláda
@@ -6861,7 +6861,7 @@
 00051525-n	slk:lemma	prenikanie
 02284951-v	slk:lemma	vracať
 01327925-a	slk:lemma	integrovaný
-00383291-s	slk:lemma	zafírovo modrý
+00383291-a	slk:lemma	zafírovo modrý
 00022316-v	slk:lemma	upokojovať
 01797148-a	slk:lemma	plánovaný
 00081737-r	slk:lemma	každoročne
@@ -6892,12 +6892,12 @@
 01511706-v	slk:lemma	hnať
 10420031-n	slk:lemma	predkladateľ petície
 05595083-n	slk:lemma	spoj
-02569558-s	slk:lemma	chytrý
+02569558-a	slk:lemma	chytrý
 09087126-n	slk:lemma	Dubunque
 05528604-n	slk:lemma	nosová dutina
 04365484-n	slk:lemma	merací prístroj zememerača
 01217859-n	slk:lemma	zamestnanie
-02059381-s	slk:lemma	neistý
+02059381-a	slk:lemma	neistý
 12922933-n	slk:lemma	krotónový olej
 06338908-n	slk:lemma	priezvisko
 00378069-n	slk:lemma	spaľovanie
@@ -6913,7 +6913,7 @@
 09429387-n	slk:lemma	diel
 08565506-n	slk:lemma	Eden
 04003597-n	slk:lemma	výtlačok
-01558641-s	slk:lemma	riadený
+01558641-a	slk:lemma	riadený
 14972359-n	slk:lemma	oxokyselina
 06528557-n	slk:lemma	nútený predaj
 04627000-n	slk:lemma	vrúcnosť
@@ -6937,10 +6937,10 @@
 14428160-n	slk:lemma	úroveň
 00038625-r	slk:lemma	samozrejme
 08604283-n	slk:lemma	Národný park Denali
-02075321-s	slk:lemma	duševne chorý
+02075321-a	slk:lemma	duševne chorý
 00859325-v	slk:lemma	rozradosťovať sa
 02386388-v	slk:lemma	poverovať
-00820975-s	slk:lemma	dnešný
+00820975-a	slk:lemma	dnešný
 04033901-n	slk:lemma	brko
 14039179-n	slk:lemma	nadšenie
 12660009-n	slk:lemma	Rubiaceae
@@ -6952,7 +6952,7 @@
 09225943-n	slk:lemma	močiar
 05154241-n	slk:lemma	nekompetentnosť
 07464083-n	slk:lemma	štafeta
-00798103-s	slk:lemma	spitý namol
+00798103-a	slk:lemma	spitý namol
 03827536-n	slk:lemma	čo robí hluk
 00610374-v	slk:lemma	spoznávať
 13992514-n	slk:lemma	autonómia
@@ -6964,7 +6964,7 @@
 02679530-v	slk:lemma	prolongovať
 03668279-n	slk:lemma	svetelné pero
 00211462-n	slk:lemma	dokončenie
-00476663-s	slk:lemma	stiesnený
+00476663-a	slk:lemma	stiesnený
 00842989-v	slk:lemma	obviniť
 01846916-v	slk:lemma	cestovať
 14759722-n	slk:lemma	koža
@@ -6977,37 +6977,37 @@
 02680512-n	slk:lemma	štôlňa
 00168564-r	slk:lemma	búrlivo
 09983572-n	slk:lemma	pastor
-01814711-s	slk:lemma	mocenský
-00912094-s	slk:lemma	nepravidelný
+01814711-a	slk:lemma	mocenský
+00912094-a	slk:lemma	nepravidelný
 01802494-v	slk:lemma	vyjadrovať emócie
 02586619-v	slk:lemma	ovládať
 06552814-n	slk:lemma	splatenie dlhu
 00186366-r	slk:lemma	formálne
 14991927-n	slk:lemma	rastlinný produkt
 05009170-n	slk:lemma	fyzikálna vlastnosť
-02367319-s	slk:lemma	špeciálny
+02367319-a	slk:lemma	špeciálny
 04893358-n	slk:lemma	skromnosť
 00362610-v	slk:lemma	zadržiavať
-01662384-s	slk:lemma	nevýhodný
-00566835-s	slk:lemma	príbuzný
+01662384-a	slk:lemma	nevýhodný
+00566835-a	slk:lemma	príbuzný
 09096664-n	slk:lemma	Cambridge
 06468951-n	slk:lemma	súhrn
 02722902-v	slk:lemma	vyčíňať
-01536641-s	slk:lemma	ultramoderný
+01536641-a	slk:lemma	ultramoderný
 00018584-a	slk:lemma	neakceptovateľný
 01067577-n	slk:lemma	oneskorenie
-00507292-s	slk:lemma	krutý
+00507292-a	slk:lemma	krutý
 01160729-n	slk:lemma	výprask
 09712448-n	slk:lemma	Haiťanka
 06549661-n	slk:lemma	oprávnenie
-00900071-s	slk:lemma	mysteriózny
+00900071-a	slk:lemma	mysteriózny
 01854132-v	slk:lemma	nabrať
 06459016-n	slk:lemma	Príbeh Zuzany
 00125602-r	slk:lemma	in flagranti
 08132046-n	slk:lemma	DARPA
 00890590-v	slk:lemma	poistiť
 05802185-n	slk:lemma	výpočet
-00298293-s	slk:lemma	hromadný
+00298293-a	slk:lemma	hromadný
 10271677-n	slk:lemma	pán
 14145095-n	slk:lemma	respiračné ochorenie
 01850315-v	slk:lemma	premiestniť sa
@@ -7019,13 +7019,13 @@
 05300675-n	slk:lemma	sluchové ústrojenstvo
 00754280-n	slk:lemma	podfuk
 04907269-n	slk:lemma	svojhlavosť
-01019713-s	slk:lemma	poddajný
+01019713-a	slk:lemma	poddajný
 01243674-n	slk:lemma	štrajk
 10437852-n	slk:lemma	žalujúci
 04255499-n	slk:lemma	sokel
 08005580-n	slk:lemma	pole
 02888659-a	slk:lemma	pobrežný
-01115920-s	slk:lemma	overený
+01115920-a	slk:lemma	overený
 04844024-n	slk:lemma	nevnímavosť
 02684875-a	slk:lemma	slávnostný
 14559208-n	slk:lemma	prolaps
@@ -7041,20 +7041,20 @@
 00737656-v	slk:lemma	uchvacovať
 00061595-v	slk:lemma	vykastrovať
 02419773-v	slk:lemma	makať
-00488857-s	slk:lemma	nezvyčajný
-01533974-s	slk:lemma	nadmerný
-00975487-s	slk:lemma	elegantný
+00488857-a	slk:lemma	nezvyčajný
+01533974-a	slk:lemma	nadmerný
+00975487-a	slk:lemma	elegantný
 05807306-n	slk:lemma	náhľad
 12144117-n	slk:lemma	obilie
 05057163-n	slk:lemma	extrémne nízka frekvencia
-02535533-s	slk:lemma	narastajúci
+02535533-a	slk:lemma	narastajúci
 07827410-n	slk:lemma	sézamové semeno
 00360485-n	slk:lemma	zmenšovanie
 10582746-n	slk:lemma	vojak
 01171183-v	slk:lemma	slopať
 00695226-v	slk:lemma	oceniť
 00294245-v	slk:lemma	kvitnúť
-01451768-s	slk:lemma	obdarený
+01451768-a	slk:lemma	obdarený
 02110220-v	slk:lemma	zakúšať
 04795545-n	slk:lemma	obyčajnosť
 01235463-n	slk:lemma	pomsta
@@ -7062,7 +7062,7 @@
 09137869-n	slk:lemma	South Carolina
 07001717-n	slk:lemma	stĺpcový graf
 07068844-n	slk:lemma	aparát
-01761375-s	slk:lemma	vylúčený zo spoločnosti
+01761375-a	slk:lemma	vylúčený zo spoločnosti
 00897241-v	slk:lemma	zdraviť
 04405540-n	slk:lemma	televízne zariadenie
 13344071-n	slk:lemma	krytie
@@ -7084,14 +7084,14 @@
 00424767-n	slk:lemma	ukrutnosť
 05510173-n	slk:lemma	dýchacia sústava
 01635432-v	slk:lemma	zviditeľniť
-00798103-s	slk:lemma	spitý
-01302544-s	slk:lemma	rozvojový
+00798103-a	slk:lemma	spitý
+01302544-a	slk:lemma	rozvojový
 14490319-n	slk:lemma	dlžoba
 00975781-n	slk:lemma	rýchla vojna
 02561332-v	slk:lemma	aplikovať
 08537837-n	slk:lemma	mestská oblasť
 00589309-v	slk:lemma	cítiť
-02215087-s	slk:lemma	jedinečný
+02215087-a	slk:lemma	jedinečný
 00813978-v	slk:lemma	diskutovať
 09956387-n	slk:lemma	expert
 05094725-n	slk:lemma	hĺbka
@@ -7111,7 +7111,7 @@
 02696920-a	slk:lemma	civilný
 00617748-v	slk:lemma	zle si (niečo) vysvetľovať
 14036735-n	slk:lemma	hnev
-01163941-s	slk:lemma	symfonický
+01163941-a	slk:lemma	symfonický
 09294285-n	slk:lemma	Grónske more
 05438956-n	slk:lemma	letálny gén
 10390427-n	slk:lemma	balič tovaru
@@ -7123,15 +7123,15 @@
 02742753-n	slk:lemma	šípka
 09048460-n	slk:lemma	Colony
 15210870-n	slk:lemma	marec
-01809245-s	slk:lemma	na nervy
+01809245-a	slk:lemma	na nervy
 00214951-v	slk:lemma	zmočiť
 05821102-n	slk:lemma	ospravedlnenie
 00630380-v	slk:lemma	zamyslieť sa
 13269683-n	slk:lemma	celková čiastka vyplatená bankou po zrušení životnej poistky
 01052372-n	slk:lemma	orientovanie
-02378496-s	slk:lemma	paralelný
+02378496-a	slk:lemma	paralelný
 14173484-n	slk:lemma	zápal hltana
-02318728-s	slk:lemma	čestný
+02318728-a	slk:lemma	čestný
 00033852-v	slk:lemma	zachmúriť sa
 10592397-n	slk:lemma	nakupujúci
 01398919-v	slk:lemma	biť
@@ -7146,15 +7146,15 @@
 00513761-n	slk:lemma	psina
 04859177-n	slk:lemma	dobrodružnosť
 00899049-n	slk:lemma	napodobovanie
-02512641-s	slk:lemma	tvrdý
+02512641-a	slk:lemma	tvrdý
 00205891-n	slk:lemma	pokuta
 01712704-v	slk:lemma	vystúpiť (na verejnosti)
-01144102-s	slk:lemma	akútny
+01144102-a	slk:lemma	akútny
 09795556-n	slk:lemma	vlastník renty
 08648781-n	slk:lemma	servisné miesto
 15089258-n	slk:lemma	vitamín
-01131454-s	slk:lemma	hrozný
-00608791-s	slk:lemma	extravagantný
+01131454-a	slk:lemma	hrozný
+00608791-a	slk:lemma	extravagantný
 00421691-v	slk:lemma	pominúť
 00107144-r	slk:lemma	ako zvyčajne
 02218173-v	slk:lemma	nazbierať
@@ -7170,8 +7170,8 @@
 01220152-n	slk:lemma	deprekácia
 08793310-n	slk:lemma	Acre, Akko, Akka, Accho
 00908351-v	slk:lemma	vychovať
-02064127-s	slk:lemma	identický
-02450512-s	slk:lemma	škodlivý
+02064127-a	slk:lemma	identický
+02450512-a	slk:lemma	škodlivý
 05032351-n	slk:lemma	odvaha
 12707781-n	slk:lemma	citrus
 03224893-n	slk:lemma	študentský domov
@@ -7204,7 +7204,7 @@
 10408552-n	slk:lemma	svätý patrón
 00664483-v	slk:lemma	overiť
 05083328-n	slk:lemma	priestorové rozloženie
-02180277-s	slk:lemma	pravý
+02180277-a	slk:lemma	pravý
 09070487-n	slk:lemma	DC
 00150671-r	slk:lemma	predovšetkým
 05857974-n	slk:lemma	arita funkcie
@@ -7213,7 +7213,7 @@
 00755745-v	slk:lemma	vyžiadať si
 04778630-n	slk:lemma	ľúbeznosť
 10587605-n	slk:lemma	pastier oviec
-02343110-s	slk:lemma	skvelý
+02343110-a	slk:lemma	skvelý
 00899847-v	slk:lemma	pozdravovať šalom
 07243837-n	slk:lemma	kázeň
 02121511-v	slk:lemma	pociťovať bolesť
@@ -7235,7 +7235,7 @@
 01518386-a	slk:lemma	armádny
 02132745-v	slk:lemma	civieť
 15274074-n	slk:lemma	prestávka
-00602563-s	slk:lemma	sporný
+00602563-a	slk:lemma	sporný
 00997794-v	slk:lemma	potvrdiť (príjem)
 07143624-n	slk:lemma	rozhovor
 04761212-n	slk:lemma	dôležitosť
@@ -7248,12 +7248,12 @@
 01489989-v	slk:lemma	nakladať
 06258680-n	slk:lemma	stránkovanie
 00096333-r	slk:lemma	nahor
-00975487-s	slk:lemma	štýlový
+00975487-a	slk:lemma	štýlový
 06437308-n	slk:lemma	Kniha prísloví
 14619225-n	slk:lemma	atóm
-01572974-s	slk:lemma	náhradkový
+01572974-a	slk:lemma	náhradkový
 06663785-n	slk:lemma	riziko nesie kupujúci
-02342608-s	slk:lemma	brilantný
+02342608-a	slk:lemma	brilantný
 05053215-n	slk:lemma	trvalosť
 15232406-n	slk:lemma	paleolit
 01860795-v	slk:lemma	pozastaviť
@@ -7265,7 +7265,7 @@
 00017531-v	slk:lemma	ísť spať
 04039848-n	slk:lemma	radar
 03624134-n	slk:lemma	nôž
-01486854-s	slk:lemma	spojený
+01486854-a	slk:lemma	spojený
 01015244-v	slk:lemma	vypovedať (svedčiť)
 00648224-v	slk:lemma	zrealizovať výskum
 13983147-n	slk:lemma	osvetlenie
@@ -7274,7 +7274,7 @@
 00276987-n	slk:lemma	zamorenie
 00312380-v	slk:lemma	zatmieť sa
 00755745-v	slk:lemma	požiadať
-00051373-s	slk:lemma	adekvátny
+00051373-a	slk:lemma	adekvátny
 01280014-v	slk:lemma	ohnúť sa
 07295629-n	slk:lemma	odmena
 15268239-n	slk:lemma	ukončenie
@@ -7284,9 +7284,9 @@
 03401129-n	slk:lemma	palivomer
 08642632-n	slk:lemma	blízkosť
 08436562-n	slk:lemma	stav
-00535293-s	slk:lemma	nejasný
+00535293-a	slk:lemma	nejasný
 05296253-n	slk:lemma	šľacha
-01856802-s	slk:lemma	zásadný
+01856802-a	slk:lemma	zásadný
 09202603-n	slk:lemma	Arafurské more
 02324045-n	slk:lemma	zajac
 02514825-n	slk:lemma	ryba kostnatá
@@ -7294,11 +7294,11 @@
 01770263-n	slk:lemma	rad Scorpionida
 01369758-v	slk:lemma	pokaziť
 11879054-n	slk:lemma	čínska kapusta
-00195684-s	slk:lemma	strašný
+00195684-a	slk:lemma	strašný
 01435380-v	slk:lemma	presúvať
 01860795-v	slk:lemma	zadržiavať
 13772468-n	slk:lemma	záťaž
-02291336-s	slk:lemma	pevný
+02291336-a	slk:lemma	pevný
 14977358-n	slk:lemma	vonkajšia omietka
 01010458-n	slk:lemma	postupnosť
 08518940-n	slk:lemma	živná oblasť
@@ -7312,14 +7312,14 @@
 00022686-v	slk:lemma	podnecovať
 06212839-n	slk:lemma	ideológia
 00544136-v	slk:lemma	piecť na ražni
-01728919-s	slk:lemma	predchádzajúci
+01728919-a	slk:lemma	predchádzajúci
 13304009-n	slk:lemma	predajná cena
 02224055-v	slk:lemma	zbaviť sa
 14859344-n	slk:lemma	priemyselné hnojivo
 00027167-n	slk:lemma	poloha
 02678839-v	slk:lemma	uchvátiť
-00818175-s	slk:lemma	krutý
-01111418-s	slk:lemma	veľkodušný
+00818175-a	slk:lemma	krutý
+01111418-a	slk:lemma	veľkodušný
 03149951-n	slk:lemma	zaujímavosť
 00795863-v	slk:lemma	zakazovať
 00508032-v	slk:lemma	vyznačkovať
@@ -7327,9 +7327,9 @@
 02731024-v	slk:lemma	zostávať
 07367385-n	slk:lemma	zlomenie
 02764779-n	slk:lemma	náprava
-00182225-s	slk:lemma	automatický
+00182225-a	slk:lemma	automatický
 01809064-v	slk:lemma	zraziť k zemi
-01151740-s	slk:lemma	tvrdý
+01151740-a	slk:lemma	tvrdý
 01041061-v	slk:lemma	stíchnuť
 10638922-n	slk:lemma	športovec
 00396642-n	slk:lemma	preplachovanie
@@ -7340,7 +7340,7 @@
 05984287-n	slk:lemma	vedomosti
 05204637-n	slk:lemma	slabosť
 12922600-n	slk:lemma	Croton
-01581305-s	slk:lemma	extra
+01581305-a	slk:lemma	extra
 01003249-v	slk:lemma	odfotografovať
 01732172-v	slk:lemma	predvádzať
 04070727-n	slk:lemma	chladiaci box
@@ -7372,8 +7372,8 @@
 00235208-n	slk:lemma	spiatočníctvo
 00896141-v	slk:lemma	potvrdzovať správnosť
 00067999-v	slk:lemma	vypotiť
-01216981-s	slk:lemma	hraný
-00013662-s	slk:lemma	reálny
+01216981-a	slk:lemma	hraný
+00013662-a	slk:lemma	reálny
 05710020-n	slk:lemma	vnímanie
 03055670-n	slk:lemma	koč
 12708293-n	slk:lemma	pomarančový strom
@@ -7393,7 +7393,7 @@
 09506830-n	slk:lemma	boh mora
 00773402-n	slk:lemma	znásilnenie
 00290308-r	slk:lemma	stručne
-00326608-s	slk:lemma	splašený
+00326608-a	slk:lemma	splašený
 02391803-v	slk:lemma	splnomocniť
 05807012-n	slk:lemma	zmysel
 05543917-n	slk:lemma	sutura coronalis
@@ -7410,7 +7410,7 @@
 08008017-n	slk:lemma	balík
 01552885-a	slk:lemma	máloktorý
 10323634-n	slk:lemma	majsterka
-00170847-s	slk:lemma	zaujímavý
+00170847-a	slk:lemma	zaujímavý
 10086383-n	slk:lemma	hráč v poli
 13250930-n	slk:lemma	majetok
 02415831-v	slk:lemma	zaneprázdňovať
@@ -7424,8 +7424,8 @@
 01582645-v	slk:lemma	linkovať
 00641820-n	slk:lemma	výskumný projekt
 03047553-n	slk:lemma	bariéra
-01649720-s	slk:lemma	čulý
-01263013-s	slk:lemma	krutý
+01649720-a	slk:lemma	čulý
+01263013-a	slk:lemma	krutý
 02483224-n	slk:lemma	rod Hylobates
 08991182-n	slk:lemma	ostrovy Samoa
 04033425-n	slk:lemma	kráľovná
@@ -7438,7 +7438,7 @@
 00081486-r	slk:lemma	každodenne
 00386915-n	slk:lemma	krájanie
 00010241-v	slk:lemma	konať reflexne
-00820975-s	slk:lemma	moderný
+00820975-a	slk:lemma	moderný
 09280573-n	slk:lemma	Fjord Clyde
 07504111-n	slk:lemma	zhnusenie
 09954879-n	slk:lemma	klamár
@@ -7452,9 +7452,9 @@
 00860292-v	slk:lemma	tlieskať
 04018399-n	slk:lemma	pub
 13416345-n	slk:lemma	cenina
-01153141-s	slk:lemma	česaný
+01153141-a	slk:lemma	česaný
 10624074-n	slk:lemma	syn
-01993408-s	slk:lemma	poriadny
+01993408-a	slk:lemma	poriadny
 06351613-n	slk:lemma	tlačené písmo
 00438065-n	slk:lemma	akrobatický kúsok
 10229498-n	slk:lemma	ochranca
@@ -7486,15 +7486,15 @@
 01557120-a	slk:lemma	väčšina
 05299178-n	slk:lemma	zmyslový orgán
 00321993-r	slk:lemma	raz-dva
-00937341-s	slk:lemma	nezasvätený
+00937341-a	slk:lemma	nezasvätený
 08642632-n	slk:lemma	prítomnosť
 03354903-n	slk:lemma	zástava
 08210254-n	slk:lemma	žandári
 06632807-n	slk:lemma	dobré popoludnie
 01556921-v	slk:lemma	oddeliť
 07303335-n	slk:lemma	hranica
-00562909-s	slk:lemma	nevhodný
-00363031-s	slk:lemma	radostný
+00562909-a	slk:lemma	nevhodný
+00363031-a	slk:lemma	radostný
 09234491-n	slk:lemma	rieka Cape Fear
 02171039-v	slk:lemma	dať pozor
 01010118-v	slk:lemma	vyhlásiť
@@ -7513,7 +7513,7 @@
 02470325-n	slk:lemma	ľudoop
 08509786-n	slk:lemma	pásmo
 02131279-v	slk:lemma	prezerať
-00890874-s	slk:lemma	rovný
+00890874-a	slk:lemma	rovný
 00889555-v	slk:lemma	zaručovať sa
 15281176-n	slk:lemma	výnosová miera
 00479176-v	slk:lemma	vraždiť
@@ -7521,7 +7521,7 @@
 07749582-n	slk:lemma	citrón
 06723452-n	slk:lemma	informácia
 03186285-n	slk:lemma	arabská plachetnica
-01865807-s	slk:lemma	obrábateľný
+01865807-a	slk:lemma	obrábateľný
 00611256-v	slk:lemma	spomínať si
 00969873-v	slk:lemma	rozniesť sa
 06725877-n	slk:lemma	deklarácia
@@ -7535,7 +7535,7 @@
 02945161-n	slk:lemma	kemping
 13098962-n	slk:lemma	floém
 01820302-v	slk:lemma	potešiť sa z
-01277426-s	slk:lemma	najdôležitejší
+01277426-a	slk:lemma	najdôležitejší
 01742726-v	slk:lemma	pestovať
 15115926-n	slk:lemma	doba testovania
 03980478-n	slk:lemma	kôň
@@ -7543,12 +7543,12 @@
 02009122-v	slk:lemma	stratiť sa
 07051728-n	slk:lemma	milostná pieseň
 13994148-n	slk:lemma	voľnosť
-00746451-s	slk:lemma	zamotaný
+00746451-a	slk:lemma	zamotaný
 02630871-v	slk:lemma	podobať sa
 00588797-a	slk:lemma	spokojný
 00510364-v	slk:lemma	urobiť machule
 04338359-n	slk:lemma	rad
-00279092-s	slk:lemma	žiariaci
+00279092-a	slk:lemma	žiariaci
 09081213-n	slk:lemma	ID
 01907258-v	slk:lemma	obrátiť sa
 04727214-n	slk:lemma	aura
@@ -7581,7 +7581,7 @@
 00219855-r	slk:lemma	úprimne
 07503260-n	slk:lemma	nechuť
 05277532-n	slk:lemma	os nasale
-01284212-s	slk:lemma	veľkolepý
+01284212-a	slk:lemma	veľkolepý
 00015953-r	slk:lemma	seriózne
 13342692-n	slk:lemma	obchodná špekulácia
 01156834-v	slk:lemma	stráviť (potravu)
@@ -7593,14 +7593,14 @@
 04675314-n	slk:lemma	dojem
 01950798-v	slk:lemma	transportovať
 09545324-n	slk:lemma	duch
-00325619-s	slk:lemma	obozretný
+00325619-a	slk:lemma	obozretný
 01881180-v	slk:lemma	motať sa
 01679980-v	slk:lemma	pokryť dekoráciou
 00051848-r	slk:lemma	rovno
 02223630-v	slk:lemma	preberať
 00048739-r	slk:lemma	mihom
 03483637-n	slk:lemma	parkovacia brzda
-01518694-s	slk:lemma	vojenský
+01518694-a	slk:lemma	vojenský
 01522276-v	slk:lemma	omotať si
 01842888-v	slk:lemma	precestovať
 00177483-r	slk:lemma	mierne
@@ -7615,7 +7615,7 @@
 00700708-v	slk:lemma	stanovovať
 02612762-v	slk:lemma	zúčastňovať sa
 03044671-n	slk:lemma	merací kábel
-01940472-s	slk:lemma	praktický
+01940472-a	slk:lemma	praktický
 00491292-r	slk:lemma	prospešne
 13977366-n	slk:lemma	incident
 00450700-n	slk:lemma	jazdecký šport
@@ -7640,16 +7640,16 @@
 01103614-n	slk:lemma	vydanie
 04955633-n	slk:lemma	matnosť
 02641035-v	slk:lemma	zastaviť sa
-01259123-s	slk:lemma	podobný človeku
+01259123-a	slk:lemma	podobný človeku
 09681351-n	slk:lemma	Žid
-01277426-s	slk:lemma	hlavný
+01277426-a	slk:lemma	hlavný
 09762509-n	slk:lemma	frajer
 01312371-v	slk:lemma	naberať
 00072012-v	slk:lemma	pomočovať sa
-02018141-s	slk:lemma	básnický
+02018141-a	slk:lemma	básnický
 13990064-n	slk:lemma	bezhriešnosť
 00138508-v	slk:lemma	otáčať
-01465214-s	slk:lemma	milostný
+01465214-a	slk:lemma	milostný
 09354780-n	slk:lemma	rieka Milk
 15168790-n	slk:lemma	brieždenie
 08622340-n	slk:lemma	tlakový bod
@@ -7668,7 +7668,7 @@
 01787955-v	slk:lemma	jedovať
 01741744-n	slk:lemma	čeľaď Boidae
 04907269-n	slk:lemma	zatvrdnutosť
-02104890-s	slk:lemma	citlivý na ožiarenie
+02104890-a	slk:lemma	citlivý na ožiarenie
 09696585-n	slk:lemma	Kanadčanka
 00700708-v	slk:lemma	určovať
 10051975-n	slk:lemma	utečenec
@@ -7691,14 +7691,14 @@
 02873244-n	slk:lemma	kufor auta
 00035758-v	slk:lemma	očistiť
 00875246-n	slk:lemma	určenie
-00010726-s	slk:lemma	dravý
+00010726-a	slk:lemma	dravý
 00040084-v	slk:lemma	pomádovať
 00466327-v	slk:lemma	porušiť súososť
 09999532-n	slk:lemma	povaľač
 02034300-v	slk:lemma	odrážať
 14553873-n	slk:lemma	neschopnosť videnia
 01827858-v	slk:lemma	kochať sa pohľadom
-00906099-s	slk:lemma	oslavný
+00906099-a	slk:lemma	oslavný
 02066304-v	slk:lemma	zísť (z cesty)
 01131515-n	slk:lemma	právna povinnosť
 01006056-v	slk:lemma	zapisovať
@@ -7716,18 +7716,18 @@
 08752021-n	slk:lemma	Dominikánska republika
 00219855-r	slk:lemma	srdečne
 07523180-n	slk:lemma	bojácnosť
-02577454-s	slk:lemma	hospodársky
+02577454-a	slk:lemma	hospodársky
 08080025-n	slk:lemma	futbalový tím
 13318147-n	slk:lemma	stále náklady
 02654216-a	slk:lemma	elektronický
 04655929-n	slk:lemma	priateľský pomer
-01254165-s	slk:lemma	studený ako ľad
+01254165-a	slk:lemma	studený ako ľad
 14197468-n	slk:lemma	pelióza
 13470392-n	slk:lemma	dvojčlenná operácia
 01603303-v	slk:lemma	pokovovať
 02304982-v	slk:lemma	kopiť
 00166146-a	slk:lemma	atraktívny
-00325619-s	slk:lemma	váhavý
+00325619-a	slk:lemma	váhavý
 00120202-n	slk:lemma	skok
 04469003-n	slk:lemma	trať električky
 13670156-n	slk:lemma	líbyjská menová jednotka
@@ -7737,8 +7737,8 @@
 00721437-v	slk:lemma	odhaliť
 01011725-v	slk:lemma	potvrdzovať
 09429752-n	slk:lemma	Seina
-01742912-s	slk:lemma	prudký
-01019283-s	slk:lemma	zdravotne postihnutý
+01742912-a	slk:lemma	prudký
+01019283-a	slk:lemma	zdravotne postihnutý
 09355850-n	slk:lemma	blato
 05128370-n	slk:lemma	paleta
 00803325-v	slk:lemma	povoliť
@@ -7753,7 +7753,7 @@
 01059900-n	slk:lemma	starostlivosť o zdravie
 02942577-n	slk:lemma	portrét
 00720565-n	slk:lemma	pozícia
-02515001-s	slk:lemma	zlý
+02515001-a	slk:lemma	zlý
 01072807-v	slk:lemma	ísť (za niečím)
 00388959-n	slk:lemma	rozvetvenie
 08896092-n	slk:lemma	Brunej
@@ -7762,12 +7762,12 @@
 09845999-n	slk:lemma	kozmetik
 13822735-n	slk:lemma	pomer medzi poistným a čiastkou vyplatenou za stratu
 00912048-v	slk:lemma	volať
-00335768-s	slk:lemma	konečný
+00335768-a	slk:lemma	konečný
 00070765-r	slk:lemma	bez mierenia
 01827064-v	slk:lemma	závidieť
 04522421-n	slk:lemma	vazokonstrikčný prostriedok
 00831074-v	slk:lemma	oboznamovať
-00813589-s	slk:lemma	pra-
+00813589-a	slk:lemma	pra-
 09334396-n	slk:lemma	súš
 10084043-n	slk:lemma	ženský potomok
 06432715-n	slk:lemma	Exodus
@@ -7784,7 +7784,7 @@
 01550949-v	slk:lemma	pretínať
 00583461-n	slk:lemma	špecializácia
 02475922-v	slk:lemma	vymenúvať
-02522938-s	slk:lemma	autonómny
+02522938-a	slk:lemma	autonómny
 14831812-n	slk:lemma	skákavý gén
 06545137-n	slk:lemma	zmluva
 09235469-n	slk:lemma	Polostrov Cape York
@@ -7812,10 +7812,10 @@
 13740168-n	slk:lemma	nula
 08049401-n	slk:lemma	združenie
 02482820-n	slk:lemma	čeľaď gibonovité
-00800597-s	slk:lemma	otupený
-01619475-s	slk:lemma	jednoznačný
+00800597-a	slk:lemma	otupený
+01619475-a	slk:lemma	jednoznačný
 14697485-n	slk:lemma	arenit
-00968010-s	slk:lemma	neobvyklý
+00968010-a	slk:lemma	neobvyklý
 06802571-n	slk:lemma	hlásateľ
 05690269-n	slk:lemma	úskalie
 10464178-n	slk:lemma	kazateľ
@@ -7839,13 +7839,13 @@
 02611630-v	slk:lemma	uviesť
 01664172-v	slk:lemma	uvariť si
 03784896-n	slk:lemma	maurský oblúk
-02515001-s	slk:lemma	darebácky
+02515001-a	slk:lemma	darebácky
 00242003-n	slk:lemma	získanie
 03273913-n	slk:lemma	elektrická chladnička
 01066163-n	slk:lemma	oneskorenie
 00451838-v	slk:lemma	napĺňať sa
 03481172-n	slk:lemma	kladivo
-01196775-s	slk:lemma	pomocný
+01196775-a	slk:lemma	pomocný
 01819147-v	slk:lemma	odradiť
 05200169-n	slk:lemma	nadanie
 00631737-v	slk:lemma	myslieť si
@@ -7871,7 +7871,7 @@
 08749650-n	slk:lemma	Svätý Martin
 03904183-n	slk:lemma	zebra
 04867130-n	slk:lemma	priamosť
-01789481-s	slk:lemma	uhrovitý
+01789481-a	slk:lemma	uhrovitý
 00285557-n	slk:lemma	chôdza
 02380571-v	slk:lemma	poslať na dôchodok
 02028366-v	slk:lemma	privaliť sa
@@ -7891,10 +7891,10 @@
 09631463-n	slk:lemma	nepríjemný človek
 01090335-v	slk:lemma	zápasiť
 01993549-v	slk:lemma	pohnúť
-01105042-s	slk:lemma	príznačný (pre danú oblasť)
+01105042-a	slk:lemma	príznačný (pre danú oblasť)
 04012260-n	slk:lemma	rekvizita
 03540267-n	slk:lemma	trikový tovar
-00877816-s	slk:lemma	alfa
+00877816-a	slk:lemma	alfa
 02742322-n	slk:lemma	šat
 00113113-n	slk:lemma	tlak
 10363913-n	slk:lemma	začiatočník
@@ -7909,10 +7909,10 @@
 05038593-n	slk:lemma	koncentrácia
 07495327-n	slk:lemma	trápenie
 14768854-n	slk:lemma	kriedový papier
-01532149-s	slk:lemma	opatrný
+01532149-a	slk:lemma	opatrný
 02327200-v	slk:lemma	vybavovať
 03574555-n	slk:lemma	inštitúcia
-01634027-s	slk:lemma	neformálny
+01634027-a	slk:lemma	neformálny
 00219012-n	slk:lemma	usmrtenie
 08459252-n	slk:lemma	reťazec (DNA)
 10527334-n	slk:lemma	revolucionár
@@ -7922,7 +7922,7 @@
 01780434-v	slk:lemma	hroziť sa
 10700517-n	slk:lemma	obyvateľ
 01214265-v	slk:lemma	vziať
-01114973-s	slk:lemma	srdečný
+01114973-a	slk:lemma	srdečný
 01202068-v	slk:lemma	piť zhlboka
 06100236-n	slk:lemma	mechanika
 00779248-n	slk:lemma	hra, pri ktorej sa vyhráva trikom
@@ -7955,7 +7955,7 @@
 13292613-n	slk:lemma	kompenzácia
 06589574-n	slk:lemma	publikácia
 01169194-a	slk:lemma	chirurgický
-01372948-s	slk:lemma	chápavý
+01372948-a	slk:lemma	chápavý
 07313636-n	slk:lemma	poranenie v dôsledku nehody
 01950798-v	slk:lemma	zaslať
 14313017-n	slk:lemma	exoftalmus
@@ -7969,7 +7969,7 @@
 01661818-n	slk:lemma	diapsid
 05515670-n	slk:lemma	vačok
 04411264-n	slk:lemma	stan
-01982186-s	slk:lemma	emblematický
+01982186-a	slk:lemma	emblematický
 07262579-n	slk:lemma	ukazovateľ
 03127718-a	slk:lemma	močový
 00242003-n	slk:lemma	opätovné prevzatie
@@ -7992,7 +7992,7 @@
 00016855-v	slk:lemma	odpadnúť
 05456257-n	slk:lemma	čapík sietnice
 02189168-v	slk:lemma	odpočuť
-00669942-s	slk:lemma	zatratený
+00669942-a	slk:lemma	zatratený
 11595312-n	slk:lemma	trieda Gymnospermae
 04138977-n	slk:lemma	rajnica
 05837850-n	slk:lemma	predstava
@@ -8008,15 +8008,15 @@
 01969216-v	slk:lemma	vystupovať
 02205896-n	slk:lemma	Hymenoptera
 15275315-n	slk:lemma	regeneračná doba
-01578856-s	slk:lemma	možný
-01628531-s	slk:lemma	sprostý
+01578856-a	slk:lemma	možný
+01628531-a	slk:lemma	sprostý
 02255081-v	slk:lemma	poukázať
 01073995-n	slk:lemma	rušenie
 02345048-v	slk:lemma	vyrabovať
 11567411-n	slk:lemma	rod dvojklíčnolistových
 10433164-n	slk:lemma	pilot lietadla
 00601043-v	slk:lemma	ponoriť sa (do niečoho)
-02384077-s	slk:lemma	štebotavý
+02384077-a	slk:lemma	štebotavý
 09358226-n	slk:lemma	mesiac
 04424218-n	slk:lemma	predmet
 09200649-n	slk:lemma	Apalachicola
@@ -8031,7 +8031,7 @@
 00356954-v	slk:lemma	vydúvať sa
 05929008-n	slk:lemma	postava
 00973077-n	slk:lemma	vedenie vojny
-01940472-s	slk:lemma	všedný
+01940472-a	slk:lemma	všedný
 05046471-n	slk:lemma	nastávajúci
 02467746-n	slk:lemma	vzdušný vak
 02162947-v	slk:lemma	jagať sa
@@ -8059,18 +8059,18 @@
 00588888-v	slk:lemma	rozumieť
 06691083-n	slk:lemma	pas
 01899708-v	slk:lemma	rýchlo sa hýbať
-01909421-s	slk:lemma	surový
+01909421-a	slk:lemma	surový
 09885145-n	slk:lemma	odberateľ
-00116245-s	slk:lemma	rozzúrený
+00116245-a	slk:lemma	rozzúrený
 05455912-n	slk:lemma	zraková bunka
-01865807-s	slk:lemma	obrobiteľný
+01865807-a	slk:lemma	obrobiteľný
 00250181-v	slk:lemma	nechať rásť
 00202284-n	slk:lemma	opozícia
 00075998-v	slk:lemma	presiľovať sa
 00196848-n	slk:lemma	obnovenie zmluvy
 09830400-n	slk:lemma	radový poslanec
 00034189-r	slk:lemma	krátko
-00440292-s	slk:lemma	ťažko chápajúci
+00440292-a	slk:lemma	ťažko chápajúci
 02163746-v	slk:lemma	vyzvedať
 15136723-n	slk:lemma	pracovný čas
 09306257-n	slk:lemma	Hwang Ho
@@ -8090,12 +8090,12 @@
 06357304-n	slk:lemma	binárny kód
 00489837-v	slk:lemma	kvantifikovať
 05833252-n	slk:lemma	balík
-02271052-s	slk:lemma	informovaný
+02271052-a	slk:lemma	informovaný
 01047338-n	slk:lemma	obnova
 00504660-n	slk:lemma	keno
 07451687-n	slk:lemma	pochovanie
 00202284-n	slk:lemma	odpor
-02024928-s	slk:lemma	luxusný
+02024928-a	slk:lemma	luxusný
 00098605-r	slk:lemma	smerujúci domov
 03049457-n	slk:lemma	komôrka
 02349212-v	slk:lemma	dávať dôveru
@@ -8106,7 +8106,7 @@
 00206130-n	slk:lemma	bojkot
 00185172-r	slk:lemma	obratne
 14336539-n	slk:lemma	zápal
-02448324-s	slk:lemma	jemný
+02448324-a	slk:lemma	jemný
 10709435-n	slk:lemma	poddaný
 02341816-v	slk:lemma	čalúniť
 00108604-v	slk:lemma	podávať
@@ -8128,8 +8128,8 @@
 03457902-n	slk:lemma	škôlka
 01459791-n	slk:lemma	ľudský plod
 00601043-v	slk:lemma	ponoriť
-01115920-s	slk:lemma	osvedčený
-01697878-s	slk:lemma	slnečný
+01115920-a	slk:lemma	osvedčený
+01697878-a	slk:lemma	slnečný
 10794014-n	slk:lemma	autorka
 02444147-a	slk:lemma	polárny
 01332730-v	slk:lemma	prikrývať
@@ -8158,12 +8158,12 @@
 01803936-v	slk:lemma	manipulovať ((s) niekým)
 05323228-n	slk:lemma	polkruhový kanálik
 06437531-n	slk:lemma	Kniha kazateľ
-00084795-s	slk:lemma	divý
+00084795-a	slk:lemma	divý
 04119360-n	slk:lemma	pohár
 13096317-n	slk:lemma	parenchým
 10340312-n	slk:lemma	muzikantka
 05016171-n	slk:lemma	horúčava
-01360962-s	slk:lemma	identický
+01360962-a	slk:lemma	identický
 02575723-v	slk:lemma	oklamať
 09492123-n	slk:lemma	mýtická bytosť
 15113229-n	slk:lemma	časové obdobie
@@ -8185,7 +8185,7 @@
 06527851-n	slk:lemma	kúpna zmluva
 01476483-v	slk:lemma	brániť
 00371264-v	slk:lemma	prikúriť
-00599005-s	slk:lemma	zvládnutý
+00599005-a	slk:lemma	zvládnutý
 08501565-n	slk:lemma	heliosféra
 10078806-n	slk:lemma	pestovateľ
 00907919-n	slk:lemma	nakrúcanie filmu
@@ -8201,29 +8201,29 @@
 00243918-n	slk:lemma	príprava jedla
 00022717-r	slk:lemma	poriadne
 02205272-v	slk:lemma	zobrať
-02060912-s	slk:lemma	samovražedný
-01912858-s	slk:lemma	prostoduchý
+02060912-a	slk:lemma	samovražedný
+01912858-a	slk:lemma	prostoduchý
 01976477-n	slk:lemma	kraby
 04690196-n	slk:lemma	ohyzdnosť
 00238778-n	slk:lemma	hypnogenéza
 06665108-n	slk:lemma	protokol
 00089408-r	slk:lemma	nanajvýš
-01001945-s	slk:lemma	oplodniteľný
+01001945-a	slk:lemma	oplodniteľný
 08122141-n	slk:lemma	federálny úrad
 00008055-v	slk:lemma	mihať
 01020005-v	slk:lemma	všimnúť si
 13942875-n	slk:lemma	okolnosť
 14396890-n	slk:lemma	rinopatia
-00830051-s	slk:lemma	učený
+00830051-a	slk:lemma	učený
 07575510-n	slk:lemma	čas na podávanie čaju
-01574925-s	slk:lemma	strašidelný
+01574925-a	slk:lemma	strašidelný
 13903738-n	slk:lemma	okraj
 07881800-n	slk:lemma	nápoj
 10227985-n	slk:lemma	právny expert
 13850304-n	slk:lemma	mierka
 00259643-n	slk:lemma	kompenzácia
 08943242-n	slk:lemma	Martinik
-01940472-s	slk:lemma	triezvy
+01940472-a	slk:lemma	triezvy
 11665372-n	slk:lemma	Angiospermae
 01156438-n	slk:lemma	mobilizácia
 01469263-v	slk:lemma	kopírovať
@@ -8232,10 +8232,10 @@
 10578162-n	slk:lemma	kňaz vychovaný v seminári
 13100677-n	slk:lemma	popínavá rastlina
 00386676-n	slk:lemma	schizma
-01014953-s	slk:lemma	stredný
+01014953-a	slk:lemma	stredný
 00947077-v	slk:lemma	determinovať
 02009433-v	slk:lemma	odísť
-00476663-s	slk:lemma	zúžený
+00476663-a	slk:lemma	zúžený
 02206619-v	slk:lemma	zabrať
 03448491-n	slk:lemma	hrdlo dórskeho stĺpa
 00007703-r	slk:lemma	čiastočne
@@ -8249,12 +8249,12 @@
 01779165-v	slk:lemma	vyľakať
 02440244-v	slk:lemma	viesť
 13998576-n	slk:lemma	obmedzenie
-01333118-s	slk:lemma	racionálny
+01333118-a	slk:lemma	racionálny
 08871007-n	slk:lemma	Anglicko
 00337078-n	slk:lemma	kľačanie
 02251743-v	slk:lemma	platiť
 09060768-n	slk:lemma	CA
-01419784-s	slk:lemma	prenesený
+01419784-a	slk:lemma	prenesený
 00040928-v	slk:lemma	namaľovať
 02139199-n	slk:lemma	netopier
 10335246-n	slk:lemma	trúchliaci
@@ -8288,7 +8288,7 @@
 01797347-v	slk:lemma	trápiť sa
 06664051-n	slk:lemma	výnos
 00416737-n	slk:lemma	najjednoduchšia cesta
-02578894-s	slk:lemma	rehoľný
+02578894-a	slk:lemma	rehoľný
 15165490-n	slk:lemma	poludnie
 15164957-n	slk:lemma	deň
 01171644-n	slk:lemma	šerm
@@ -8310,13 +8310,13 @@
 00900726-n	slk:lemma	nakreslenie
 09221070-n	slk:lemma	dvojhviezda
 04933544-n	slk:lemma	konštitúcia
-02363811-s	slk:lemma	imunizovaný
+02363811-a	slk:lemma	imunizovaný
 01860795-v	slk:lemma	pozastavovať sa
 01235137-n	slk:lemma	odveta
 08499840-n	slk:lemma	kolónia
 01686956-v	slk:lemma	vykresľovať
 01418667-v	slk:lemma	miešať
-01572974-s	slk:lemma	náhradný
+01572974-a	slk:lemma	náhradný
 06055692-n	slk:lemma	štúdium dávkovania liekov
 02290461-v	slk:lemma	ťažiť (z niečoho)
 01101329-n	slk:lemma	inzercia
@@ -8328,7 +8328,7 @@
 01845477-n	slk:lemma	zúbkozobce
 10009162-n	slk:lemma	zadržaná osoba
 11493827-n	slk:lemma	elektrické napätie
-00021110-s	slk:lemma	úslužný
+00021110-a	slk:lemma	úslužný
 08339454-n	slk:lemma	tajná služba
 14121058-n	slk:lemma	struma s exoftalmom
 01001294-v	slk:lemma	rozpísať sa
@@ -8338,7 +8338,7 @@
 09354780-n	slk:lemma	Milk
 03118661-a	slk:lemma	slovanský
 00781480-n	slk:lemma	krádež v obchode
-01037885-s	slk:lemma	medzinárodný
+01037885-a	slk:lemma	medzinárodný
 01579260-n	slk:lemma	havran
 02159955-n	slk:lemma	hmyz
 02853740-a	slk:lemma	patriaci k jašterom
@@ -8348,20 +8348,20 @@
 02672371-n	slk:lemma	nocľah
 02725286-v	slk:lemma	viaznuť
 07189130-n	slk:lemma	žiadosť
-02062133-s	slk:lemma	schopný predaja
+02062133-a	slk:lemma	schopný predaja
 00168075-r	slk:lemma	neúspešne
 03259505-n	slk:lemma	byt
 08722394-n	slk:lemma	Tierra del Fuego
 05806623-n	slk:lemma	porozumenie
 06275634-n	slk:lemma	pošta
 00243373-n	slk:lemma	uvedenie
-01593079-s	slk:lemma	ľudový
+01593079-a	slk:lemma	ľudový
 09145751-n	slk:lemma	Paris
 08301525-n	slk:lemma	Medzinárodná organizácia práce
 05249232-n	slk:lemma	miechový kanál
 00180611-r	slk:lemma	nezávisle
 12260021-n	slk:lemma	Fagales
-01840880-s	slk:lemma	slabomyseľný
+01840880-a	slk:lemma	slabomyseľný
 02669081-v	slk:lemma	prevyšovať
 08436759-n	slk:lemma	porast
 01104624-v	slk:lemma	švindľovať
@@ -8399,7 +8399,7 @@
 00841986-v	slk:lemma	nabonzovať (na niekoho)
 08121301-n	slk:lemma	protipožiarny útvar
 02031158-v	slk:lemma	deliť
-02119716-s	slk:lemma	skutočný
+02119716-a	slk:lemma	skutočný
 07970721-n	slk:lemma	rod
 13619592-n	slk:lemma	štvrtina galónu
 00434075-n	slk:lemma	akrobacia
@@ -8415,11 +8415,11 @@
 02374924-v	slk:lemma	odvážiť sa
 09691149-n	slk:lemma	Argentínčan
 00405360-n	slk:lemma	ohýbanie
-01462324-s	slk:lemma	milý
+01462324-a	slk:lemma	milý
 00779248-n	slk:lemma	klam
 01673891-v	slk:lemma	upliesť
 00021212-r	slk:lemma	niekedy
-00170847-s	slk:lemma	príťažlivý
+00170847-a	slk:lemma	príťažlivý
 10278128-n	slk:lemma	maminka
 05706954-n	slk:lemma	vypustenie
 03378915-n	slk:lemma	futbalové hrisko
@@ -8450,7 +8450,7 @@
 01042228-v	slk:lemma	povrávať si
 00341757-v	slk:lemma	ťahať sa
 02066304-v	slk:lemma	odbehnúť
-00341655-s	slk:lemma	čiste náhodný
+00341655-a	slk:lemma	čiste náhodný
 05838765-n	slk:lemma	trieda
 01808374-v	slk:lemma	pociťovať odpor
 01504480-v	slk:lemma	začať sa biť
@@ -8488,7 +8488,7 @@
 01900150-n	slk:lemma	zarastanie
 00138611-r	slk:lemma	akiste
 02269143-v	slk:lemma	ušetriť
-02384077-s	slk:lemma	rozvláčny
+02384077-a	slk:lemma	rozvláčny
 07505538-n	slk:lemma	nezáujem
 01846658-v	slk:lemma	plaviť
 15188359-n	slk:lemma	Veľkonočná nedeľa
@@ -8515,7 +8515,7 @@
 00103194-r	slk:lemma	spočiatku
 09916348-n	slk:lemma	hlavný výkonný úradník
 02090435-v	slk:lemma	zatočiť
-02230324-s	slk:lemma	pomocný
+02230324-a	slk:lemma	pomocný
 02923510-a	slk:lemma	moslimský
 10617193-n	slk:lemma	špeh
 04599396-n	slk:lemma	práca
@@ -8531,11 +8531,11 @@
 00314835-r	slk:lemma	otvorene
 02493030-v	slk:lemma	navštevovať
 01280488-v	slk:lemma	zohýbať sa
-00640660-s	slk:lemma	strohý
+00640660-a	slk:lemma	strohý
 13858392-n	slk:lemma	nezlučiteľnosť
 00510364-v	slk:lemma	pokryť škvrnami
 10128909-n	slk:lemma	gigant
-02502578-s	slk:lemma	bezvýznamný
+02502578-a	slk:lemma	bezvýznamný
 06551627-n	slk:lemma	výsadná listina
 08541841-n	slk:lemma	zemepisná oblasť
 13857486-n	slk:lemma	protirečivosť
@@ -8543,14 +8543,14 @@
 04371225-n	slk:lemma	kúpalisko
 09738708-n	slk:lemma	Američan
 02228698-v	slk:lemma	priradiť
-01392633-s	slk:lemma	malý
+01392633-a	slk:lemma	malý
 00679389-v	slk:lemma	vybrať si
 02603699-v	slk:lemma	existovať
 00127531-n	slk:lemma	naj
 04241573-n	slk:lemma	zberný krúžok
 06619065-n	slk:lemma	predstavenie
 05356442-n	slk:lemma	vedľajšia hlavová žila
-00414919-s	slk:lemma	skupinový
+00414919-a	slk:lemma	skupinový
 03323703-n	slk:lemma	spevňovač
 00368302-n	slk:lemma	obeh
 03339296-n	slk:lemma	fólia z plastu
@@ -8565,7 +8565,7 @@
 03173929-n	slk:lemma	dodávkové vozidlo
 03717131-n	slk:lemma	válov
 04263760-n	slk:lemma	zdroj svetla
-01394075-s	slk:lemma	malý
+01394075-a	slk:lemma	malý
 00608808-v	slk:lemma	premýšľať
 06544142-n	slk:lemma	posledná vôľa
 10084295-n	slk:lemma	dievčatko
@@ -8573,8 +8573,8 @@
 00063630-r	slk:lemma	dovedna
 01245325-v	slk:lemma	vystavovať účinkom pary
 09005273-n	slk:lemma	Kabarovsk
-00521329-s	slk:lemma	zrealizovaný
-00282675-s	slk:lemma	hodvábny
+00521329-a	slk:lemma	zrealizovaný
+00282675-a	slk:lemma	hodvábny
 04248607-n	slk:lemma	snímka
 01214265-v	slk:lemma	brať
 01239064-n	slk:lemma	zapojenie
@@ -8659,7 +8659,7 @@
 02764378-a	slk:lemma	paramilitaristický
 09133010-n	slk:lemma	Oregon
 00894738-v	slk:lemma	vyjasňovať
-00792202-s	slk:lemma	prevládajúci
+00792202-a	slk:lemma	prevládajúci
 00182213-n	slk:lemma	hlasovanie
 07800091-n	slk:lemma	potrava
 00889555-v	slk:lemma	zaručiť
@@ -8672,7 +8672,7 @@
 08612786-n	slk:lemma	kontúra
 13266515-n	slk:lemma	zahraničná pomoc
 02904223-a	slk:lemma	správcovský
-00049879-s	slk:lemma	dodatočný
+00049879-a	slk:lemma	dodatočný
 02525868-v	slk:lemma	prenáhliť sa
 14441825-n	slk:lemma	prevaha
 00426958-v	slk:lemma	stratiť sa
@@ -8697,10 +8697,10 @@
 11433140-n	slk:lemma	Brownov pohyb
 01188725-v	slk:lemma	vyžiadať si
 05289601-n	slk:lemma	kontraktibilný orgán
-01996875-s	slk:lemma	zodpovedný
+01996875-a	slk:lemma	zodpovedný
 01469263-v	slk:lemma	prikladať
 02349212-v	slk:lemma	odovzdávať
-00377224-s	slk:lemma	svetlofialový
+00377224-a	slk:lemma	svetlofialový
 02130524-v	slk:lemma	pozrieť sa
 10592152-n	slk:lemma	živnostník
 11524662-n	slk:lemma	povetrie
@@ -8739,7 +8739,7 @@
 07991364-n	slk:lemma	kongregácia
 05121418-n	slk:lemma	určitý počet
 09040998-n	slk:lemma	Antiochia
-01647983-s	slk:lemma	mladý
+01647983-a	slk:lemma	mladý
 05129565-n	slk:lemma	úsek
 09779790-n	slk:lemma	poľnohospodár
 02541302-a	slk:lemma	chorý
@@ -8772,7 +8772,7 @@
 02213690-v	slk:lemma	odoprieť
 00665886-v	slk:lemma	uistiť
 01782650-v	slk:lemma	znepokojovať (niekoho)
-00128733-s	slk:lemma	nový
+00128733-a	slk:lemma	nový
 08242799-n	slk:lemma	pracovná skupina
 00621734-v	slk:lemma	pliesť
 08395298-n	slk:lemma	jazdná polícia Spojených štátov
@@ -8800,12 +8800,12 @@
 10363149-n	slk:lemma	notár
 02208903-v	slk:lemma	vziať do (pre)nájmu
 10605253-n	slk:lemma	lyžiar
-01179241-s	slk:lemma	božský
+01179241-a	slk:lemma	božský
 00327824-n	slk:lemma	hojdanie
 01546111-v	slk:lemma	stáť
 09405515-n	slk:lemma	Rappahannock
 13326620-n	slk:lemma	výmenný kurz
-00535293-s	slk:lemma	nepochopiteľný
+00535293-a	slk:lemma	nepochopiteľný
 00715541-v	slk:lemma	vysvetľovať
 13135832-n	slk:lemma	semienko
 14180848-n	slk:lemma	sepsa
@@ -8817,7 +8817,7 @@
 10660333-n	slk:lemma	klamár
 00983824-v	slk:lemma	vydávať (zvuk)
 09223725-n	slk:lemma	prikrývka
-02408977-s	slk:lemma	miestny
+02408977-a	slk:lemma	miestny
 00630380-v	slk:lemma	rozvážiť
 04875935-n	slk:lemma	zlodejstvo
 08736517-n	slk:lemma	Pobrežie Slonoviny
@@ -8825,33 +8825,33 @@
 00058743-n	slk:lemma	útek
 00098605-r	slk:lemma	späť domov
 09761310-n	slk:lemma	hráč na akordeón
-01802774-s	slk:lemma	hrozný
+01802774-a	slk:lemma	hrozný
 15162388-n	slk:lemma	slávnosť
 00259096-r	slk:lemma	skôr
-00378782-s	slk:lemma	olivový
-01751609-s	slk:lemma	ako nový
+00378782-a	slk:lemma	olivový
+01751609-a	slk:lemma	ako nový
 05108947-n	slk:lemma	vzrast
 00836236-v	slk:lemma	reprezentovať
 09763668-n	slk:lemma	akustik
 02072159-v	slk:lemma	prebiehať
 03080238-a	slk:lemma	latinský
 08750334-n	slk:lemma	Kuba
-00135092-s	slk:lemma	náležitý
+00135092-a	slk:lemma	náležitý
 00055142-v	slk:lemma	rozmnožiť sa
 01165043-v	slk:lemma	užiť
 00250181-v	slk:lemma	dozrieť
 03309356-n	slk:lemma	páska na oko
-00403072-s	slk:lemma	meniaci sa
+00403072-a	slk:lemma	meniaci sa
 01033527-v	slk:lemma	pokryť (tematicky)
-00697691-s	slk:lemma	neurčiteľný
+00697691-a	slk:lemma	neurčiteľný
 04547592-n	slk:lemma	murovaný plot
 05729036-n	slk:lemma	rozdelenie
-00891970-s	slk:lemma	izotermický
+00891970-a	slk:lemma	izotermický
 15225249-n	slk:lemma	akademický rok
 09484664-n	slk:lemma	mýtická bytosť
 02136754-v	slk:lemma	odzrkadľovať
 08180639-n	slk:lemma	robotnícka trieda
-02570643-s	slk:lemma	nezmyselný
+02570643-a	slk:lemma	nezmyselný
 01846658-v	slk:lemma	priplaviť
 06664473-n	slk:lemma	maximálna rýchlosť
 02220461-v	slk:lemma	prepisovať (majetok)
@@ -8859,7 +8859,7 @@
 05816287-n	slk:lemma	údaj
 00226618-a	slk:lemma	priaznivý
 04546194-n	slk:lemma	vychádzková palica
-02412880-s	slk:lemma	kapilárový
+02412880-a	slk:lemma	kapilárový
 08152787-n	slk:lemma	klérus
 09977326-n	slk:lemma	hráč kriketu
 00847478-v	slk:lemma	poškodzovať povesť
@@ -8878,7 +8878,7 @@
 05018542-n	slk:lemma	iluminácia
 01614925-n	slk:lemma	Haliaeetus leucocephalus
 00455919-v	slk:lemma	dopĺňať sa
-01439155-s	slk:lemma	nudný
+01439155-a	slk:lemma	nudný
 06773434-n	slk:lemma	zmluva
 10577284-n	slk:lemma	osoba, ktorá predáva majetok alebo tovar
 01247807-n	slk:lemma	prepustenie z otroctva
@@ -8921,20 +8921,20 @@
 07051185-n	slk:lemma	blues
 14993378-n	slk:lemma	otravný plyn
 03570372-n	slk:lemma	infraštruktúra
-00803275-s	slk:lemma	akútny
+00803275-a	slk:lemma	akútny
 00389308-n	slk:lemma	dávkovanie
 00844254-n	slk:lemma	pohlavný život
 02857099-a	slk:lemma	básnický
 01907258-v	slk:lemma	otáčať sa
 13300411-n	slk:lemma	nezaplatenie
-00547317-s	slk:lemma	jadrný
+00547317-a	slk:lemma	jadrný
 00223250-v	slk:lemma	doložiť
-02114613-s	slk:lemma	zhnisaný
+02114613-a	slk:lemma	zhnisaný
 07513508-n	slk:lemma	znepokojenie
 04906471-n	slk:lemma	poslušnosť
 02333909-n	slk:lemma	krysa čierna
 00467719-n	slk:lemma	hra na špecifickej hracej ploche
-02415294-s	slk:lemma	slabunký
+02415294-a	slk:lemma	slabunký
 04582625-n	slk:lemma	dvierka
 03671272-n	slk:lemma	železničná trať
 01224031-n	slk:lemma	nezdvorilosť
@@ -8952,9 +8952,9 @@
 04348184-n	slk:lemma	ponorka
 01048059-n	slk:lemma	obnovenie
 09417560-n	slk:lemma	Ruhr
-00389310-s	slk:lemma	šedý
+00389310-a	slk:lemma	šedý
 02629390-v	slk:lemma	predchádzať
-00974159-s	slk:lemma	starodávny
+00974159-a	slk:lemma	starodávny
 13530408-n	slk:lemma	oxidácia
 09286630-n	slk:lemma	rieka Ganga
 06781581-n	slk:lemma	slovná hračka
@@ -8980,19 +8980,19 @@
 00859758-v	slk:lemma	baviť
 13711663-n	slk:lemma	milibar
 14081375-n	slk:lemma	záchvat
-01728919-s	slk:lemma	bývalý
+01728919-a	slk:lemma	bývalý
 02611630-v	slk:lemma	stanoviť
 01280014-v	slk:lemma	krútiť sa
 04782116-n	slk:lemma	des
 01212230-v	slk:lemma	prejsť
-02465350-s	slk:lemma	zodpovedný
+02465350-a	slk:lemma	zodpovedný
 01889610-v	slk:lemma	potriasť
 00598753-v	slk:lemma	dobiehať
 06617413-n	slk:lemma	pornografický film
-02074929-s	slk:lemma	bláznivý
+02074929-a	slk:lemma	bláznivý
 13263779-n	slk:lemma	dedičstvo
-02331857-s	slk:lemma	prosperujúci
-01881478-s	slk:lemma	chybný
+02331857-a	slk:lemma	prosperujúci
+01881478-a	slk:lemma	chybný
 13280658-n	slk:lemma	obálka s výplatou
 13775706-n	slk:lemma	potopa
 01435380-v	slk:lemma	doručiť
@@ -9016,9 +9016,9 @@
 06640533-n	slk:lemma	index Dow Jones
 01771535-v	slk:lemma	pocítiť
 00751525-a	slk:lemma	dôstojný
-00627004-s	slk:lemma	hmatateľný
+00627004-a	slk:lemma	hmatateľný
 08746475-n	slk:lemma	Veracruz
-01366062-s	slk:lemma	smútočný
+01366062-a	slk:lemma	smútočný
 07507098-n	slk:lemma	rozpaky
 02304982-v	slk:lemma	nahromadiť
 07548978-n	slk:lemma	nevôľa
@@ -9042,15 +9042,15 @@
 09827683-n	slk:lemma	bábätko
 01111816-v	slk:lemma	skórovať
 06583354-n	slk:lemma	výnimočný postup
-00018850-s	slk:lemma	sporný
+00018850-a	slk:lemma	sporný
 00643250-a	slk:lemma	tvorivý
 02472987-n	slk:lemma	ľudská rasa
 13304665-n	slk:lemma	najnižšie podanie
 07123552-n	slk:lemma	jačanie
 06408651-n	slk:lemma	štúdia
 00270215-v	slk:lemma	uviesť do vojenskej pohotovosti
-00378892-s	slk:lemma	pomarančový
-00123485-s	slk:lemma	nasledujúci
+00378892-a	slk:lemma	pomarančový
+00123485-a	slk:lemma	nasledujúci
 10123711-n	slk:lemma	starý blázon
 01001294-v	slk:lemma	oznámiť
 00897241-v	slk:lemma	zdraviť sa
@@ -9087,7 +9087,7 @@
 04646548-n	slk:lemma	vážnosť
 02711987-v	slk:lemma	opierať sa o
 08253815-n	slk:lemma	večera
-00032733-s	slk:lemma	rýchly
+00032733-a	slk:lemma	rýchly
 00060833-v	slk:lemma	kastrovať
 06413889-n	slk:lemma	knižočka
 00921300-v	slk:lemma	naznačiť
@@ -9099,26 +9099,26 @@
 13566928-n	slk:lemma	termická emisia
 03068181-n	slk:lemma	golier
 07702642-n	slk:lemma	raňajky
-01385773-s	slk:lemma	mamutí
+01385773-a	slk:lemma	mamutí
 02274482-v	slk:lemma	prisvojiť si
 11481334-n	slk:lemma	trajektória
-01664015-s	slk:lemma	radostný
+01664015-a	slk:lemma	radostný
 15229677-n	slk:lemma	ranný spev
 00586183-a	slk:lemma	ničivý
 04589593-n	slk:lemma	rám okna
 00596132-v	slk:lemma	vedieť
 00592535-n	slk:lemma	funkcia stavbyvedúceho
 09457851-n	slk:lemma	rieka Tiber
-01690606-s	slk:lemma	tradičný
+01690606-a	slk:lemma	tradičný
 00227165-v	slk:lemma	zintenzívniť
 05456456-n	slk:lemma	tyčinka
 02746365-n	slk:lemma	delostrelectvo
 06641524-n	slk:lemma	index cien výrobcov
 00197772-n	slk:lemma	náhrada
-00464068-s	slk:lemma	obklopený pevninou
+00464068-a	slk:lemma	obklopený pevninou
 01856211-v	slk:lemma	odsťahovať sa
 01176219-n	slk:lemma	porazenie
-00668208-s	slk:lemma	najnovší
+00668208-a	slk:lemma	najnovší
 04105893-n	slk:lemma	izba
 02734192-a	slk:lemma	genetický
 00074095-r	slk:lemma	pred
@@ -9147,7 +9147,7 @@
 00896141-v	slk:lemma	odôvodňovať
 02104523-n	slk:lemma	ovčiak
 00213186-n	slk:lemma	odovzdanie
-01944088-s	slk:lemma	rozumný
+01944088-a	slk:lemma	rozumný
 02669789-v	slk:lemma	postačiť
 00163233-n	slk:lemma	vôľa
 00834259-v	slk:lemma	klamať
@@ -9183,11 +9183,11 @@
 02823750-n	slk:lemma	pohár na pivo
 00876332-v	slk:lemma	predložiť závet
 00208210-v	slk:lemma	kaziť sa
-00793592-s	slk:lemma	druhoradý
-01893510-s	slk:lemma	mierny
+00793592-a	slk:lemma	druhoradý
+01893510-a	slk:lemma	mierny
 01740892-a	slk:lemma	pokojný
 09779623-n	slk:lemma	poľnohospodársky pracovník
-02436025-s	slk:lemma	nemožný
+02436025-a	slk:lemma	nemožný
 04270891-n	slk:lemma	oštep
 13950812-n	slk:lemma	kňazský stav
 10403876-n	slk:lemma	cestujúci
@@ -9209,7 +9209,7 @@
 01101913-v	slk:lemma	porážať
 07238455-n	slk:lemma	význam
 01848465-v	slk:lemma	podliehať
-00049016-s	slk:lemma	doplňujúci
+00049016-a	slk:lemma	doplňujúci
 02855390-n	slk:lemma	plameňomet
 01556346-v	slk:lemma	odtrhávať
 09815455-n	slk:lemma	cesionár
@@ -9231,7 +9231,7 @@
 00123500-r	slk:lemma	úsporne
 01809064-v	slk:lemma	vyraziť dych
 10269458-n	slk:lemma	nocľažník
-00708738-s	slk:lemma	mrvivý
+00708738-a	slk:lemma	mrvivý
 00765649-v	slk:lemma	nabádať
 00952524-v	slk:lemma	hovoriť
 13331198-n	slk:lemma	obnos
@@ -9246,7 +9246,7 @@
 02698319-v	slk:lemma	definovať
 00248765-r	slk:lemma	najmä
 04565233-n	slk:lemma	okraj cesty
-00900071-s	slk:lemma	tajuplný
+00900071-a	slk:lemma	tajuplný
 00151521-r	slk:lemma	ozlomkrky
 01981699-a	slk:lemma	reprezentujúci
 01523908-n	slk:lemma	rad Passeriformes
@@ -9280,7 +9280,7 @@
 13246475-n	slk:lemma	majetok, nehnuteľný
 01835496-v	slk:lemma	prechádzať
 13409363-n	slk:lemma	schodok
-00440579-s	slk:lemma	hlúpy
+00440579-a	slk:lemma	hlúpy
 06070929-n	slk:lemma	ekológia
 08737376-n	slk:lemma	Guatemala City
 01088923-v	slk:lemma	umiestňovať
@@ -9310,7 +9310,7 @@
 05695554-n	slk:lemma	ekvivalent
 01794340-a	slk:lemma	farebný
 14753414-n	slk:lemma	prednizón
-01230616-s	slk:lemma	stratený
+01230616-a	slk:lemma	stratený
 15004501-n	slk:lemma	zbytok
 00076196-n	slk:lemma	chyba
 06547059-n	slk:lemma	splnomocnenie
@@ -9318,8 +9318,8 @@
 00282050-n	slk:lemma	povýšenie
 10100761-n	slk:lemma	trúba
 05281189-n	slk:lemma	sternum
-02083908-s	slk:lemma	nezáživný
-01311605-s	slk:lemma	kolonizovaný
+02083908-a	slk:lemma	nezáživný
+01311605-a	slk:lemma	kolonizovaný
 01214863-n	slk:lemma	ochrana
 13507336-n	slk:lemma	štádium profázy
 01578254-v	slk:lemma	ponárať
@@ -9335,14 +9335,14 @@
 10612210-n	slk:lemma	neporiadník
 02207345-n	slk:lemma	včelia kráľovná
 00795863-v	slk:lemma	zakázať
-00989647-s	slk:lemma	vychudnutý
+00989647-a	slk:lemma	vychudnutý
 01245318-n	slk:lemma	holokaust
 06312966-n	slk:lemma	zložka
 02730326-v	slk:lemma	naraziť (na niečo)
 00171135-r	slk:lemma	z ničoho nič
 07298154-n	slk:lemma	prekvapenie
 00334210-r	slk:lemma	zanedbane
-00799401-s	slk:lemma	zdrogovaný
+00799401-a	slk:lemma	zdrogovaný
 00035718-r	slk:lemma	priemerne
 00838367-n	slk:lemma	jedenie
 09957013-n	slk:lemma	pacifista
@@ -9356,10 +9356,10 @@
 14428160-n	slk:lemma	kvalita
 08497294-n	slk:lemma	krajina
 12618942-n	slk:lemma	rad Rosales
-02570643-s	slk:lemma	smiešny
+02570643-a	slk:lemma	smiešny
 00319886-v	slk:lemma	upiecť
 01001294-v	slk:lemma	vykladať
-00595299-s	slk:lemma	nepretržitý
+00595299-a	slk:lemma	nepretržitý
 13400798-n	slk:lemma	daň
 01501960-v	slk:lemma	položiť
 01054335-n	slk:lemma	držba
@@ -9371,7 +9371,7 @@
 01486312-v	slk:lemma	uzavrieť (do niečoho)
 01815628-v	slk:lemma	potešiť
 01914521-a	slk:lemma	kvalitatívny
-02370625-s	slk:lemma	nepoznaný
+02370625-a	slk:lemma	nepoznaný
 01873784-v	slk:lemma	presadzovať
 10043643-n	slk:lemma	ekonóm
 00870912-n	slk:lemma	delenie
@@ -9411,14 +9411,14 @@
 02387346-n	slk:lemma	shirský kôň
 00260622-n	slk:lemma	náprava
 03530910-n	slk:lemma	kapota
-01483677-s	slk:lemma	chlapský
+01483677-a	slk:lemma	chlapský
 01127795-v	slk:lemma	chrániť
 00177289-r	slk:lemma	silne
 01126360-v	slk:lemma	zaberať územie
 05710860-n	slk:lemma	vizuálne vnímanie
 09543353-n	slk:lemma	satan
 05927813-n	slk:lemma	osnova
-00936523-s	slk:lemma	skúsený
+00936523-a	slk:lemma	skúsený
 00509846-n	slk:lemma	veselie
 05808794-n	slk:lemma	čítanie
 05644527-n	slk:lemma	hospodárnosť
@@ -9437,7 +9437,7 @@
 09952539-n	slk:lemma	dirigent
 02970534-n	slk:lemma	taška na prenášanie dieťaťa
 00596484-v	slk:lemma	byť informovaný
-00339742-s	slk:lemma	sebavedomý
+00339742-a	slk:lemma	sebavedomý
 13509196-n	slk:lemma	úbytok
 05325606-n	slk:lemma	predsieňové okno
 07519253-n	slk:lemma	strach
@@ -9445,8 +9445,8 @@
 00024257-r	slk:lemma	vôbec
 04953954-n	slk:lemma	jas
 00230058-r	slk:lemma	navonok
-02161982-s	slk:lemma	závažný
-02281182-s	slk:lemma	plný chuti
+02161982-a	slk:lemma	závažný
+02281182-a	slk:lemma	plný chuti
 05577410-n	slk:lemma	prst na nohe
 01432601-v	slk:lemma	nosiť
 02131279-v	slk:lemma	vyšetriť
@@ -9468,7 +9468,7 @@
 05638063-n	slk:lemma	zručnosť
 00042614-r	slk:lemma	smutne
 00490035-a	slk:lemma	výnimočný
-01335458-s	slk:lemma	učenlivý
+01335458-a	slk:lemma	učenlivý
 03259505-n	slk:lemma	dom
 01059564-v	slk:lemma	nevšímať si
 05646218-n	slk:lemma	hlúposť
@@ -9483,7 +9483,7 @@
 05554804-n	slk:lemma	dvorec prsnej bradavky
 03282060-n	slk:lemma	hrádza
 01997910-a	slk:lemma	nezodpovedný
-02081114-s	slk:lemma	fajn
+02081114-a	slk:lemma	fajn
 00359862-a	slk:lemma	štedrý
 02542795-v	slk:lemma	poslúchnuť
 07553301-n	slk:lemma	súcit
@@ -9492,7 +9492,7 @@
 00075021-v	slk:lemma	vyčerpať sa
 13619592-n	slk:lemma	quart
 00230746-v	slk:lemma	narastať
-01780740-s	slk:lemma	psychický
+01780740-a	slk:lemma	psychický
 08008017-n	slk:lemma	balíček
 02728440-n	slk:lemma	šaty
 02037272-a	slk:lemma	nepoctivý
@@ -9500,7 +9500,7 @@
 03225988-n	slk:lemma	dvojlôžko
 09439879-n	slk:lemma	Solent
 13957601-n	slk:lemma	existencia
-00699521-s	slk:lemma	prvotný
+00699521-a	slk:lemma	prvotný
 00008997-r	slk:lemma	totálne
 00039318-r	slk:lemma	nepochybne
 06362953-n	slk:lemma	písomné dielo
@@ -9513,7 +9513,7 @@
 01480336-n	slk:lemma	trieda drsnokožce
 05240850-n	slk:lemma	neuroepitel
 13563522-n	slk:lemma	zásobovanie
-01870636-s	slk:lemma	neprofesionálny
+01870636-a	slk:lemma	neprofesionálny
 02691156-n	slk:lemma	letún
 00713167-v	slk:lemma	uvádzať do súvislosti
 02450256-v	slk:lemma	zúčastniť sa
@@ -9524,7 +9524,7 @@
 01741943-n	slk:lemma	veľhad
 08327816-n	slk:lemma	porada
 09637684-n	slk:lemma	neger
-00330728-s	slk:lemma	centrický
+00330728-a	slk:lemma	centrický
 02935891-n	slk:lemma	kantína
 00823532-n	slk:lemma	defenzíva
 10134001-n	slk:lemma	brankár
@@ -9534,13 +9534,13 @@
 01568630-v	slk:lemma	zadržať
 00797430-v	slk:lemma	odmietnuť
 00658052-v	slk:lemma	odhadnúť
-01935935-s	slk:lemma	fiktívny
+01935935-a	slk:lemma	fiktívny
 11804604-n	slk:lemma	Caryophyllaceae
 05979595-n	slk:lemma	démonizmus
 01703454-v	slk:lemma	prerozprávať
 00184117-v	slk:lemma	vmiešať
 13670281-n	slk:lemma	líbyjský dinár
-01591394-s	slk:lemma	kráľovský
+01591394-a	slk:lemma	kráľovský
 00994623-n	slk:lemma	delostreľba
 00706243-v	slk:lemma	navrhnúť
 09086995-n	slk:lemma	Des Moines
@@ -9571,7 +9571,7 @@
 05646218-n	slk:lemma	sprostosť
 07247071-n	slk:lemma	publicita
 00502757-v	slk:lemma	hnojiť
-00650900-s	slk:lemma	kritický
+00650900-a	slk:lemma	kritický
 05598147-n	slk:lemma	nos
 03084204-n	slk:lemma	príslušenstvo počítača
 00359862-a	slk:lemma	nemilý
@@ -9580,7 +9580,7 @@
 01787955-v	slk:lemma	iritovať
 00479275-r	slk:lemma	zajtra
 08735705-n	slk:lemma	Stredná Amerika
-01977488-s	slk:lemma	všímavý
+01977488-a	slk:lemma	všímavý
 00157412-r	slk:lemma	občas
 04081844-n	slk:lemma	prekážka
 05328115-n	slk:lemma	mazová žľaza
@@ -9596,7 +9596,7 @@
 00988028-v	slk:lemma	popísať
 03646296-n	slk:lemma	točovka
 08410688-n	slk:lemma	internátna škola
-02406370-s	slk:lemma	nervózny
+02406370-a	slk:lemma	nervózny
 08356375-n	slk:lemma	legislatívna zložka
 03093379-a	slk:lemma	olympský
 00252894-n	slk:lemma	očista
@@ -9606,15 +9606,15 @@
 00282050-n	slk:lemma	pokrok
 04477091-n	slk:lemma	profil pneumatiky
 11902389-n	slk:lemma	Papaver somniferum
-02132224-s	slk:lemma	nemravný
+02132224-a	slk:lemma	nemravný
 09916348-n	slk:lemma	výkonný predseda akciovej spoločnosti
 00426958-v	slk:lemma	miznúť
 01948077-v	slk:lemma	surfovať
 02389128-n	slk:lemma	palomino
-00516887-s	slk:lemma	pomerný
+00516887-a	slk:lemma	pomerný
 00526948-n	slk:lemma	dlažba
 03882611-n	slk:lemma	vypĺňanie panelom
-01625063-s	slk:lemma	oplzlý
+01625063-a	slk:lemma	oplzlý
 00115859-r	slk:lemma	politicky
 05328232-n	slk:lemma	tuková žľaza
 09036880-n	slk:lemma	Krung Thep
@@ -9634,7 +9634,7 @@
 03592773-n	slk:lemma	stĺpik karosérie
 09799213-n	slk:lemma	apoštol
 04358381-n	slk:lemma	plocha
-02199523-s	slk:lemma	biliónový
+02199523-a	slk:lemma	biliónový
 00192659-v	slk:lemma	dať trochu života
 01759326-v	slk:lemma	podnietiť
 09791530-n	slk:lemma	finančný analytik
@@ -9646,7 +9646,7 @@
 14994328-n	slk:lemma	polymér
 13252973-n	slk:lemma	prevedené vlastníctvo
 00609683-v	slk:lemma	uchovať v pamäti
-01376355-s	slk:lemma	legendárny
+01376355-a	slk:lemma	legendárny
 04308915-n	slk:lemma	parná komora
 05275905-n	slk:lemma	dolná čeľusť
 01116585-v	slk:lemma	odolať
@@ -9668,14 +9668,14 @@
 00796976-v	slk:lemma	vyjadrovať pohŕdanie
 00604424-n	slk:lemma	predsedníctvo
 00173761-n	slk:lemma	prostriedok
-02067491-s	slk:lemma	rozmanitý
+02067491-a	slk:lemma	rozmanitý
 05584486-n	slk:lemma	necht na nohe
 00014201-v	slk:lemma	triasť sa
 00201058-n	slk:lemma	prechod
 07072698-n	slk:lemma	rétorika
 08742205-n	slk:lemma	Acapulco de Juarez
 11409059-n	slk:lemma	chemický jav
-02033450-s	slk:lemma	ľavý krajný
+02033450-a	slk:lemma	ľavý krajný
 09679925-n	slk:lemma	katolík
 01058574-v	slk:lemma	poznamenávať
 14329578-n	slk:lemma	bolesť semenníkov
@@ -9689,7 +9689,7 @@
 05304252-n	slk:lemma	dutina
 15058544-n	slk:lemma	cholesterín
 00269140-v	slk:lemma	ochromovať
-02312450-s	slk:lemma	krivý
+02312450-a	slk:lemma	krivý
 05951072-n	slk:lemma	predtucha
 05154908-n	slk:lemma	podpora
 02171453-n	slk:lemma	skarabeusovitý chrobák
@@ -9702,7 +9702,7 @@
 02763740-v	slk:lemma	svietiť
 01134781-v	slk:lemma	streliť
 08993288-n	slk:lemma	Saudská Arábia
-00850648-s	slk:lemma	uhladený
+00850648-a	slk:lemma	uhladený
 06057539-n	slk:lemma	všeobecná anatómia
 02422026-v	slk:lemma	oslobodiť
 04893787-n	slk:lemma	sporivosť
@@ -9712,10 +9712,10 @@
 00069901-r	slk:lemma	hlasno
 08948155-n	slk:lemma	Guiana
 03015254-n	slk:lemma	zásuvková skriňa
-00993885-s	slk:lemma	smrtiaci
+00993885-a	slk:lemma	smrtiaci
 02698145-a	slk:lemma	klasický
 05846355-n	slk:lemma	reštrikcia
-01168166-s	slk:lemma	zneschopňujúci
+01168166-a	slk:lemma	zneschopňujúci
 00031515-r	slk:lemma	už nie
 11953339-n	slk:lemma	čakanka
 15191233-n	slk:lemma	Halloween
@@ -9723,7 +9723,7 @@
 07355491-n	slk:lemma	smrť
 07176243-n	slk:lemma	povolenie
 00836277-a	slk:lemma	únavný
-01764351-s	slk:lemma	obmedzujúci
+01764351-a	slk:lemma	obmedzujúci
 13400334-n	slk:lemma	hypotekárny úver
 11876803-n	slk:lemma	brokolica
 01655505-v	slk:lemma	zriaďovať
@@ -9736,22 +9736,22 @@
 01973759-v	slk:lemma	nadvihovať
 05979909-n	slk:lemma	skepsa
 05013642-n	slk:lemma	kondenzačná teplota
-00919919-s	slk:lemma	túžiaci
-01500247-s	slk:lemma	mechanický
+00919919-a	slk:lemma	túžiaci
+01500247-a	slk:lemma	mechanický
 00024814-v	slk:lemma	ochladzovať sa
 07584593-n	slk:lemma	polievka
 11416988-n	slk:lemma	odpoveď
 07526505-n	slk:lemma	dôvera
 04944048-n	slk:lemma	sklon
-00807399-s	slk:lemma	jednotvárny
+00807399-a	slk:lemma	jednotvárny
 05682950-n	slk:lemma	zainteresovanie
 06782680-n	slk:lemma	predpoklad
 06453324-n	slk:lemma	spisy
-01246148-s	slk:lemma	protismerný
+01246148-a	slk:lemma	protismerný
 00266812-r	slk:lemma	isto
 00007884-r	slk:lemma	napoly
 06439924-n	slk:lemma	Kniha proroka Jonáša
-02576223-s	slk:lemma	dubový
+02576223-a	slk:lemma	dubový
 09281777-n	slk:lemma	plavidlo
 05736149-n	slk:lemma	evaluácia
 09886220-n	slk:lemma	ničomník
@@ -9770,7 +9770,7 @@
 08946187-n	slk:lemma	Ghana
 00775156-v	slk:lemma	ruvať sa
 00752954-n	slk:lemma	lesť
-01771839-s	slk:lemma	hustý
+01771839-a	slk:lemma	hustý
 00364260-n	slk:lemma	vzostup
 06471069-n	slk:lemma	dekrét
 10453533-n	slk:lemma	pápež
@@ -9801,7 +9801,7 @@
 13839662-n	slk:lemma	vzťah právnika a klienta
 02083806-v	slk:lemma	prebudiť sa
 03094503-n	slk:lemma	kontajner
-00833018-s	slk:lemma	funkčný
+00833018-a	slk:lemma	funkčný
 06100555-n	slk:lemma	nukleárna fyzika
 04408330-n	slk:lemma	Šalamúnov chrám
 02460619-v	slk:lemma	prenajať si
@@ -9834,9 +9834,9 @@
 01718158-a	slk:lemma	paralelný
 13260936-n	slk:lemma	hrubý odbyt
 05579436-n	slk:lemma	biceps
-01645678-s	slk:lemma	sivovlasý
+01645678-a	slk:lemma	sivovlasý
 02298632-v	slk:lemma	ponúkať cenu
-00473243-s	slk:lemma	zápalný
+00473243-a	slk:lemma	zápalný
 01568630-v	slk:lemma	premôcť
 00021265-n	slk:lemma	krmivo
 00941166-v	slk:lemma	burcovať
@@ -9853,7 +9853,7 @@
 02555434-v	slk:lemma	umožniť
 04692157-n	slk:lemma	kaz
 03974215-n	slk:lemma	špička
-02465115-s	slk:lemma	autentický
+02465115-a	slk:lemma	autentický
 02570267-v	slk:lemma	zhýčkať
 00227165-v	slk:lemma	stupňovať
 07673397-n	slk:lemma	rastlinný olej
@@ -9864,23 +9864,23 @@
 09936620-n	slk:lemma	zberateľ
 11427842-n	slk:lemma	smola
 06471737-n	slk:lemma	listina
-00168910-s	slk:lemma	pôvabný
+00168910-a	slk:lemma	pôvabný
 14892510-n	slk:lemma	torkretovaný betón
 13983515-n	slk:lemma	temnota
 00174987-r	slk:lemma	divoko
 02219094-v	slk:lemma	vyživovať
 01432517-n	slk:lemma	rod rýb
-00193480-s	slk:lemma	hrozný
+00193480-a	slk:lemma	hrozný
 08651832-n	slk:lemma	štvrť chudoby
 05916306-n	slk:lemma	záblesk
-01692512-s	slk:lemma	pod šírym nebom
+01692512-a	slk:lemma	pod šírym nebom
 01147060-v	slk:lemma	odrážať
 14493145-n	slk:lemma	bieda
 00070765-r	slk:lemma	naslepo
 01545079-v	slk:lemma	klásť
 02062212-v	slk:lemma	posotiť
 00191142-n	slk:lemma	zmena
-00304670-s	slk:lemma	zúrivý
+00304670-a	slk:lemma	zúrivý
 06003682-n	slk:lemma	čistý počtový postup
 01544692-v	slk:lemma	položiť
 13367448-n	slk:lemma	zásoba
@@ -9906,7 +9906,7 @@
 00333613-r	slk:lemma	priveľmi
 02421199-v	slk:lemma	podrobiť sa
 01147451-n	slk:lemma	zamedzenie
-02507772-s	slk:lemma	všestranný
+02507772-a	slk:lemma	všestranný
 03773504-n	slk:lemma	raketa
 13980845-n	slk:lemma	konflikt
 09387880-n	slk:lemma	rieka Pearl
@@ -9927,7 +9927,7 @@
 10378412-n	slk:lemma	vodič
 06282651-n	slk:lemma	jazyková komunikácia
 09351547-n	slk:lemma	jazero
-01532454-s	slk:lemma	neveľký
+01532454-a	slk:lemma	neveľký
 00780148-n	slk:lemma	klam
 02935891-n	slk:lemma	bufet
 00947077-v	slk:lemma	vymedziť
@@ -9935,10 +9935,10 @@
 05384691-n	slk:lemma	lakťová žila
 15240119-n	slk:lemma	predsezóna
 06072145-n	slk:lemma	lesníctvo
-00969556-s	slk:lemma	nezvyčajný
+00969556-a	slk:lemma	nezvyčajný
 09465795-n	slk:lemma	elementárna bunka
 10093818-n	slk:lemma	obchodník s rybami
-00915321-s	slk:lemma	presný
+00915321-a	slk:lemma	presný
 00065184-r	slk:lemma	medzitým
 02749778-a	slk:lemma	inštitucionálny
 00575561-v	slk:lemma	eliminovať
@@ -9951,7 +9951,7 @@
 04863969-n	slk:lemma	rozhodnosť
 09242037-n	slk:lemma	rieka Charles
 13144794-n	slk:lemma	vínna réva
-01441271-s	slk:lemma	dlhodobý
+01441271-a	slk:lemma	dlhodobý
 04686003-n	slk:lemma	atraktívnosť
 04610503-n	slk:lemma	dvor
 05501185-n	slk:lemma	mozgový kmeň
@@ -9959,11 +9959,11 @@
 05671325-n	slk:lemma	záležitosť
 01858094-a	slk:lemma	súkromný
 02238085-v	slk:lemma	nadobúdať
-01726859-s	slk:lemma	fanatický
+01726859-a	slk:lemma	fanatický
 04626879-n	slk:lemma	neskrývanosť
 04857083-n	slk:lemma	statočnosť
-00922840-s	slk:lemma	obyčajný
-00521329-s	slk:lemma	hotový
+00922840-a	slk:lemma	obyčajný
+00521329-a	slk:lemma	hotový
 01140471-n	slk:lemma	príkaz
 09004625-n	slk:lemma	Čečénska republika
 02416955-v	slk:lemma	podniknúť finančnú operáciu
@@ -9990,18 +9990,18 @@
 15213115-n	slk:lemma	október
 00248659-v	slk:lemma	postúpiť
 01853310-v	slk:lemma	čerpať
-01206318-s	slk:lemma	horný
+01206318-a	slk:lemma	horný
 08659446-n	slk:lemma	pole
 04184701-n	slk:lemma	trieska
 10564660-n	slk:lemma	prispievateľ
 05993367-n	slk:lemma	pozitivizmus
-02074929-s	slk:lemma	pobláznený
+02074929-a	slk:lemma	pobláznený
 02118933-v	slk:lemma	registrovať
 01320872-n	slk:lemma	samica
 15122011-n	slk:lemma	hudobný takt
 02251743-v	slk:lemma	vyplácať
 09783537-n	slk:lemma	štipendista
-02077904-s	slk:lemma	vyšinutý
+02077904-a	slk:lemma	vyšinutý
 02322230-v	slk:lemma	potiahnuť
 06604066-n	slk:lemma	myšlienka
 01265989-v	slk:lemma	končiť
@@ -10033,7 +10033,7 @@
 03717447-n	slk:lemma	káblová studňa
 02468017-n	slk:lemma	uropygiálna žľaza
 01212024-v	slk:lemma	zmocniť sa
-00935103-s	slk:lemma	úsporný
+00935103-a	slk:lemma	úsporný
 00666886-v	slk:lemma	anulovať
 03159535-n	slk:lemma	mliekáreň
 00510364-v	slk:lemma	pokrývať machuľami
@@ -10055,10 +10055,10 @@
 14364802-n	slk:lemma	kurie oko
 05624700-n	slk:lemma	tvorivé myslenie
 03797390-n	slk:lemma	džbán
-00698586-s	slk:lemma	nepôvodný
+00698586-a	slk:lemma	nepôvodný
 14440488-n	slk:lemma	pokorenie
 13761801-n	slk:lemma	štipka
-01122595-s	slk:lemma	nedocenený
+01122595-a	slk:lemma	nedocenený
 01219111-a	slk:lemma	hornatý
 02257370-v	slk:lemma	vystriedať
 09285254-n	slk:lemma	zlomok
@@ -10073,8 +10073,8 @@
 00216174-n	slk:lemma	prepustenie
 00364440-n	slk:lemma	vzostup
 02684924-v	slk:lemma	neprestať
-00124685-s	slk:lemma	vodný
-00750602-s	slk:lemma	ľahký
+00124685-a	slk:lemma	vodný
+00750602-a	slk:lemma	ľahký
 08760856-n	slk:lemma	Škandinávsky poloostrov
 01816431-v	slk:lemma	uspokojiť
 04893358-n	slk:lemma	striedmosť
@@ -10082,8 +10082,8 @@
 05161436-n	slk:lemma	pohľadávka
 02274482-v	slk:lemma	okupovať
 01863817-v	slk:lemma	zabrzdiť
-01084297-s	slk:lemma	nadžganý
-02502994-s	slk:lemma	bezvýznamný
+01084297-a	slk:lemma	nadžganý
+02502994-a	slk:lemma	bezvýznamný
 03504723-n	slk:lemma	ústredňa
 09040601-n	slk:lemma	Ankara
 02324026-v	slk:lemma	požičiavať si
@@ -10094,18 +10094,18 @@
 09996784-n	slk:lemma	dekan
 00966809-v	slk:lemma	oznámiť
 02975994-n	slk:lemma	kazeínová farba
-01855086-s	slk:lemma	pohotovostný
-01971671-s	slk:lemma	z otcovej strany
+01855086-a	slk:lemma	pohotovostný
+01971671-a	slk:lemma	z otcovej strany
 10768585-n	slk:lemma	bojovník
 00250181-v	slk:lemma	dorásť
-00122844-s	slk:lemma	vyplývajúci
-01854129-s	slk:lemma	dodatočný
+00122844-a	slk:lemma	vyplývajúci
+01854129-a	slk:lemma	dodatočný
 09772029-n	slk:lemma	adolescent
 02380571-v	slk:lemma	poslať do dôchodku
 14478684-n	slk:lemma	zlyhanie
 02471327-v	slk:lemma	zapísať (do zoznamu)
 06435198-n	slk:lemma	Druhá kniha kráľov
-00900071-s	slk:lemma	okultný
+00900071-a	slk:lemma	okultný
 13255883-n	slk:lemma	ľahké peniaze
 00385501-n	slk:lemma	odlúčenie
 00784874-v	slk:lemma	sliediť
@@ -10115,7 +10115,7 @@
 14512817-n	slk:lemma	okolnosti
 09967555-n	slk:lemma	kozák
 02837416-n	slk:lemma	heroín
-02068946-s	slk:lemma	ten istý
+02068946-a	slk:lemma	ten istý
 08972521-n	slk:lemma	Nový Zéland
 12268246-n	slk:lemma	dub
 00050693-n	slk:lemma	objavenie sa
@@ -10142,7 +10142,7 @@
 02931227-a	slk:lemma	týkajúci sa sviatostí
 00263272-n	slk:lemma	figurácia
 07340094-n	slk:lemma	havária
-00522463-s	slk:lemma	dokonalý
+00522463-a	slk:lemma	dokonalý
 00001930-n	slk:lemma	fyzikálna entita
 02459173-v	slk:lemma	usádzať
 14496710-n	slk:lemma	poradie
@@ -10153,7 +10153,7 @@
 09203481-n	slk:lemma	Arauca
 00038625-r	slk:lemma	zaiste
 00649362-v	slk:lemma	prehľadať
-00631798-s	slk:lemma	presný
+00631798-a	slk:lemma	presný
 00341560-v	slk:lemma	postupovať
 06459834-n	slk:lemma	Kniha Judit
 00229605-v	slk:lemma	zvýšiť
@@ -10168,7 +10168,7 @@
 09284015-n	slk:lemma	les
 12156819-n	slk:lemma	obilné zrno
 06152460-n	slk:lemma	náuka o výkone trestu a náprave páchateľov
-00224515-s	slk:lemma	zlomyseľný
+00224515-a	slk:lemma	zlomyseľný
 01232635-a	slk:lemma	horizontálny
 00033020-n	slk:lemma	prejav
 01955508-v	slk:lemma	odoslať
@@ -10181,7 +10181,7 @@
 00250143-n	slk:lemma	pracovný tok
 00744305-n	slk:lemma	krivda
 02389346-v	slk:lemma	kontaktovať sa (s)
-01400961-s	slk:lemma	súdny
+01400961-a	slk:lemma	súdny
 06706676-n	slk:lemma	vavrín
 03454211-n	slk:lemma	lodný hák
 01835496-v	slk:lemma	premiestniť
@@ -10205,9 +10205,9 @@
 05177705-n	slk:lemma	donucovací postup
 00705227-v	slk:lemma	mávať v pláne
 15243730-n	slk:lemma	geologická časová jednotka
-00789494-s	slk:lemma	apatický
+00789494-a	slk:lemma	apatický
 02663643-v	slk:lemma	závisieť od
-00418364-s	slk:lemma	čistučký
+00418364-a	slk:lemma	čistučký
 11425580-n	slk:lemma	atmosférický fenomén
 02453321-v	slk:lemma	zavracať
 01169317-n	slk:lemma	odpor
@@ -10232,7 +10232,7 @@
 00105603-r	slk:lemma	pohotovo
 05469424-n	slk:lemma	Paciniho korpuskula
 09954879-n	slk:lemma	dôverník
-01036754-s	slk:lemma	domáci
+01036754-a	slk:lemma	domáci
 01001294-v	slk:lemma	rozpisovať sa
 00249313-v	slk:lemma	poklesnúť
 01711965-v	slk:lemma	nakrúcať
@@ -10265,7 +10265,7 @@
 05514410-n	slk:lemma	ženské genitálie
 01235946-n	slk:lemma	odveta
 07506149-n	slk:lemma	bezcitnosť
-00971506-s	slk:lemma	v móde
+00971506-a	slk:lemma	v móde
 09752795-n	slk:lemma	lev
 04350905-n	slk:lemma	šaty
 00004394-r	slk:lemma	láskavo
@@ -10273,8 +10273,8 @@
 07238455-n	slk:lemma	narážka
 03481521-n	slk:lemma	kladivo
 00620424-n	slk:lemma	mäsiarstvo
-00837415-s	slk:lemma	namáhavý
-00627004-s	slk:lemma	hmotný
+00837415-a	slk:lemma	namáhavý
+00627004-a	slk:lemma	hmotný
 00595630-v	slk:lemma	byť si istý
 03224032-n	slk:lemma	dvere
 08172877-n	slk:lemma	Ázia
@@ -10331,7 +10331,7 @@
 02345647-v	slk:lemma	zanechať, prepustiť, vzdať sa
 05486920-n	slk:lemma	kôrovitá oblasť
 03137558-a	slk:lemma	komerčný
-00194357-s	slk:lemma	zlovestný
+00194357-a	slk:lemma	zlovestný
 02131418-n	slk:lemma	Ursidae
 09176342-n	slk:lemma	Lascar
 13356112-n	slk:lemma	financie
@@ -10349,9 +10349,9 @@
 08659446-n	slk:lemma	oblasť
 06642138-n	slk:lemma	informácia
 15206195-n	slk:lemma	štvrť storočia
-02094203-s	slk:lemma	istý
+02094203-a	slk:lemma	istý
 03003730-n	slk:lemma	komora
-02074929-s	slk:lemma	pojašený
+02074929-a	slk:lemma	pojašený
 05893916-n	slk:lemma	podvod
 14616181-n	slk:lemma	kyselina korková
 00325975-n	slk:lemma	alpinizmus
@@ -10395,7 +10395,7 @@
 00522145-n	slk:lemma	predvedenie
 05509889-n	slk:lemma	dýchacie ústrojenstvo
 00036935-r	slk:lemma	s konečnou platnosťou
-00528167-s	slk:lemma	plenárny
+00528167-a	slk:lemma	plenárny
 03695957-n	slk:lemma	nosič
 00205891-n	slk:lemma	konfiškácia
 05586446-n	slk:lemma	endoskelet členovcov
@@ -10407,9 +10407,9 @@
 05245626-n	slk:lemma	vyrážka
 00925735-v	slk:lemma	žasnúť
 02467662-v	slk:lemma	rozdeliť sa
-01935935-s	slk:lemma	vymyslený
+01935935-a	slk:lemma	vymyslený
 03578656-n	slk:lemma	vstupný bod
-01591394-s	slk:lemma	vladársky
+01591394-a	slk:lemma	vladársky
 01651293-v	slk:lemma	pokúšať sa
 05921123-n	slk:lemma	jadro
 00102586-v	slk:lemma	spôsobovať ujmu
@@ -10442,11 +10442,11 @@
 03699975-n	slk:lemma	mechanizmus
 02510337-v	slk:lemma	skrotiť
 09021503-n	slk:lemma	Turkménsko
-00609564-s	slk:lemma	bizarný
+00609564-a	slk:lemma	bizarný
 00309368-n	slk:lemma	výlet autom
 02881757-n	slk:lemma	pinč
 02920503-n	slk:lemma	bunker
-00792202-s	slk:lemma	prvoradý
+00792202-a	slk:lemma	prvoradý
 02256109-v	slk:lemma	ceniť si
 00442115-n	slk:lemma	plávanie
 00669155-n	slk:lemma	ženská obriezka
@@ -10457,7 +10457,7 @@
 00047056-r	slk:lemma	zďaleka
 04134632-n	slk:lemma	presýpacie hodiny
 00245289-v	slk:lemma	hasiť
-00224515-s	slk:lemma	zlovoľný
+00224515-a	slk:lemma	zlovoľný
 09043052-n	slk:lemma	Uganda
 05098620-n	slk:lemma	hlučnosť
 15245990-n	slk:lemma	jedlo
@@ -10515,7 +10515,7 @@
 02416410-n	slk:lemma	rod koza
 00226133-r	slk:lemma	obozretne
 13371355-n	slk:lemma	poklad
-02110447-s	slk:lemma	oddelený
+02110447-a	slk:lemma	oddelený
 07359599-n	slk:lemma	posun
 02062081-v	slk:lemma	pohybovať sa
 09379705-n	slk:lemma	rieka Orange
@@ -10539,7 +10539,7 @@
 00351485-n	slk:lemma	zmenšovanie
 09923673-n	slk:lemma	štátny príslušník
 05948537-n	slk:lemma	sekta
-01263445-s	slk:lemma	príšerný
+01263445-a	slk:lemma	príšerný
 03623556-n	slk:lemma	nôž
 00018302-r	slk:lemma	v podstate
 00248765-r	slk:lemma	obzvlášť
@@ -10584,7 +10584,7 @@
 02851099-n	slk:lemma	ochrana
 05708432-n	slk:lemma	percepcia
 02726305-n	slk:lemma	byt
-00510644-s	slk:lemma	účinný
+00510644-a	slk:lemma	účinný
 05518870-n	slk:lemma	vajcovod
 08212347-n	slk:lemma	zamestnanci
 09170109-n	slk:lemma	Veľká Viktóriina púšť
@@ -10595,7 +10595,7 @@
 06532095-n	slk:lemma	zmluva
 01819390-a	slk:lemma	plus
 05581514-n	slk:lemma	kopyto
-00421590-s	slk:lemma	hnusný
+00421590-a	slk:lemma	hnusný
 14418822-n	slk:lemma	konfederácia
 06051380-n	slk:lemma	hygiena
 00364064-v	slk:lemma	zastaviť
@@ -10626,21 +10626,21 @@
 01103159-n	slk:lemma	tlač
 12709103-n	slk:lemma	veľký pomaranč
 01649999-v	slk:lemma	podnecovať
-01578856-s	slk:lemma	prípadný
+01578856-a	slk:lemma	prípadný
 02423762-v	slk:lemma	točiť do fliaš
 00881998-v	slk:lemma	gratulovať
 03699975-n	slk:lemma	mašina
-01950711-s	slk:lemma	neokrôchaný
+01950711-a	slk:lemma	neokrôchaný
 01875295-v	slk:lemma	kolísať sa
 01208597-n	slk:lemma	pomoc
 07234230-n	slk:lemma	obžaloba
 14449405-n	slk:lemma	nedostatok
-01276482-s	slk:lemma	alfa
+01276482-a	slk:lemma	alfa
 07183151-n	slk:lemma	dohadovanie sa
 14010636-n	slk:lemma	pozastavenie
 10599354-n	slk:lemma	prostý človek
 13129165-n	slk:lemma	byľ
-02384077-s	slk:lemma	táravý
+02384077-a	slk:lemma	táravý
 13457378-n	slk:lemma	zmenšenie
 13273154-n	slk:lemma	prídavok
 09398217-n	slk:lemma	Potomac
@@ -10653,7 +10653,7 @@
 01058574-v	slk:lemma	zaznamenávať
 10575705-n	slk:lemma	pestovateľ semien
 03135656-n	slk:lemma	rozpera
-02481012-s	slk:lemma	rozdrobený (národ)
+02481012-a	slk:lemma	rozdrobený (národ)
 01742726-v	slk:lemma	zušľachťovať
 04340750-n	slk:lemma	nedobytná pokladňa
 07541760-n	slk:lemma	šťastnosť
@@ -10670,7 +10670,7 @@
 05338410-n	slk:lemma	bazilárna tepna
 00427580-n	slk:lemma	žart
 00205046-v	slk:lemma	polepšovať
-02026629-s	slk:lemma	zbankrotovaný
+02026629-a	slk:lemma	zbankrotovaný
 05829480-n	slk:lemma	negatívny podnet
 00089027-n	slk:lemma	podrobenie
 00992518-v	slk:lemma	podávať si ruky
@@ -10679,13 +10679,13 @@
 08553535-n	slk:lemma	obytné pásmo
 01631072-v	slk:lemma	obnoviť si
 00665886-v	slk:lemma	podoprieť (faktami)
-02074929-s	slk:lemma	šibnutý
+02074929-a	slk:lemma	šibnutý
 04361641-n	slk:lemma	potlačovač
 00841986-v	slk:lemma	vyzrádzať
 06260121-n	slk:lemma	komunikačný kanál
 06803157-n	slk:lemma	signalizácia
 01651293-v	slk:lemma	pokúsiť sa
-00127948-s	slk:lemma	nasledovný
+00127948-a	slk:lemma	nasledovný
 05068461-n	slk:lemma	spád
 00971650-v	slk:lemma	označovať
 02640226-v	slk:lemma	oneskorovať sa
@@ -10714,7 +10714,7 @@
 11642430-n	slk:lemma	lat. Montezuma cypress
 00281462-n	slk:lemma	približovanie sa
 08494231-n	slk:lemma	zábavný park
-01277097-s	slk:lemma	podstatný
+01277097-a	slk:lemma	podstatný
 00021212-r	slk:lemma	občas
 07316603-n	slk:lemma	pohroma
 01570935-v	slk:lemma	škrtiť
@@ -10728,10 +10728,10 @@
 01064148-n	slk:lemma	voľno
 05773923-n	slk:lemma	dohad
 09439032-n	slk:lemma	snehové pole
-01794995-s	slk:lemma	barokový
+01794995-a	slk:lemma	barokový
 03548086-n	slk:lemma	kryt náboja kolesa
 08827126-n	slk:lemma	Ontario
-01134486-s	slk:lemma	mierny
+01134486-a	slk:lemma	mierny
 12874783-n	slk:lemma	sézam
 09936215-n	slk:lemma	spolupracovník
 07499615-n	slk:lemma	vľúdnosť
@@ -10787,7 +10787,7 @@
 07286014-n	slk:lemma	znamenie
 12992868-n	slk:lemma	huba
 00746718-v	slk:lemma	vydať príkaz
-01783522-s	slk:lemma	kostolný
+01783522-a	slk:lemma	kostolný
 01131515-n	slk:lemma	zákonom stanovená povinnosť
 05509452-n	slk:lemma	genitourinárny systém
 07321967-n	slk:lemma	návrat
@@ -10818,8 +10818,8 @@
 02833576-n	slk:lemma	skosená hrana
 00666886-v	slk:lemma	urobiť neplatným
 00054285-v	slk:lemma	oťarchavieť
-00876204-s	slk:lemma	neživý
-01926229-s	slk:lemma	rozumný
+00876204-a	slk:lemma	neživý
+01926229-a	slk:lemma	rozumný
 00264366-n	slk:lemma	obohatenie
 13301835-n	slk:lemma	prekročenie rozpočtu nákladov
 01556921-v	slk:lemma	separovať
@@ -10855,7 +10855,7 @@
 00338821-n	slk:lemma	prerovnávanie
 02525447-v	slk:lemma	zafungovať
 13686877-n	slk:lemma	Britský šiling
-00959244-s	slk:lemma	spoľahlivý
+00959244-a	slk:lemma	spoľahlivý
 09036452-n	slk:lemma	Thajsko
 03068862-n	slk:lemma	objímka
 00674607-v	slk:lemma	vyberať
@@ -10876,7 +10876,7 @@
 04210390-n	slk:lemma	relikviár
 13664396-n	slk:lemma	birr
 02111838-v	slk:lemma	lámať sa
-01514141-s	slk:lemma	výrazný
+01514141-a	slk:lemma	výrazný
 02567147-v	slk:lemma	rušivo zasiahnuť
 00997020-v	slk:lemma	podpisovať
 01513430-v	slk:lemma	vyzliekať sa (z)
@@ -10885,7 +10885,7 @@
 10362319-n	slk:lemma	nefajčiar
 01049475-n	slk:lemma	maskovanie
 00311057-r	slk:lemma	úplne
-01742912-s	slk:lemma	búrlivý
+01742912-a	slk:lemma	búrlivý
 08860123-n	slk:lemma	Veľká Británia
 02627666-v	slk:lemma	zrodiť sa
 01227190-n	slk:lemma	odpustenie
@@ -10896,8 +10896,8 @@
 00066191-v	slk:lemma	preliať slzy
 01058574-v	slk:lemma	podotýkať
 06693502-n	slk:lemma	velebenie
-01711465-s	slk:lemma	boľavý
-00764484-s	slk:lemma	priamy
+01711465-a	slk:lemma	boľavý
+00764484-a	slk:lemma	priamy
 13324609-n	slk:lemma	zriaďovací poplatok
 00595505-v	slk:lemma	ignorovať
 00285557-n	slk:lemma	krok
@@ -10907,7 +10907,7 @@
 01742726-v	slk:lemma	dopestovať
 00175135-r	slk:lemma	divoko
 08799958-n	slk:lemma	Rímska republika
-02250430-s	slk:lemma	opustený
+02250430-a	slk:lemma	opustený
 08795654-n	slk:lemma	Sodoma
 08287436-n	slk:lemma	konzervatórium
 04752221-n	slk:lemma	nerovnosť
@@ -10921,7 +10921,7 @@
 06515662-n	slk:lemma	kronika
 02323902-n	slk:lemma	zajacovité
 06434165-n	slk:lemma	Kniha Sudcov
-02344672-s	slk:lemma	príma
+02344672-a	slk:lemma	príma
 02484570-v	slk:lemma	strieľať
 08399586-n	slk:lemma	škála
 00763399-v	slk:lemma	ustanoviť
@@ -10945,13 +10945,13 @@
 02620466-v	slk:lemma	podliehať
 02570267-v	slk:lemma	rozmaznať
 15292336-n	slk:lemma	hliadka
-00182225-s	slk:lemma	samospúšťací
+00182225-a	slk:lemma	samospúšťací
 06785367-n	slk:lemma	tvrdý oriešok
 02344381-v	slk:lemma	odplatiť sa
-01921466-s	slk:lemma	hlučný
-00567860-s	slk:lemma	opustený
+01921466-a	slk:lemma	hlučný
+00567860-a	slk:lemma	opustený
 02705428-v	slk:lemma	naťahovať sa
-01564881-s	slk:lemma	stuhnutý (od strachu)
+01564881-a	slk:lemma	stuhnutý (od strachu)
 00508672-n	slk:lemma	lotéria
 01143838-v	slk:lemma	poľovať
 15289524-n	slk:lemma	doba výroby
@@ -10974,7 +10974,7 @@
 08763193-n	slk:lemma	Dominické spoločenstvo
 02074915-n	slk:lemma	rad mäsožravce
 08151490-n	slk:lemma	kult (prenesene)
-00904290-s	slk:lemma	obdivuhodný
+00904290-a	slk:lemma	obdivuhodný
 06729864-n	slk:lemma	požiadavka
 09129442-n	slk:lemma	North Dakota
 09099526-n	slk:lemma	MI
@@ -10996,13 +10996,13 @@
 00888786-v	slk:lemma	zaviazať
 09815188-n	slk:lemma	hlupák
 01686132-v	slk:lemma	stvárňovať
-00848466-s	slk:lemma	nariadený
-00937616-s	slk:lemma	nevyskúšaný
+00848466-a	slk:lemma	nariadený
+00937616-a	slk:lemma	nevyskúšaný
 02487547-n	slk:lemma	makak rhesus
 14001348-n	slk:lemma	závislosť
 00060477-v	slk:lemma	vykastrovať
 00429048-n	slk:lemma	pobavenie
-01629681-s	slk:lemma	agresívny
+01629681-a	slk:lemma	agresívny
 09631129-n	slk:lemma	persona non grata
 07476623-n	slk:lemma	porážka
 02953598-a	slk:lemma	ortodoxný
@@ -11010,7 +11010,7 @@
 07360293-n	slk:lemma	premena tuhého skupenstva na plynné
 00265119-n	slk:lemma	reštaurovanie
 02257370-v	slk:lemma	zmeniť
-01792573-s	slk:lemma	číry
+01792573-a	slk:lemma	číry
 14474435-n	slk:lemma	požehnanie
 01639714-v	slk:lemma	načrtnúť
 10726786-n	slk:lemma	obchodný cestujúci
@@ -11031,13 +11031,13 @@
 07584332-n	slk:lemma	polievka
 00713167-v	slk:lemma	spájať si
 01983771-v	slk:lemma	meniť (polohu, postoj, pozíciu)
-01958259-s	slk:lemma	osvedčený
+01958259-a	slk:lemma	osvedčený
 02478701-v	slk:lemma	robiť platným
 10368414-n	slk:lemma	blázon
 00069879-v	slk:lemma	ubližovať
 07227406-n	slk:lemma	prísľub
 01147060-v	slk:lemma	zavracať
-01082714-s	slk:lemma	nevydarený
+01082714-a	slk:lemma	nevydarený
 01104406-n	slk:lemma	agrobiznis
 04602044-n	slk:lemma	pracovisko
 01335804-v	slk:lemma	zaviazať
@@ -11051,7 +11051,7 @@
 00621058-v	slk:lemma	vyjasňovať
 08673395-n	slk:lemma	pozemok
 07430480-n	slk:lemma	signál pozadia
-00669853-s	slk:lemma	zatratený
+00669853-a	slk:lemma	zatratený
 03132076-n	slk:lemma	kriketová pálka
 01655505-v	slk:lemma	vytvárať
 05349659-n	slk:lemma	lakrimálna artéria
@@ -11061,9 +11061,9 @@
 00531489-v	slk:lemma	znižovať
 02274482-v	slk:lemma	ukoristiť
 06371999-n	slk:lemma	krátka poviedka
-01150063-s	slk:lemma	láskou roztúžený
+01150063-a	slk:lemma	láskou roztúžený
 01843055-v	slk:lemma	precestovať
-00505410-s	slk:lemma	jedinečný
+00505410-a	slk:lemma	jedinečný
 09255921-n	slk:lemma	Coosa
 00419908-n	slk:lemma	zneužívanie
 03637787-n	slk:lemma	lancetový oblúk
@@ -11073,14 +11073,14 @@
 07071483-n	slk:lemma	ústny prejav
 15116724-n	slk:lemma	kozmický čas
 01181475-n	slk:lemma	riadny súdny proces
-00408445-s	slk:lemma	nevýrazný
+00408445-a	slk:lemma	nevýrazný
 05084201-n	slk:lemma	vzdialenosť
 00471613-n	slk:lemma	baseball
 02141973-v	slk:lemma	dať okázale najavo
 07461050-n	slk:lemma	trojdňové podujatie
 00034574-n	slk:lemma	láskavosť
-00176387-s	slk:lemma	priaznivý
-00116245-s	slk:lemma	zlostný
+00176387-a	slk:lemma	priaznivý
+00116245-a	slk:lemma	zlostný
 06333653-n	slk:lemma	meno
 13518963-n	slk:lemma	prirodzený jav
 01580467-v	slk:lemma	obkolesovať
@@ -11090,16 +11090,16 @@
 13746672-n	slk:lemma	11
 03963982-n	slk:lemma	hracia karta
 00227165-v	slk:lemma	zosilniť sa
-02052603-s	slk:lemma	meštiansky
+02052603-a	slk:lemma	meštiansky
 07902121-n	slk:lemma	neutrálna liehovina
-01443097-s	slk:lemma	prchavý
+01443097-a	slk:lemma	prchavý
 08438223-n	slk:lemma	krovinatý porast
 08738272-n	slk:lemma	El Salvador
 01969216-v	slk:lemma	stúpnuť
 00928630-v	slk:lemma	postúpiť
 00844847-n	slk:lemma	počatie
 05936561-n	slk:lemma	optická fúzia
-00201961-s	slk:lemma	obrátený
+00201961-a	slk:lemma	obrátený
 00122954-n	slk:lemma	strieľanie
 03367740-n	slk:lemma	flotila
 02236896-n	slk:lemma	polokrídlovce
@@ -11110,7 +11110,7 @@
 13969854-n	slk:lemma	ohľad
 01759326-v	slk:lemma	vzbudzovať
 03969998-n	slk:lemma	okrasné pero
-02112701-s	slk:lemma	hromadný
+02112701-a	slk:lemma	hromadný
 01467370-v	slk:lemma	lemovať
 03224387-n	slk:lemma	dvor
 06434650-n	slk:lemma	Prvá kniha Samuelova
@@ -11132,7 +11132,7 @@
 04857490-n	slk:lemma	nadšenie
 04697442-n	slk:lemma	cudnosť
 13360254-n	slk:lemma	fond pre vedenie vojny
-00978754-s	slk:lemma	rýchly
+00978754-a	slk:lemma	rýchly
 02469835-v	slk:lemma	zlučovať sa
 01077350-n	slk:lemma	profylaxia
 02893418-n	slk:lemma	panvica na žeravé uhlie
@@ -11155,12 +11155,12 @@
 02483708-n	slk:lemma	Symphalangus syndactylus
 10000945-n	slk:lemma	mladistvý previnilec
 03187268-n	slk:lemma	dialógový rámček
-01397998-s	slk:lemma	pórovitý
-00711308-s	slk:lemma	tvrdý
+01397998-a	slk:lemma	pórovitý
+00711308-a	slk:lemma	tvrdý
 05774614-n	slk:lemma	inferencia
 00406612-n	slk:lemma	zohýbanie
 01747374-v	slk:lemma	kopírovať
-01925708-s	slk:lemma	jasný
+01925708-a	slk:lemma	jasný
 09250016-n	slk:lemma	Colorado
 00804476-v	slk:lemma	ustupovať
 00430140-n	slk:lemma	hazardná hra
@@ -11168,7 +11168,7 @@
 10162991-n	slk:lemma	hlava
 04938110-n	slk:lemma	pevnosť
 06738281-n	slk:lemma	vysvetlenie
-01515692-s	slk:lemma	dotyčný
+01515692-a	slk:lemma	dotyčný
 02710137-v	slk:lemma	rozvetviť sa
 10325656-n	slk:lemma	číslo
 08234792-n	slk:lemma	firemné odbory
@@ -11177,14 +11177,14 @@
 10780632-n	slk:lemma	žena
 05281874-n	slk:lemma	tarzálna kosť
 00955601-v	slk:lemma	spracovávať
-02114613-s	slk:lemma	obsahujúci hnis
+02114613-a	slk:lemma	obsahujúci hnis
 02320374-v	slk:lemma	započítavať
 02676610-a	slk:lemma	v tvare zvona
 01762582-a	slk:lemma	neprijateľný
 02167052-v	slk:lemma	dívať sa
 15290337-n	slk:lemma	obdobie
 00672433-v	slk:lemma	odhadovať
-01640124-s	slk:lemma	dávny
+01640124-a	slk:lemma	dávny
 00263272-n	slk:lemma	ozdobovanie
 09152944-n	slk:lemma	Washington
 06833004-n	slk:lemma	r
@@ -11193,13 +11193,13 @@
 00224599-n	slk:lemma	lynč
 12711596-n	slk:lemma	citrónovník
 04217882-n	slk:lemma	vývesná tabuľa
-00828661-s	slk:lemma	vyšportovaný
+00828661-a	slk:lemma	vyšportovaný
 00029836-v	slk:lemma	plakať od smiechu
 00165269-r	slk:lemma	načas
 02968074-n	slk:lemma	prístrešok pre auto
 01322343-n	slk:lemma	šteniatko
 07001717-n	slk:lemma	stĺpcový diagram
-01041209-s	slk:lemma	láskavý
+01041209-a	slk:lemma	láskavý
 13911872-n	slk:lemma	bodka
 02086079-n	slk:lemma	pekinéz
 01117541-n	slk:lemma	predaj
@@ -11215,7 +11215,7 @@
 00151087-n	slk:lemma	objavenie
 10713686-n	slk:lemma	ceremoniár
 01150981-v	slk:lemma	obracať sa
-02110447-s	slk:lemma	vyčlenený
+02110447-a	slk:lemma	vyčlenený
 06259166-n	slk:lemma	listový papier
 06797169-n	slk:lemma	indikácia
 13331198-n	slk:lemma	suma
@@ -11230,11 +11230,11 @@
 06748969-n	slk:lemma	prognóza
 03490884-n	slk:lemma	vešiak
 08510666-n	slk:lemma	tvár
-00215087-s	slk:lemma	chlpatý
+00215087-a	slk:lemma	chlpatý
 00259927-v	slk:lemma	postihovať (čím)
 00066191-v	slk:lemma	plakať
 07874780-n	slk:lemma	kaša
-01302544-s	slk:lemma	rozvíjajúci sa
+01302544-a	slk:lemma	rozvíjajúci sa
 00008997-r	slk:lemma	fakticky
 00372660-r	slk:lemma	taktne
 03201638-n	slk:lemma	dlhé večerné šaty
@@ -11276,28 +11276,28 @@
 00521296-v	slk:lemma	naštrbiť
 01150559-v	slk:lemma	smerovať
 13942743-n	slk:lemma	bežný
-01789117-s	slk:lemma	mramorovaný
+01789117-a	slk:lemma	mramorovaný
 05079866-n	slk:lemma	postavenie
 01097192-v	slk:lemma	vstúpiť
 00551215-n	slk:lemma	program
 01239868-n	slk:lemma	vec
 01091427-v	slk:lemma	vzpierať sa
-01392633-s	slk:lemma	drobný
-01625063-s	slk:lemma	protivný
+01392633-a	slk:lemma	drobný
+01625063-a	slk:lemma	protivný
 01088757-n	slk:lemma	invalidné poistenie
 00678221-a	slk:lemma	dvojročný
 09753498-n	slk:lemma	Kozorožec
 06687358-n	slk:lemma	potvrdenie
 02174115-v	slk:lemma	štrngať
 00496673-v	slk:lemma	nechať
-01947741-s	slk:lemma	slušný
+01947741-a	slk:lemma	slušný
 02961225-n	slk:lemma	autobatéria
 02655135-v	slk:lemma	nachádzať sa
 13580415-n	slk:lemma	dostatok
 10332385-n	slk:lemma	mať
 09274739-n	slk:lemma	rieka Eufrat
 08848094-n	slk:lemma	štát Bahrajn
-01384212-s	slk:lemma	široký
+01384212-a	slk:lemma	široký
 00250484-r	slk:lemma	vedľa seba
 01531998-v	slk:lemma	špiniť
 13470491-n	slk:lemma	klesanie
@@ -11314,14 +11314,14 @@
 06833663-n	slk:lemma	iksko
 01716227-a	slk:lemma	schodný (riešenie)
 02510337-v	slk:lemma	krotiť
-02214736-s	slk:lemma	jediný
+02214736-a	slk:lemma	jediný
 03661340-n	slk:lemma	klapka
 01752884-v	slk:lemma	vytvárať
 08892058-n	slk:lemma	Galloway
-02517169-s	slk:lemma	hodný videnia
+02517169-a	slk:lemma	hodný videnia
 00077458-v	slk:lemma	zvracať
-00729439-s	slk:lemma	samostatný
-01044730-s	slk:lemma	ľahkomyseľný
+00729439-a	slk:lemma	samostatný
+01044730-a	slk:lemma	ľahkomyseľný
 02294436-v	slk:lemma	deliť
 15251600-n	slk:lemma	dvojstoročné jubileum
 00073177-n	slk:lemma	zaokrúhlenie
@@ -11333,13 +11333,13 @@
 02683127-v	slk:lemma	dištancovať
 10128909-n	slk:lemma	obor
 00945255-v	slk:lemma	predniesť
-00780352-s	slk:lemma	ostrý
+00780352-a	slk:lemma	ostrý
 02053941-v	slk:lemma	približovať sa
 08308497-n	slk:lemma	konferencia
 01434278-v	slk:lemma	odnášať si
 14236595-n	slk:lemma	nádor
 02794123-a	slk:lemma	tajomnícky
-01808227-s	slk:lemma	skvelý
+01808227-a	slk:lemma	skvelý
 04051439-n	slk:lemma	bok
 00994449-n	slk:lemma	kanónová paľba
 07363346-n	slk:lemma	pohyb smerom dole
@@ -11354,19 +11354,19 @@
 07233863-n	slk:lemma	zlorečenie
 00446980-n	slk:lemma	lukostreľba
 00891734-v	slk:lemma	znovu poisťovať
-02130821-s	slk:lemma	nerozhodný
+02130821-a	slk:lemma	nerozhodný
 08718391-n	slk:lemma	Falklandské ostrovy
 01747945-v	slk:lemma	vytlačiť
 05132221-n	slk:lemma	hladina vody
 03103128-n	slk:lemma	chladiaci systém
 00908621-v	slk:lemma	uprednostniť
 05869584-n	slk:lemma	celok
-02565425-s	slk:lemma	ochotný
+02565425-a	slk:lemma	ochotný
 00021766-a	slk:lemma	akurátny
 02500775-v	slk:lemma	bičovať
 06471069-n	slk:lemma	patent
 00106170-r	slk:lemma	nenápadne
-01155603-s	slk:lemma	kalkulujúci
+01155603-a	slk:lemma	kalkulujúci
 03397762-n	slk:lemma	okraj
 05888929-n	slk:lemma	teória
 13681142-n	slk:lemma	česká peňažná jednotka
@@ -11386,10 +11386,10 @@
 14741124-n	slk:lemma	transmastná kyselina
 01195536-a	slk:lemma	nápomocný
 10700201-n	slk:lemma	nájomník
-00803275-s	slk:lemma	prenikavý
+00803275-a	slk:lemma	prenikavý
 00282103-r	slk:lemma	opatrne
 06748466-n	slk:lemma	pracovný plán
-02123579-s	slk:lemma	vyvolený
+02123579-a	slk:lemma	vyvolený
 09431133-n	slk:lemma	rieka Seyhan
 05595531-n	slk:lemma	guľovitý kĺb
 05584390-n	slk:lemma	necht na palci
@@ -11406,12 +11406,12 @@
 00512877-v	slk:lemma	umožňovať
 02994858-n	slk:lemma	telefónna ústredňa
 10176679-n	slk:lemma	nádenník
-00933599-s	slk:lemma	drahý
+00933599-a	slk:lemma	drahý
 02232190-v	slk:lemma	presunúť
 05316175-n	slk:lemma	očný sval
 00770834-n	slk:lemma	neoprávnené použitie autorsky chráneného materiálu
 00195194-n	slk:lemma	premena
-01629681-s	slk:lemma	útočný
+01629681-a	slk:lemma	útočný
 02108377-v	slk:lemma	prechádzať (niečím)
 07307477-n	slk:lemma	udalosť
 05766247-n	slk:lemma	preklad
@@ -11421,19 +11421,19 @@
 01945516-v	slk:lemma	plachtiť
 06725877-n	slk:lemma	vyhlásenie
 09265910-n	slk:lemma	deziderátum
-01040825-s	slk:lemma	pamätný deň
+01040825-a	slk:lemma	pamätný deň
 08472890-n	slk:lemma	robotnícke odbory
 03173929-n	slk:lemma	dodávkové auto
 01764800-v	slk:lemma	upokojovať
 00876442-v	slk:lemma	konzultovať
-02026629-s	slk:lemma	skrachovaný
-00919919-s	slk:lemma	žiadostivý
+02026629-a	slk:lemma	skrachovaný
+00919919-a	slk:lemma	žiadostivý
 14448333-n	slk:lemma	nedostatok
 02289295-v	slk:lemma	nadobúdať
-01993408-s	slk:lemma	dobrý
+01993408-a	slk:lemma	dobrý
 00835609-a	slk:lemma	neefektívny
 04543772-n	slk:lemma	koleso vagóna
-01664310-s	slk:lemma	nerealistický
+01664310-a	slk:lemma	nerealistický
 03964744-n	slk:lemma	hračka
 00136329-n	slk:lemma	výkop
 06539770-n	slk:lemma	ustanovenie
@@ -11466,7 +11466,7 @@
 08119525-n	slk:lemma	odbytové oddelenie
 00940384-v	slk:lemma	vyjadriť sa
 05471837-n	slk:lemma	mandibulárna kondyla
-01279611-s	slk:lemma	vážny
+01279611-a	slk:lemma	vážny
 00064643-v	slk:lemma	bolieť
 02552449-v	slk:lemma	obnoviť
 01849288-a	slk:lemma	snobský
@@ -11475,19 +11475,19 @@
 02133435-v	slk:lemma	črtať sa
 02604760-v	slk:lemma	byť
 06656741-n	slk:lemma	hospodárska politika
-00330506-s	slk:lemma	uprostred
+00330506-a	slk:lemma	uprostred
 04565375-n	slk:lemma	zbraň
 05710020-n	slk:lemma	percepcia
 00068901-n	slk:lemma	nedodržanie
-00886253-s	slk:lemma	horlivý
+00886253-a	slk:lemma	horlivý
 00064151-n	slk:lemma	šláger
 13395897-n	slk:lemma	dolár
-02083908-s	slk:lemma	suchársky
-00250739-s	slk:lemma	šialene odvážny
-01166413-s	slk:lemma	blahodarný
-01644225-s	slk:lemma	seniorský
+02083908-a	slk:lemma	suchársky
+00250739-a	slk:lemma	šialene odvážny
+01166413-a	slk:lemma	blahodarný
+01644225-a	slk:lemma	seniorský
 14797813-n	slk:lemma	indigo
-00461609-s	slk:lemma	zahmlený
+00461609-a	slk:lemma	zahmlený
 02528163-n	slk:lemma	kostnatá ryba
 04874672-n	slk:lemma	nepoctivosť
 02075296-n	slk:lemma	mäsožravec
@@ -11495,7 +11495,7 @@
 08734385-n	slk:lemma	Konžská demokratická republika
 00074407-r	slk:lemma	spätne
 00004258-n	slk:lemma	živý tvor
-00051373-s	slk:lemma	schopný
+00051373-a	slk:lemma	schopný
 01924590-n	slk:lemma	kmeň Plathelminthes
 13814336-n	slk:lemma	bratský zväzok
 00257228-n	slk:lemma	starostlivosť o vlasy
@@ -11505,17 +11505,17 @@
 00070765-r	slk:lemma	svojvoľne
 04512476-n	slk:lemma	Penn
 01621555-v	slk:lemma	zhotovovať
-00792202-s	slk:lemma	vrcholný
+00792202-a	slk:lemma	vrcholný
 01252730-v	slk:lemma	zablatiť
 15264607-n	slk:lemma	správny rytmus
 14618253-n	slk:lemma	zásada
-02500590-s	slk:lemma	neplatný
+02500590-a	slk:lemma	neplatný
 09034402-n	slk:lemma	Latakia
 07535010-n	slk:lemma	žiaľ
 00213694-n	slk:lemma	prepustenie
 02806907-a	slk:lemma	symbolický
 02464327-n	slk:lemma	noha zvieraťa
-01916979-s	slk:lemma	pochybný
+01916979-a	slk:lemma	pochybný
 10407954-n	slk:lemma	patrón
 04713428-n	slk:lemma	zhoda
 01020005-v	slk:lemma	podotýkať
@@ -11531,11 +11531,11 @@
 02351467-v	slk:lemma	predávať pod cenou
 01038666-v	slk:lemma	zhovárať sa
 01973125-v	slk:lemma	zliezť
-01882292-s	slk:lemma	prorocký
+01882292-a	slk:lemma	prorocký
 03417345-n	slk:lemma	záhrada
 02396205-v	slk:lemma	ustanoviť
-01285136-s	slk:lemma	galantný
-00990855-s	slk:lemma	štíhly
+01285136-a	slk:lemma	galantný
+00990855-a	slk:lemma	štíhly
 13250398-n	slk:lemma	bohatstvo
 13266892-n	slk:lemma	peňažný grant
 02066450-n	slk:lemma	ozubené
@@ -11549,24 +11549,24 @@
 06358159-n	slk:lemma	cieľový kód
 00875519-n	slk:lemma	ocenenie
 00515069-n	slk:lemma	vtip
-02023430-s	slk:lemma	biedny
+02023430-a	slk:lemma	biedny
 13875185-n	slk:lemma	kotúč
 00626428-v	slk:lemma	interpretovať
-00886253-s	slk:lemma	zanietený
-02568480-s	slk:lemma	neschopný letu
+00886253-a	slk:lemma	zanietený
+02568480-a	slk:lemma	neschopný letu
 05690916-n	slk:lemma	zábrana
 05615373-n	slk:lemma	uvážlivosť
 00035491-r	slk:lemma	divne
 02813399-n	slk:lemma	arkier
 14327435-n	slk:lemma	bolesť v uchu
 05770926-n	slk:lemma	uvažovanie
-00197773-s	slk:lemma	najvzdialenejší
-00449332-s	slk:lemma	okolitý
+00197773-a	slk:lemma	najvzdialenejší
+00449332-a	slk:lemma	okolitý
 00515414-n	slk:lemma	rozptýlenie
 00075021-v	slk:lemma	zničiť (niekoho)
-01947741-s	slk:lemma	kultúrny
+01947741-a	slk:lemma	kultúrny
 02298160-v	slk:lemma	predávať na trhu
-00590271-s	slk:lemma	netrpezlivý
+00590271-a	slk:lemma	netrpezlivý
 00908351-v	slk:lemma	vychovávať
 02681795-v	slk:lemma	udržiavať
 02764438-v	slk:lemma	žiariť
@@ -11604,7 +11604,7 @@
 07704656-n	slk:lemma	frumenty
 10512201-n	slk:lemma	zelenáč
 00283568-n	slk:lemma	chôdza
-01050088-s	slk:lemma	neblahý
+01050088-a	slk:lemma	neblahý
 03120491-n	slk:lemma	kurt
 01815628-v	slk:lemma	tešiť
 00240293-v	slk:lemma	zväčšiť
@@ -11628,17 +11628,17 @@
 05220461-n	slk:lemma	časť tela
 00644583-v	slk:lemma	preskúmať
 06760722-n	slk:lemma	niečo nekalé
-00022437-s	slk:lemma	presný
+00022437-a	slk:lemma	presný
 05817743-n	slk:lemma	situácia
-02403505-s	slk:lemma	napnutý
+02403505-a	slk:lemma	napnutý
 01131515-n	slk:lemma	zákonná povinnosť
 02199999-n	slk:lemma	komárovité
 01005063-a	slk:lemma	hotový
 01069578-n	slk:lemma	sebadisciplína
-01742119-s	slk:lemma	pokojný
+01742119-a	slk:lemma	pokojný
 13474290-n	slk:lemma	emisia
 02304507-v	slk:lemma	padnúť (do zajatia)
-01492907-s	slk:lemma	detský
+01492907-a	slk:lemma	detský
 00823750-n	slk:lemma	obrana
 00557686-v	slk:lemma	vyprať
 12143572-n	slk:lemma	rod Zea
@@ -11659,7 +11659,7 @@
 02151940-n	slk:lemma	krídlo
 02131279-v	slk:lemma	preveriť
 07548978-n	slk:lemma	neľúbosť
-00729133-s	slk:lemma	alternatívny
+00729133-a	slk:lemma	alternatívny
 04497962-n	slk:lemma	tunel
 01393714-v	slk:lemma	vyzametať
 03125792-a	slk:lemma	holičský
@@ -11697,11 +11697,11 @@
 00598954-v	slk:lemma	dopočuť sa
 09135447-n	slk:lemma	Erie
 02380745-n	slk:lemma	mustang
-01238914-s	slk:lemma	spiaci
+01238914-a	slk:lemma	spiaci
 03709363-n	slk:lemma	veľká fľaša
 06770275-n	slk:lemma	dohoda
 00120223-r	slk:lemma	súbežne
-00590669-s	slk:lemma	diskutabilný
+00590669-a	slk:lemma	diskutabilný
 08414040-n	slk:lemma	inšpektorát
 12289744-n	slk:lemma	rad Gentianales
 00305431-r	slk:lemma	nevedome
@@ -11717,12 +11717,12 @@
 00477941-v	slk:lemma	znečistiť
 10401829-n	slk:lemma	aktér
 00224168-v	slk:lemma	doznievať
-01731786-s	slk:lemma	súčasný
+01731786-a	slk:lemma	súčasný
 03223162-n	slk:lemma	zámok dverí
 00852181-n	slk:lemma	antikoncepcia
 03409591-n	slk:lemma	sedlová strecha
 06526619-n	slk:lemma	koncesia
-01917594-s	slk:lemma	podozrivý
+01917594-a	slk:lemma	podozrivý
 15230363-n	slk:lemma	večerná pobožnosť
 05832264-n	slk:lemma	obava
 01462005-v	slk:lemma	sceliť sa
@@ -11734,10 +11734,10 @@
 02262752-v	slk:lemma	predložiť
 02629390-v	slk:lemma	znemožňovať
 01774426-v	slk:lemma	mať odpor
-00554098-s	slk:lemma	v nezhode (s)
+00554098-a	slk:lemma	v nezhode (s)
 00210212-a	slk:lemma	bez trávy
 02225739-v	slk:lemma	šanovať
-01143006-s	slk:lemma	postupný
+01143006-a	slk:lemma	postupný
 02069551-v	slk:lemma	nalievať
 02405252-v	slk:lemma	odstavovať
 01828391-a	slk:lemma	motorový
@@ -11752,19 +11752,19 @@
 01501960-v	slk:lemma	postaviť
 14112855-n	slk:lemma	infarkt
 06729499-n	slk:lemma	vyhlásenie
-01876261-s	slk:lemma	pokročilý
+01876261-a	slk:lemma	pokročilý
 05752544-n	slk:lemma	učenie sa
 00335384-n	slk:lemma	sklon
 06427387-n	slk:lemma	encyklopédia
 00744305-n	slk:lemma	poškodenie
 09999532-n	slk:lemma	neplatič
-00418364-s	slk:lemma	nepoškvrnený
+00418364-a	slk:lemma	nepoškvrnený
 01093380-n	slk:lemma	konverzia
 02762169-n	slk:lemma	automatický pilot
 08326114-n	slk:lemma	občianská mravnostná polícia
 00020142-r	slk:lemma	ustavične
 04694441-n	slk:lemma	fľak
-01059711-s	slk:lemma	stály
+01059711-a	slk:lemma	stály
 04694809-n	slk:lemma	škvrna
 00257742-a	slk:lemma	ohraničený
 00921300-v	slk:lemma	indikovať
@@ -11806,7 +11806,7 @@
 02851099-n	slk:lemma	roleta
 12874429-n	slk:lemma	Pedaliaceae
 01387786-v	slk:lemma	stláčať
-01855086-s	slk:lemma	pomocný
+01855086-a	slk:lemma	pomocný
 00397576-v	slk:lemma	rozpadnúť sa
 08602650-n	slk:lemma	Big Bend
 05750657-n	slk:lemma	spôsob
@@ -11814,7 +11814,7 @@
 00326440-n	slk:lemma	pokles
 01144133-n	slk:lemma	plánovanie
 04620216-n	slk:lemma	charakter
-00860127-s	slk:lemma	experimentálny
+00860127-a	slk:lemma	experimentálny
 01976220-v	slk:lemma	zmáčať
 09070487-n	slk:lemma	District of Columbia
 01214265-v	slk:lemma	vziať si
@@ -11862,7 +11862,7 @@
 06652878-n	slk:lemma	rokovací poriadok parlamentu
 08739206-n	slk:lemma	Panamská republika
 00075021-v	slk:lemma	vyčerpávať sa
-02064127-s	slk:lemma	rovnaký
+02064127-a	slk:lemma	rovnaký
 00614999-v	slk:lemma	opomínať
 00876874-n	slk:lemma	percepcia pomocou zmyslov
 00538668-n	slk:lemma	mambo
@@ -11882,7 +11882,7 @@
 10409011-n	slk:lemma	človek bez prostriedkov
 00521209-n	slk:lemma	výstava
 13152742-n	slk:lemma	list
-01830599-s	slk:lemma	mocný
+01830599-a	slk:lemma	mocný
 00475819-v	slk:lemma	zbaviť viny
 01411085-v	slk:lemma	bičovať
 00479176-v	slk:lemma	pobíjať
@@ -11893,9 +11893,9 @@
 05268965-n	slk:lemma	tukový vankúšik
 02771564-v	slk:lemma	potopiť sa
 15055633-n	slk:lemma	ľahká hmla
-01735346-s	slk:lemma	matersky nežný
+01735346-a	slk:lemma	matersky nežný
 00196485-n	slk:lemma	zámena
-00070427-s	slk:lemma	zmyselný
+00070427-a	slk:lemma	zmyselný
 08987423-n	slk:lemma	Svätý Krištof a Nevis
 00730247-n	slk:lemma	pridelenie
 06600684-n	slk:lemma	exkurz
@@ -11928,23 +11928,23 @@
 07451687-n	slk:lemma	pohreb
 00898963-a	slk:lemma	tajný
 15249636-n	slk:lemma	pokolenie
-00666610-s	slk:lemma	aktuálny
+00666610-a	slk:lemma	aktuálny
 04218142-n	slk:lemma	pečať
 05245775-n	slk:lemma	uhor
 00021212-r	slk:lemma	raz začas
 00008007-r	slk:lemma	celkom
 01907076-v	slk:lemma	vyprevádzať
 05615028-n	slk:lemma	logika
-02446931-s	slk:lemma	chrumkavý
+02446931-a	slk:lemma	chrumkavý
 09777975-n	slk:lemma	agent
 00614224-n	slk:lemma	písanie
 01695259-n	slk:lemma	podtrieda Archosauria
 09165613-n	slk:lemma	Severná Rodézia
-02180277-s	slk:lemma	nefalšovaný
+02180277-a	slk:lemma	nefalšovaný
 02058794-a	slk:lemma	rizikový
 00151521-r	slk:lemma	o sto šesť
 07082198-n	slk:lemma	jazyk
-01695269-s	slk:lemma	zakrytý
+01695269-a	slk:lemma	zakrytý
 02707659-a	slk:lemma	kulinársky
 14473655-n	slk:lemma	spokojnosť
 03600806-n	slk:lemma	joint
@@ -11954,7 +11954,7 @@
 08892186-n	slk:lemma	Aberdeen
 00772253-n	slk:lemma	prejav exhibicionizmu
 00557686-v	slk:lemma	oprať
-00195684-s	slk:lemma	príšerný
+00195684-a	slk:lemma	príšerný
 04100174-n	slk:lemma	stojan
 02950711-a	slk:lemma	strategický
 00084759-r	slk:lemma	extra
@@ -11964,7 +11964,7 @@
 00459498-v	slk:lemma	švihnúť
 02062209-n	slk:lemma	rad Cetacea
 00794367-n	slk:lemma	test
-01710260-s	slk:lemma	voľný
+01710260-a	slk:lemma	voľný
 00075021-v	slk:lemma	opotrebúvať sa
 05830059-n	slk:lemma	ťažkosť
 03291741-n	slk:lemma	obal
@@ -11992,7 +11992,7 @@
 00855301-n	slk:lemma	vyfajčenie
 13903079-n	slk:lemma	kraj
 03674270-n	slk:lemma	dátové spojenie
-01474942-s	slk:lemma	ovládateľný
+01474942-a	slk:lemma	ovládateľný
 04665210-n	slk:lemma	neobozretnosť
 01041415-v	slk:lemma	kývať
 13662703-n	slk:lemma	menová podjednotka
@@ -12007,18 +12007,18 @@
 01775535-v	slk:lemma	ľúbiť
 09235244-n	slk:lemma	mys York
 04856308-n	slk:lemma	bezpečnosť
-01516346-s	slk:lemma	dotyčný
+01516346-a	slk:lemma	dotyčný
 01085237-v	slk:lemma	rozhodovať
 01826498-v	slk:lemma	dať prednosť
-00477661-s	slk:lemma	domácky
+00477661-a	slk:lemma	domácky
 04072193-n	slk:lemma	regulačné zariadenie
 02028366-v	slk:lemma	valiť sa
 01296154-v	slk:lemma	zašiť
 00415226-n	slk:lemma	podoba
-02547862-s	slk:lemma	pokrytý rosou
+02547862-a	slk:lemma	pokrytý rosou
 02711987-v	slk:lemma	spoliehať sa na
 08435388-n	slk:lemma	sústava
-01709437-s	slk:lemma	predplatený
+01709437-a	slk:lemma	predplatený
 00897564-v	slk:lemma	obracať sa na
 04487081-n	slk:lemma	trolejbus
 10623354-n	slk:lemma	volebný agitátor
@@ -12026,7 +12026,7 @@
 02375131-v	slk:lemma	angažovať sa
 09401474-n	slk:lemma	Pyreneje
 08174398-n	slk:lemma	NATO
-02071782-s	slk:lemma	príbuzný
+02071782-a	slk:lemma	príbuzný
 00984609-n	slk:lemma	rozviedka
 00463234-v	slk:lemma	krotiť
 14180327-n	slk:lemma	postihnutý svrabom
@@ -12037,7 +12037,7 @@
 04010205-n	slk:lemma	korzo
 07497797-n	slk:lemma	záľuba
 03407369-n	slk:lemma	bezpečnostná poistka
-02418412-s	slk:lemma	pravdepodobný
+02418412-a	slk:lemma	pravdepodobný
 12485653-n	slk:lemma	motýlí ker
 00818466-n	slk:lemma	opatrovanie
 07523180-n	slk:lemma	rezervovanosť
@@ -12050,7 +12050,7 @@
 00925735-v	slk:lemma	obdivovať (niečo)
 02336449-a	slk:lemma	nedostatočný
 01234345-n	slk:lemma	absencia
-01262284-s	slk:lemma	dobročinný
+01262284-a	slk:lemma	dobročinný
 00512186-v	slk:lemma	odpájať
 03452594-n	slk:lemma	skriňové hodiny
 06451891-n	slk:lemma	Pentateuch
@@ -12061,7 +12061,7 @@
 09209263-n	slk:lemma	Atlantický oceán
 02635659-v	slk:lemma	zanechať
 01568630-v	slk:lemma	zakryť
-00818008-s	slk:lemma	nový
+00818008-a	slk:lemma	nový
 01642924-v	slk:lemma	predložiť
 01025913-a	slk:lemma	nekompromisný
 01552519-v	slk:lemma	odstrihávať
@@ -12073,7 +12073,7 @@
 01934554-a	slk:lemma	nereálny
 05633385-n	slk:lemma	objav
 00206302-n	slk:lemma	vyhnanstvo
-01732601-s	slk:lemma	plánovaný
+01732601-a	slk:lemma	plánovaný
 02295550-v	slk:lemma	spoločne užiť
 01480149-v	slk:lemma	lapiť
 00648224-v	slk:lemma	prebádať
@@ -12081,23 +12081,23 @@
 00882802-v	slk:lemma	pamätať
 08906952-n	slk:lemma	Tibet
 07475364-n	slk:lemma	výprask
-01827946-s	slk:lemma	slabý
+01827946-a	slk:lemma	slabý
 08326383-n	slk:lemma	stály výbor
 04013729-n	slk:lemma	protetická pomôcka
 01578821-v	slk:lemma	naberať
 03149169-a	slk:lemma	do ruky
 01564144-v	slk:lemma	ruinovať
-01277097-s	slk:lemma	základný
+01277097-a	slk:lemma	základný
 00033421-r	slk:lemma	okamžite
-01626562-s	slk:lemma	ohavný
+01626562-a	slk:lemma	ohavný
 13023134-n	slk:lemma	vreckatá huba
-00818175-s	slk:lemma	primitívny
+00818175-a	slk:lemma	primitívny
 00223983-n	slk:lemma	krviprelievanie
 03177059-n	slk:lemma	odletová hala
 03712444-n	slk:lemma	hnacie pero
 09545976-n	slk:lemma	duch
 01322854-v	slk:lemma	zakáľať
-02449952-s	slk:lemma	jedovatý
+02449952-a	slk:lemma	jedovatý
 00586598-v	slk:lemma	zadržať
 02723016-v	slk:lemma	jedovať sa
 14668277-n	slk:lemma	bauxit
@@ -12135,12 +12135,12 @@
 07251984-n	slk:lemma	postup
 08738820-n	slk:lemma	Nikaragua
 02384041-v	slk:lemma	uviesť do úradu
-02369027-s	slk:lemma	trpký
+02369027-a	slk:lemma	trpký
 02838345-n	slk:lemma	lodná pumpa
 08081668-n	slk:lemma	viera
 09367827-n	slk:lemma	rieka Neckar
-01514141-s	slk:lemma	divoký
-01792573-s	slk:lemma	prostý
+01514141-a	slk:lemma	divoký
+01792573-a	slk:lemma	prostý
 02064887-v	slk:lemma	odkláňať
 09479635-n	slk:lemma	rieka Willamette
 02400037-v	slk:lemma	preferovať (niekoho pred niekým)
@@ -12153,21 +12153,21 @@
 02770211-n	slk:lemma	veranda
 02137132-v	slk:lemma	ukázať
 00868910-n	slk:lemma	počty
-02215382-s	slk:lemma	osobitný
+02215382-a	slk:lemma	osobitný
 02027612-v	slk:lemma	pchať sa
 02294179-v	slk:lemma	dostávať diel
 09181557-n	slk:lemma	zlozvyk
 05726596-n	slk:lemma	systém
 13133613-n	slk:lemma	klas
-00195684-s	slk:lemma	strašidelný
+00195684-a	slk:lemma	strašidelný
 01809064-v	slk:lemma	vyrážať dych
 00415676-n	slk:lemma	životná dráha
-01306645-s	slk:lemma	schopný
+01306645-a	slk:lemma	schopný
 00794981-v	slk:lemma	urobiť zoznam
 08709399-n	slk:lemma	Kajmanie ostrovy
 13790912-n	slk:lemma	podklad
 06856568-n	slk:lemma	hudobná škála
-00304144-s	slk:lemma	rozbúrený
+00304144-a	slk:lemma	rozbúrený
 10105733-n	slk:lemma	útočník
 13658828-n	slk:lemma	centimeter
 00800242-v	slk:lemma	odstupovať od (sľubu, zmluvy)
@@ -12184,7 +12184,7 @@
 13497135-n	slk:lemma	rast
 03015441-a	slk:lemma	keramický
 02283324-v	slk:lemma	ponechávať si
-00711308-s	slk:lemma	prísny
+00711308-a	slk:lemma	prísny
 05924519-n	slk:lemma	ideál
 00975781-n	slk:lemma	rýchly útok
 10842730-n	slk:lemma	Kardinál Bellarmine
@@ -12206,7 +12206,7 @@
 03387653-n	slk:lemma	lejáreň
 09848489-n	slk:lemma	veriaci
 01202068-v	slk:lemma	slopať
-00824509-s	slk:lemma	smerujúci na západ
+00824509-a	slk:lemma	smerujúci na západ
 05296775-n	slk:lemma	nervové tkanivo
 15275598-n	slk:lemma	spomalenie
 05798043-n	slk:lemma	pokus
@@ -12215,7 +12215,7 @@
 00843468-v	slk:lemma	obviňovať
 06686174-n	slk:lemma	garancia
 02976983-a	slk:lemma	kvantový
-00608791-s	slk:lemma	cudzí
+00608791-a	slk:lemma	cudzí
 00352826-v	slk:lemma	ukončiť
 00746587-n	slk:lemma	blasfémia
 01525776-a	slk:lemma	cestovný
@@ -12224,7 +12224,7 @@
 04530566-n	slk:lemma	loď
 05823932-n	slk:lemma	poznanie
 00635850-n	slk:lemma	skúmanie
-01899167-s	slk:lemma	rozvážny
+01899167-a	slk:lemma	rozvážny
 00992041-v	slk:lemma	gestikulovať
 00387310-v	slk:lemma	obrátiť sa
 00259177-n	slk:lemma	náprava
@@ -12233,7 +12233,7 @@
 05944958-n	slk:lemma	nádej
 00918471-v	slk:lemma	veštiť
 01807770-v	slk:lemma	lákať
-01572171-s	slk:lemma	odfarbený
+01572171-a	slk:lemma	odfarbený
 00209943-n	slk:lemma	zakončenie
 13945102-n	slk:lemma	úrad
 01876028-v	slk:lemma	ukolísať
@@ -12270,7 +12270,7 @@
 02566528-v	slk:lemma	prestúpiť
 09264116-n	slk:lemma	rieka Delaware
 10255096-n	slk:lemma	domáci
-01558641-s	slk:lemma	poháňaný
+01558641-a	slk:lemma	poháňaný
 00324384-n	slk:lemma	stúpanie
 02946507-a	slk:lemma	atlantický
 02004874-v	slk:lemma	vracať sa
@@ -12284,14 +12284,14 @@
 01072262-v	slk:lemma	súťažiť
 04691178-n	slk:lemma	deformácia
 01835496-v	slk:lemma	premiestňovať
-00748359-s	slk:lemma	seriózny
+00748359-a	slk:lemma	seriózny
 13508333-n	slk:lemma	lingvistický proces
 00297951-n	slk:lemma	hlboké brodenie
 13724582-n	slk:lemma	kilogram
 01015244-v	slk:lemma	dokladať
 08303504-n	slk:lemma	spolok
 02345048-v	slk:lemma	spustošiť
-00148852-s	slk:lemma	prefíkaný
+00148852-a	slk:lemma	prefíkaný
 06519253-n	slk:lemma	letenka
 00839834-v	slk:lemma	zveličovať
 13624190-n	slk:lemma	l
@@ -12305,7 +12305,7 @@
 04495555-n	slk:lemma	tudorovský oblúk
 09202810-n	slk:lemma	Araguaya
 04099429-n	slk:lemma	raketa
-01628531-s	slk:lemma	vulgárny
+01628531-a	slk:lemma	vulgárny
 13470491-n	slk:lemma	ubúdanie
 00221583-r	slk:lemma	všeobecne
 07260623-n	slk:lemma	štandard
@@ -12315,7 +12315,7 @@
 03142431-n	slk:lemma	krypta
 03057920-n	slk:lemma	ramienko na šaty
 01986483-a	slk:lemma	porovnateľný
-01300661-s	slk:lemma	disciplinárny
+01300661-a	slk:lemma	disciplinárny
 03538037-n	slk:lemma	kôň
 15165917-n	slk:lemma	poľudňajší
 04463679-n	slk:lemma	koľajnica
@@ -12332,8 +12332,8 @@
 00167920-r	slk:lemma	darmo
 08698379-n	slk:lemma	africká krajina
 09103943-n	slk:lemma	Mississippi
-00049016-s	slk:lemma	pomocný
-00710097-s	slk:lemma	odolný proti otrasom
+00049016-a	slk:lemma	pomocný
+00710097-a	slk:lemma	odolný proti otrasom
 00311057-r	slk:lemma	celkom
 08182716-n	slk:lemma	zástup
 00911562-v	slk:lemma	žialiť
@@ -12345,27 +12345,27 @@
 01647229-v	slk:lemma	vytvárať
 07344015-n	slk:lemma	západ slnka
 09168336-n	slk:lemma	Veľká austrálska púšť
-00194357-s	slk:lemma	hrozivý
+00194357-a	slk:lemma	hrozivý
 00008007-r	slk:lemma	vcelku
 02647497-v	slk:lemma	vydržať (dlho)
 01382086-a	slk:lemma	veľký
 08326114-n	slk:lemma	výbor bdelosti
-01038332-s	slk:lemma	domáci
+01038332-a	slk:lemma	domáci
 05093581-n	slk:lemma	dimenzia
-00202095-s	slk:lemma	obrátený
+00202095-a	slk:lemma	obrátený
 03307037-n	slk:lemma	predlžovacia šnúra
 01032892-n	slk:lemma	modlitebné stretnutie
-02075321-s	slk:lemma	labilný
+02075321-a	slk:lemma	labilný
 03508101-n	slk:lemma	bojler
 00059552-n	slk:lemma	manéver
 03352366-n	slk:lemma	nôž z rybieho príboru
 00899597-v	slk:lemma	zdraviť
 08756202-n	slk:lemma	Trinidad a Tobago
-02090567-s	slk:lemma	očividný
+02090567-a	slk:lemma	očividný
 07272084-n	slk:lemma	logo
 06782680-n	slk:lemma	dohad
-00974519-s	slk:lemma	ošumelý
-00978199-s	slk:lemma	rezký
+00974519-a	slk:lemma	ošumelý
+00978199-a	slk:lemma	rezký
 00859758-v	slk:lemma	pobaviť
 04694809-n	slk:lemma	fľak
 00758459-a	slk:lemma	diplomatický
@@ -12382,7 +12382,7 @@
 08063446-n	slk:lemma	obchodník
 00550341-n	slk:lemma	improvizácia
 03925226-n	slk:lemma	obrázok
-00329034-s	slk:lemma	rozčlenený
+00329034-a	slk:lemma	rozčlenený
 08103299-n	slk:lemma	podkmeň
 02651193-v	slk:lemma	žiť (s niekým)
 01673668-n	slk:lemma	podrad Sauria
@@ -12399,7 +12399,7 @@
 03015254-n	slk:lemma	na šaty
 01392237-v	slk:lemma	prechádzať
 00314835-r	slk:lemma	rovno
-00979031-s	slk:lemma	okamžitý
+00979031-a	slk:lemma	okamžitý
 08821578-n	slk:lemma	Prímorské provincie
 09795556-n	slk:lemma	rentier
 00844298-v	slk:lemma	žalovať sa
@@ -12416,14 +12416,14 @@
 05107765-n	slk:lemma	hodnota
 06632807-n	slk:lemma	príjemné popoludnie
 00100543-n	slk:lemma	podanie
-01779428-s	slk:lemma	osobný
+01779428-a	slk:lemma	osobný
 09698901-n	slk:lemma	Kubánka
 05190804-n	slk:lemma	moc
 02128120-n	slk:lemma	rod Panthera
 07203696-n	slk:lemma	kladná odpoveď
 00674607-v	slk:lemma	vybrať
 01196037-v	slk:lemma	zdržať sa
-00696996-s	slk:lemma	mierny
+00696996-a	slk:lemma	mierny
 05289057-n	slk:lemma	svalové tkanivo
 04188179-n	slk:lemma	prestieradlo
 02492362-v	slk:lemma	zašantiť
@@ -12435,7 +12435,7 @@
 13925752-n	slk:lemma	stav
 09848489-n	slk:lemma	zástanca
 00079951-v	slk:lemma	zavlažovať
-01878870-s	slk:lemma	slušný
+01878870-a	slk:lemma	slušný
 00531489-v	slk:lemma	ponížiť sa
 00897564-v	slk:lemma	adresovať
 13371030-n	slk:lemma	cennosť
@@ -12448,7 +12448,7 @@
 02889425-n	slk:lemma	brzda
 00002684-n	slk:lemma	predmet
 01655505-v	slk:lemma	vybudovať
-01689223-s	slk:lemma	otrepaný
+01689223-a	slk:lemma	otrepaný
 14498843-n	slk:lemma	nízkosť
 14849880-n	slk:lemma	pieskový papier
 00249300-r	slk:lemma	zvonka
@@ -12459,30 +12459,30 @@
 01463965-a	slk:lemma	oddaný
 00182406-v	slk:lemma	pridať
 08436452-n	slk:lemma	obchodík
-00517554-s	slk:lemma	polovičný
+00517554-a	slk:lemma	polovičný
 04285146-n	slk:lemma	športový výstroj
 07051728-n	slk:lemma	ľúbostná pieseň
 13328853-n	slk:lemma	odpis
-02396098-s	slk:lemma	horký
+02396098-a	slk:lemma	horký
 07237409-n	slk:lemma	obvinenie
 08252602-n	slk:lemma	večierok
 03077419-a	slk:lemma	novinársky
 02162947-v	slk:lemma	zalesknúť sa
-02035086-s	slk:lemma	morálny
+02035086-a	slk:lemma	morálny
 05724234-n	slk:lemma	schopnosť lokalizovať pocit
-00893118-s	slk:lemma	pomerne istý
+00893118-a	slk:lemma	pomerne istý
 00402308-n	slk:lemma	metamorfóza
 02078399-a	slk:lemma	neukojiteľný
 07185870-n	slk:lemma	želanie
-02323358-s	slk:lemma	posilnený
+02323358-a	slk:lemma	posilnený
 01095218-v	slk:lemma	vykonať službu
 02090435-v	slk:lemma	krútiť sa (v tanci, do klbka)
 13371958-n	slk:lemma	diamant
 05338614-n	slk:lemma	pažná tepna
-00950119-s	slk:lemma	satelitný
+00950119-a	slk:lemma	satelitný
 02679530-v	slk:lemma	naťahovať
 02727462-v	slk:lemma	ostať
-02471984-s	slk:lemma	podzemný
+02471984-a	slk:lemma	podzemný
 08378819-n	slk:lemma	spoločenský systém
 01523654-v	slk:lemma	odvinúť
 14406303-n	slk:lemma	panika
@@ -12494,7 +12494,7 @@
 01686132-v	slk:lemma	znázorniť
 04795545-n	slk:lemma	bežnosť
 06269956-n	slk:lemma	vedecká štúdia
-00015720-s	slk:lemma	veľmi hojný
+00015720-a	slk:lemma	veľmi hojný
 03711459-n	slk:lemma	hlavná paluba
 00888786-v	slk:lemma	uzatvárať zmluvu
 00675701-a	slk:lemma	kruhový
@@ -12503,17 +12503,17 @@
 02690708-v	slk:lemma	ležať
 08596076-n	slk:lemma	pobrežie
 13976322-n	slk:lemma	chaos
-01735346-s	slk:lemma	matersky láskavý
+01735346-a	slk:lemma	matersky láskavý
 00016702-v	slk:lemma	kývať
 05091770-n	slk:lemma	šanca
 06889330-n	slk:lemma	pompéznosť
 00015388-n	slk:lemma	živočích
 09286478-n	slk:lemma	záliv Galway
-01673946-s	slk:lemma	bežný
+01673946-a	slk:lemma	bežný
 01056236-n	slk:lemma	navštevovanie
 09145851-n	slk:lemma	Plano
 05031560-n	slk:lemma	svalnatosť
-01141468-s	slk:lemma	neľahký
+01141468-a	slk:lemma	neľahký
 01733661-a	slk:lemma	doteraz nenarodený
 02630189-v	slk:lemma	mať
 14407536-n	slk:lemma	čaro
@@ -12522,10 +12522,10 @@
 03104594-n	slk:lemma	odtlačok
 04179271-n	slk:lemma	kanalizačné potrubie
 00206479-r	slk:lemma	v rýchlosti
-01950711-s	slk:lemma	neotesaný
+01950711-a	slk:lemma	neotesaný
 02063018-v	slk:lemma	nakloniť sa
 05196375-n	slk:lemma	kontrola
-00026168-s	slk:lemma	základný
+00026168-a	slk:lemma	základný
 06768735-n	slk:lemma	nesprávny údaj
 15281176-n	slk:lemma	miera návratnosti
 12352639-n	slk:lemma	trpasličí banán
@@ -12546,27 +12546,27 @@
 06500937-n	slk:lemma	cestovný pas
 01144876-n	slk:lemma	vedenie
 05475681-n	slk:lemma	zväzok
-00128733-s	slk:lemma	jedinečný
+00128733-a	slk:lemma	jedinečný
 05317354-n	slk:lemma	očná rohovka
 02768864-n	slk:lemma	kulisa
 06447039-n	slk:lemma	Druhý Petrov list
-02412880-s	slk:lemma	vlásočnicový
+02412880-a	slk:lemma	vlásočnicový
 14052046-n	slk:lemma	podlomené zdravie
 13948766-n	slk:lemma	postavenie hviezdy
 00193406-n	slk:lemma	adaptácia
-01764895-s	slk:lemma	preventívny
+01764895-a	slk:lemma	preventívny
 04187061-n	slk:lemma	puzdro
-02372118-s	slk:lemma	bilaterálne symetrický
+02372118-a	slk:lemma	bilaterálne symetrický
 02477755-v	slk:lemma	zrušiť
 00622384-v	slk:lemma	ohromovať
 00508032-v	slk:lemma	označiť
 00872107-n	slk:lemma	pripočítavanie
-01732601-s	slk:lemma	nastávajúci
+01732601-a	slk:lemma	nastávajúci
 05105265-n	slk:lemma	priestrannosť
 06865345-n	slk:lemma	hudobná nota
 00150287-v	slk:lemma	prispôsobovať
 02579447-v	slk:lemma	skaziť (morálne)
-01592262-s	slk:lemma	kráľovnin
+01592262-a	slk:lemma	kráľovnin
 02621395-v	slk:lemma	pozostávať
 10388440-n	slk:lemma	najvyšší vládca
 08889191-n	slk:lemma	Dublin
@@ -12598,11 +12598,11 @@
 03117939-n	slk:lemma	druhopis
 02038357-v	slk:lemma	nakláňať sa
 02753724-a	slk:lemma	právnický
-01755024-s	slk:lemma	trvalý
+01755024-a	slk:lemma	trvalý
 00966152-v	slk:lemma	ubytovať sa
 02443849-v	slk:lemma	uviesť do činnosti
 08327390-n	slk:lemma	predsedníctvo
-00567161-s	slk:lemma	spätý
+00567161-a	slk:lemma	spätý
 00085219-n	slk:lemma	zhabanie
 00140967-v	slk:lemma	zdeformovať
 08565006-n	slk:lemma	Rustbelt
@@ -12620,7 +12620,7 @@
 02711846-a	slk:lemma	priemerný
 05123416-n	slk:lemma	objem
 02620587-v	slk:lemma	znamenať
-00179190-s	slk:lemma	blahoslavený
+00179190-a	slk:lemma	blahoslavený
 01083645-n	slk:lemma	určenie
 07903208-n	slk:lemma	brandy
 01651293-v	slk:lemma	ísť na vec
@@ -12644,7 +12644,7 @@
 00806502-v	slk:lemma	schváliť
 09614315-n	slk:lemma	tvorca
 07959016-n	slk:lemma	celkový súčet
-01892506-s	slk:lemma	hrdý na
+01892506-a	slk:lemma	hrdý na
 01577093-v	slk:lemma	namočiť sa
 00041188-n	slk:lemma	hranie
 07355887-n	slk:lemma	úbytok
@@ -12652,7 +12652,7 @@
 02133902-n	slk:lemma	rod Thalarctos
 01470496-a	slk:lemma	zemepisný
 02419773-v	slk:lemma	drieť sa
-02081114-s	slk:lemma	v poriadku
+02081114-a	slk:lemma	v poriadku
 00095320-r	slk:lemma	zhora dole
 03933529-n	slk:lemma	prístavisko
 00387666-r	slk:lemma	naľavo
@@ -12660,17 +12660,17 @@
 13411005-n	slk:lemma	kontrolná bilancia
 00158996-n	slk:lemma	mesmerizmus
 02672859-v	slk:lemma	kompenzovať si
-01320474-s	slk:lemma	očistený od obvinenia
-02406370-s	slk:lemma	popudlivý
+01320474-a	slk:lemma	očistený od obvinenia
+02406370-a	slk:lemma	popudlivý
 00430140-n	slk:lemma	hra o peniaze
 01067070-n	slk:lemma	preloženie
 01364008-a	slk:lemma	smutný
 00142665-n	slk:lemma	porovnanie
-01916784-s	slk:lemma	sporný
+01916784-a	slk:lemma	sporný
 00718924-a	slk:lemma	nezávislý
 11439690-n	slk:lemma	oblak
 00510364-v	slk:lemma	urobiť škvrny
-02044860-s	slk:lemma	kruhový
+02044860-a	slk:lemma	kruhový
 00475647-v	slk:lemma	urobiť čistky
 04871720-n	slk:lemma	otvorenosť
 00779248-n	slk:lemma	trik, predajný
@@ -12706,19 +12706,19 @@
 02172683-v	slk:lemma	zacinkať
 02733782-a	slk:lemma	tvoriaci rozmnožovacie puky
 02693070-n	slk:lemma	núdzové letisko
-01266092-s	slk:lemma	suchý
+01266092-a	slk:lemma	suchý
 03740161-n	slk:lemma	medikácia
-01552802-s	slk:lemma	hŕba
+01552802-a	slk:lemma	hŕba
 01237901-v	slk:lemma	netrafiť sa
-01441000-s	slk:lemma	dlhoročný
+01441000-a	slk:lemma	dlhoročný
 01960911-v	slk:lemma	doplávať
-00168910-s	slk:lemma	príťažlivý
+00168910-a	slk:lemma	príťažlivý
 10468962-n	slk:lemma	predsedníčka
 00356954-v	slk:lemma	pokriviť sa
 10258602-n	slk:lemma	poskytovateľ licencie
 00514463-v	slk:lemma	zvýrazniť
 09345127-n	slk:lemma	rieka Madeira
-01625063-s	slk:lemma	nechutný
+01625063-a	slk:lemma	nechutný
 08078020-n	slk:lemma	domácnosť
 08550364-n	slk:lemma	opátstvo
 01843055-v	slk:lemma	byť na vychádzke
@@ -12743,8 +12743,8 @@
 01698271-v	slk:lemma	napísať
 15300051-n	slk:lemma	11. september
 14686913-n	slk:lemma	benzín
-01466775-s	slk:lemma	frigidný
-02164913-s	slk:lemma	chatrný
+01466775-a	slk:lemma	frigidný
+02164913-a	slk:lemma	chatrný
 01064062-v	slk:lemma	podceňovať
 13954818-n	slk:lemma	aktualita
 00167447-r	slk:lemma	napokon
@@ -12788,10 +12788,10 @@
 00031068-v	slk:lemma	postihovať kŕčmi
 02781764-n	slk:lemma	balistokardiograf
 09461170-n	slk:lemma	lesná farma
-02071782-s	slk:lemma	podobný
+02071782-a	slk:lemma	podobný
 00815686-v	slk:lemma	odpovedať
 04665210-n	slk:lemma	neopatrnosť
-02401288-s	slk:lemma	oslobodený od dane
+02401288-a	slk:lemma	oslobodený od dane
 01038666-v	slk:lemma	porozprávať sa
 00632627-v	slk:lemma	uvažovať
 14178913-n	slk:lemma	protozoálna infekcia
@@ -12800,9 +12800,9 @@
 05692419-n	slk:lemma	kauzálny faktor
 06269956-n	slk:lemma	štúdia
 02292004-v	slk:lemma	oplatiť sa
-01466476-s	slk:lemma	manželke oddaný
+01466476-a	slk:lemma	manželke oddaný
 00783199-n	slk:lemma	únos (dopravného prostriedku)
-01153595-s	slk:lemma	bavlnovitý
+01153595-a	slk:lemma	bavlnovitý
 01173038-n	slk:lemma	rana
 05933638-n	slk:lemma	zorné pole
 00057042-r	slk:lemma	nijako
@@ -12832,11 +12832,11 @@
 13983515-n	slk:lemma	temno
 00694578-n	slk:lemma	operácia rázštepu podnebia
 00897746-v	slk:lemma	pýtať sa
-02229584-s	slk:lemma	hrubý
+02229584-a	slk:lemma	hrubý
 02228698-v	slk:lemma	vykázať
 09144117-n	slk:lemma	El Paso
 02281093-v	slk:lemma	robiť si zásoby
-02070342-s	slk:lemma	rozdielny
+02070342-a	slk:lemma	rozdielny
 04925218-n	slk:lemma	mentálny vek
 03665924-n	slk:lemma	žiarovka
 02350105-n	slk:lemma	púštny potkan
@@ -12846,7 +12846,7 @@
 05757536-n	slk:lemma	škola
 01886220-n	slk:lemma	podtrieda Eutheria
 00499924-n	slk:lemma	gulečník
-01181446-s	slk:lemma	svetský
+01181446-a	slk:lemma	svetský
 01424456-v	slk:lemma	objať sa
 09613191-n	slk:lemma	súťažiaci
 09410724-n	slk:lemma	Rio Bravo
@@ -12860,39 +12860,39 @@
 00278810-n	slk:lemma	žuvanie
 00394803-n	slk:lemma	ochudobnenie
 02296726-v	slk:lemma	ponúknuť
-00219389-s	slk:lemma	znamenitý
+00219389-a	slk:lemma	znamenitý
 06445729-n	slk:lemma	Druhý list apoštola Pavla Timotejovi
 03528263-n	slk:lemma	spotrebič do domácnosti
 00043078-v	slk:lemma	naparádiť
-01628531-s	slk:lemma	hanlivý
+01628531-a	slk:lemma	hanlivý
 01857392-v	slk:lemma	zostať
 08083320-n	slk:lemma	katolícka Cirkev
-01579128-s	slk:lemma	konečný
+01579128-a	slk:lemma	konečný
 01886728-v	slk:lemma	schádzať bez motora
 00847340-n	slk:lemma	rozmnožovanie
-00070111-s	slk:lemma	kozmetický
+00070111-a	slk:lemma	kozmetický
 00346693-n	slk:lemma	obrátenie
 02130524-v	slk:lemma	kukať sa
 13863186-n	slk:lemma	dvojdimenzionálny obrazec
 06428792-n	slk:lemma	prepracovanie
 10462860-n	slk:lemma	praktik
-00011327-s	slk:lemma	prízemný
+00011327-a	slk:lemma	prízemný
 01317541-n	slk:lemma	domáce zviera
 03511175-n	slk:lemma	plot
 08648322-n	slk:lemma	oblasť
 04060904-n	slk:lemma	kontajner
 00365668-r	slk:lemma	nápadne
 00990655-v	slk:lemma	oslovovať (niekoho)
-02065958-s	slk:lemma	opačný
+02065958-a	slk:lemma	opačný
 07233863-n	slk:lemma	kliatba
 00272844-r	slk:lemma	krížom
 14145095-n	slk:lemma	respiračná choroba
 02248349-a	slk:lemma	sociálny
-01865807-s	slk:lemma	kultivovateľný
-00228294-s	slk:lemma	prvý
+01865807-a	slk:lemma	kultivovateľný
+00228294-a	slk:lemma	prvý
 00641252-v	slk:lemma	odčítať
 02638960-n	slk:lemma	rod Amia
-00848466-s	slk:lemma	obligátny
+00848466-a	slk:lemma	obligátny
 02691156-n	slk:lemma	letúň
 00009147-v	slk:lemma	zhadzovať (parohy)
 00211462-n	slk:lemma	finalizácia
@@ -12908,14 +12908,14 @@
 14252864-n	slk:lemma	ochorenie oka
 13149506-n	slk:lemma	biele korenie
 14180565-n	slk:lemma	bilharzia
-01677200-s	slk:lemma	hrozný
+01677200-a	slk:lemma	hrozný
 03395859-n	slk:lemma	Fresnelova šošovka
 02563327-v	slk:lemma	vykonať
 02745453-a	slk:lemma	ideografický
 00724081-a	slk:lemma	dôveryhodný
 02760429-n	slk:lemma	automatická zbraň
 00240184-n	slk:lemma	zavádzanie
-01523724-s	slk:lemma	schopný prevozu
+01523724-a	slk:lemma	schopný prevozu
 01167146-n	slk:lemma	poslušnosť
 01577093-v	slk:lemma	spúšťať
 06365467-n	slk:lemma	čítanie
@@ -12944,7 +12944,7 @@
 00545501-n	slk:lemma	spievanie
 06143454-n	slk:lemma	veda o štátnej a miestnej verejnej správe
 00048475-r	slk:lemma	v dnešných časoch
-00823556-s	slk:lemma	smerujúci na východ
+00823556-a	slk:lemma	smerujúci na východ
 04654337-n	slk:lemma	priateľskosť
 08602822-n	slk:lemma	Národný park Big Bend
 00029367-r	slk:lemma	a čo viac
@@ -12956,33 +12956,33 @@
 05510506-n	slk:lemma	horné dýchacie cesty
 00962447-v	slk:lemma	rozprávať
 03002816-n	slk:lemma	koliba
-02515001-s	slk:lemma	skazený
+02515001-a	slk:lemma	skazený
 01556921-v	slk:lemma	odštiepiť sa
 02712443-v	slk:lemma	predchádzať
 02660442-v	slk:lemma	zhodovať sa
 02430580-v	slk:lemma	dištancovať sa
-01591699-s	slk:lemma	kráľovský
+01591699-a	slk:lemma	kráľovský
 02725286-v	slk:lemma	uviaznuť
 05058580-n	slk:lemma	tempo
 13735355-n	slk:lemma	spoločný násobok
-01266092-s	slk:lemma	posmešný
+01266092-a	slk:lemma	posmešný
 10011902-n	slk:lemma	diktátor
 06802571-n	slk:lemma	posol
 00682592-v	slk:lemma	prehodnocovať
 05710860-n	slk:lemma	zrakový vnem
 09167767-n	slk:lemma	Veľká Arabská púšť
-00719328-s	slk:lemma	absolútny
+00719328-a	slk:lemma	absolútny
 00219012-n	slk:lemma	vražda
 10091651-n	slk:lemma	hasič
 00831191-n	slk:lemma	respirácia
-00858558-s	slk:lemma	pevný
+00858558-a	slk:lemma	pevný
 01105639-v	slk:lemma	vyniknúť nad
 02267529-v	slk:lemma	utrácať
-01723648-s	slk:lemma	nezaujatý
+01723648-a	slk:lemma	nezaujatý
 01114055-n	slk:lemma	obchod s narkotikami
 01523986-v	slk:lemma	stočiť
 09749142-n	slk:lemma	obyvateľ Glasgowa
-02327315-s	slk:lemma	škriepny
+02327315-a	slk:lemma	škriepny
 14036539-n	slk:lemma	hnev
 01853310-v	slk:lemma	napumpovať
 01229938-n	slk:lemma	zhromaždenie
@@ -12999,9 +12999,9 @@
 04610368-n	slk:lemma	Yale
 00069918-n	slk:lemma	porušenie poručníctva
 00319939-n	slk:lemma	nasledovať
-02378347-s	slk:lemma	koexistenčný
+02378347-a	slk:lemma	koexistenčný
 04867871-n	slk:lemma	pokryteckosť
-01154030-s	slk:lemma	páperový
+01154030-a	slk:lemma	páperový
 04188643-n	slk:lemma	plát
 14474435-n	slk:lemma	milosť
 00119568-n	slk:lemma	skok
@@ -13036,8 +13036,8 @@
 01326015-n	slk:lemma	hrebienok
 08664443-n	slk:lemma	miesto
 08388636-n	slk:lemma	pairovia
-01564315-s	slk:lemma	bez pohybu
-00656507-s	slk:lemma	kľúčový
+01564315-a	slk:lemma	bez pohybu
+00656507-a	slk:lemma	kľúčový
 00071321-r	slk:lemma	neďaleko
 01873294-v	slk:lemma	odtláčať
 00071165-r	slk:lemma	naokolo
@@ -13048,12 +13048,12 @@
 02624263-v	slk:lemma	vzniknúť
 00022903-n	slk:lemma	výrobok
 00257269-v	slk:lemma	rozširovať sa
-01640482-s	slk:lemma	použitý
+01640482-a	slk:lemma	použitý
 02035919-v	slk:lemma	zahýnať
 06599788-n	slk:lemma	predmet
 04080454-n	slk:lemma	rezonančná dutina
 01856211-v	slk:lemma	vysťahovať sa
-00418364-s	slk:lemma	bez škvŕn
+00418364-a	slk:lemma	bez škvŕn
 00423471-r	slk:lemma	priamo
 10000945-n	slk:lemma	previnilec
 00540211-n	slk:lemma	škótsky tanec reel
@@ -13069,7 +13069,7 @@
 00877327-v	slk:lemma	prebádať
 00054821-n	slk:lemma	vysťahovanie
 00365471-n	slk:lemma	zmenšenie
-01165943-s	slk:lemma	nápravný
+01165943-a	slk:lemma	nápravný
 04550546-n	slk:lemma	kostýmy
 00651991-v	slk:lemma	rozlišovať
 00047317-v	slk:lemma	skúšať
@@ -13086,8 +13086,8 @@
 02540670-v	slk:lemma	obslúžiť
 00210768-r	slk:lemma	obyčajne
 01150981-v	slk:lemma	adresovať
-00310433-s	slk:lemma	podrobný
-01774483-s	slk:lemma	nepremastiteľný
+00310433-a	slk:lemma	podrobný
+01774483-a	slk:lemma	nepremastiteľný
 00712708-v	slk:lemma	počítať s niekým/niečím
 00032863-r	slk:lemma	odteraz
 02464626-n	slk:lemma	zadná noha
@@ -13101,7 +13101,7 @@
 00497129-r	slk:lemma	po zásluhe
 00037919-v	slk:lemma	okúpať sa
 06513366-n	slk:lemma	petícia
-01266092-s	slk:lemma	ironický
+01266092-a	slk:lemma	ironický
 14706889-n	slk:lemma	adenín
 00240184-n	slk:lemma	založenie
 00354183-n	slk:lemma	umŕtvovanie
@@ -13112,7 +13112,7 @@
 02324587-n	slk:lemma	zajačik
 00884011-v	slk:lemma	sľubovať
 13810818-n	slk:lemma	zvyšok
-01115635-s	slk:lemma	pravý
+01115635-a	slk:lemma	pravý
 02611630-v	slk:lemma	určovať
 11449002-n	slk:lemma	jav
 00367066-n	slk:lemma	vystupňovanie
@@ -13133,22 +13133,22 @@
 11462526-n	slk:lemma	vietor
 01210737-v	slk:lemma	narábať s niečím
 07456188-n	slk:lemma	súťaž
-00545746-s	slk:lemma	ľahostajný
+00545746-a	slk:lemma	ľahostajný
 02469835-v	slk:lemma	spojiť sa
-02372118-s	slk:lemma	bilaterálny
+02372118-a	slk:lemma	bilaterálny
 08724545-n	slk:lemma	Turkistán
-00431004-s	slk:lemma	nejasný
+00431004-a	slk:lemma	nejasný
 00652466-n	slk:lemma	sledovanie
 04980008-n	slk:lemma	vôňa
 10254392-n	slk:lemma	ten, kto požičiava peniaze
-01568684-s	slk:lemma	celosvetový
+01568684-a	slk:lemma	celosvetový
 00262881-v	slk:lemma	znehodnotiť
 14648100-n	slk:lemma	kyslík
 09044862-n	slk:lemma	Spojené americké štáty
 14541852-n	slk:lemma	nebezpečenstvo
-01610484-s	slk:lemma	objavený
-00789494-s	slk:lemma	mierny
-00487198-s	slk:lemma	spoločenský
+01610484-a	slk:lemma	objavený
+00789494-a	slk:lemma	mierny
+00487198-a	slk:lemma	spoločenský
 00208210-v	slk:lemma	pohoršiť
 01113068-n	slk:lemma	obchodovanie
 06492939-n	slk:lemma	denné menu
@@ -13161,10 +13161,10 @@
 02676261-n	slk:lemma	nástroj
 01108627-v	slk:lemma	premôcť
 13863186-n	slk:lemma	rovinný obrazec
-01870636-s	slk:lemma	neodborný
+01870636-a	slk:lemma	neodborný
 00454237-n	slk:lemma	rybárčenie
-01662119-s	slk:lemma	nevhodný
-01439155-s	slk:lemma	rozvláčny
+01662119-a	slk:lemma	nevhodný
+01439155-a	slk:lemma	rozvláčny
 13546169-n	slk:lemma	racionalizácia
 01313093-n	slk:lemma	Živočíchy
 01617192-v	slk:lemma	urobiť
@@ -13182,7 +13182,7 @@
 07486628-n	slk:lemma	baženie
 00946105-v	slk:lemma	vyčísliť
 02578510-v	slk:lemma	zachovať
-02123007-s	slk:lemma	hravý ako mačiatko
+02123007-a	slk:lemma	hravý ako mačiatko
 07324673-n	slk:lemma	rozmach
 00225410-r	slk:lemma	prísne
 01134781-v	slk:lemma	odstreliť
@@ -13211,7 +13211,7 @@
 14440137-n	slk:lemma	nemilosť
 13532196-n	slk:lemma	paralelná operácia
 00338817-a	slk:lemma	sebavedomý
-01784401-s	slk:lemma	pohanský
+01784401-a	slk:lemma	pohanský
 05098520-n	slk:lemma	úroveň signálu
 01462005-v	slk:lemma	zlučovať sa
 00167447-r	slk:lemma	nakoniec
@@ -13233,7 +13233,7 @@
 05690269-n	slk:lemma	prekážka
 05733583-n	slk:lemma	hodnotenie
 02586619-v	slk:lemma	nariadiť
-02218314-s	slk:lemma	rozličný
+02218314-a	slk:lemma	rozličný
 07387509-n	slk:lemma	zvuk
 01825237-v	slk:lemma	želať si
 03956331-n	slk:lemma	satelit
@@ -13252,7 +13252,7 @@
 02536557-v	slk:lemma	vplývať (na)
 05126228-n	slk:lemma	pokra
 00313502-n	slk:lemma	kozmický let
-01552802-s	slk:lemma	kopa
+01552802-a	slk:lemma	kopa
 00328230-n	slk:lemma	opätovný vstup
 01412346-v	slk:lemma	porážať
 00311687-n	slk:lemma	pútna cesta
@@ -13266,7 +13266,7 @@
 00077950-v	slk:lemma	dusiť
 01140658-n	slk:lemma	mandát
 10207681-n	slk:lemma	hospitalizovaný pacient
-01649651-s	slk:lemma	pomerne mladý
+01649651-a	slk:lemma	pomerne mladý
 05458576-n	slk:lemma	materská vaječná bunka
 00808191-a	slk:lemma	dynamický
 14493716-n	slk:lemma	chudoba
@@ -13277,8 +13277,8 @@
 01124794-n	slk:lemma	vládnutie
 00064643-v	slk:lemma	raniť
 02297409-v	slk:lemma	ponúknuť
-00135455-s	slk:lemma	správny
-00874226-s	slk:lemma	rezký
+00135455-a	slk:lemma	správny
+00874226-a	slk:lemma	rezký
 02148788-v	slk:lemma	odprezentovať
 07709333-n	slk:lemma	listová zelenina
 05332569-n	slk:lemma	detská žľaza
@@ -13342,7 +13342,7 @@
 00346693-n	slk:lemma	zmena smeru
 02394822-n	slk:lemma	čeľaď sviňovité
 01168569-n	slk:lemma	súťaž
-01136248-s	slk:lemma	mrzutý
+01136248-a	slk:lemma	mrzutý
 09255207-n	slk:lemma	šelf
 06788785-n	slk:lemma	predpis
 02873839-n	slk:lemma	kiosk
@@ -13351,18 +13351,18 @@
 02294436-v	slk:lemma	rozdať
 00168237-n	slk:lemma	taktický manéver
 15281329-n	slk:lemma	návratnosť investície
-00669942-s	slk:lemma	čertovský
-02057226-s	slk:lemma	svetský
+00669942-a	slk:lemma	čertovský
+02057226-a	slk:lemma	svetský
 05840188-n	slk:lemma	odroda
-00847715-s	slk:lemma	bezplatný
+00847715-a	slk:lemma	bezplatný
 01338663-v	slk:lemma	pokrývať dlaždicami
 10383816-n	slk:lemma	tvorca
 04304375-n	slk:lemma	elektrický spúšťač
-01038580-s	slk:lemma	samosprávny
-01390588-s	slk:lemma	super
+01038580-a	slk:lemma	samosprávny
+01390588-a	slk:lemma	super
 02219442-v	slk:lemma	uživiť (niekoho)
 01899708-v	slk:lemma	pohnúť sa
-02331857-s	slk:lemma	prekvitajúci
+02331857-a	slk:lemma	prekvitajúci
 05580416-n	slk:lemma	kladkový kĺb
 09254614-n	slk:lemma	svetadiel
 03049326-n	slk:lemma	cyklus, uzavretý
@@ -13372,7 +13372,7 @@
 06532095-n	slk:lemma	listina
 01069809-v	slk:lemma	požiadať
 02299801-v	slk:lemma	prekonávať koho
-00936297-s	slk:lemma	starší
+00936297-a	slk:lemma	starší
 05638987-n	slk:lemma	zručnosť
 09265134-n	slk:lemma	rieka Demerara
 04713428-n	slk:lemma	korešpondencia
@@ -13382,7 +13382,7 @@
 02681795-v	slk:lemma	držať
 13902482-n	slk:lemma	špička
 00102457-n	slk:lemma	automatizácia
-01991166-s	slk:lemma	zaťatý
+01991166-a	slk:lemma	zaťatý
 02539686-v	slk:lemma	prevziať povinnosť
 02670890-v	slk:lemma	zastávať
 07385803-n	slk:lemma	ruch
@@ -13391,15 +13391,15 @@
 13771404-n	slk:lemma	troška
 00341757-v	slk:lemma	natiahnuť sa
 07098193-n	slk:lemma	rétorický prostriedok
-00136589-s	slk:lemma	splatný na požiadanie pred splatnosťou
+00136589-a	slk:lemma	splatný na požiadanie pred splatnosťou
 07938773-n	slk:lemma	usporiadanie
 00151689-v	slk:lemma	znížiť
 04315948-n	slk:lemma	systém stereo
 02247977-v	slk:lemma	znovu získať
 01871949-a	slk:lemma	nevýnosný
 02579447-v	slk:lemma	znemravňovať
-00953886-s	slk:lemma	oku podobný
-02450512-s	slk:lemma	jedovatý
+00953886-a	slk:lemma	oku podobný
+02450512-a	slk:lemma	jedovatý
 14135956-n	slk:lemma	horúčka Lassa
 00034710-a	slk:lemma	činný
 00610374-v	slk:lemma	rozpoznávať
@@ -13409,14 +13409,14 @@
 07062315-n	slk:lemma	kovbojská hudba
 06845599-n	slk:lemma	obchodný názov
 02018049-v	slk:lemma	nasadnúť
-01042703-s	slk:lemma	slávnostný
+01042703-a	slk:lemma	slávnostný
 13597585-n	slk:lemma	základ
 15270245-n	slk:lemma	čas
 04446276-n	slk:lemma	toaleta
 11952900-n	slk:lemma	Cichorium
 00511041-n	slk:lemma	pijatika
 02729414-v	slk:lemma	ponechávať
-01440889-s	slk:lemma	perspektívny
+01440889-a	slk:lemma	perspektívny
 10305802-n	slk:lemma	lekár
 08350470-n	slk:lemma	Federálny rezervný systém
 02339171-v	slk:lemma	poskytovať
@@ -13433,7 +13433,7 @@
 09466280-n	slk:lemma	svet
 00820976-v	slk:lemma	potvrdiť
 14441610-n	slk:lemma	hanba
-01948958-s	slk:lemma	jemnučký
+01948958-a	slk:lemma	jemnučký
 03322099-n	slk:lemma	statok
 00388392-n	slk:lemma	rozvetvenie
 04878861-n	slk:lemma	zrada
@@ -13453,7 +13453,7 @@
 02659763-v	slk:lemma	hodiť sa
 09749142-n	slk:lemma	Glasgowan
 07661583-n	slk:lemma	plece
-00453308-s	slk:lemma	blízky
+00453308-a	slk:lemma	blízky
 00888786-v	slk:lemma	zaviazať sa
 02689274-n	slk:lemma	vzduchovka
 02478701-v	slk:lemma	uvádzať do platnosti
@@ -13470,12 +13470,12 @@
 02916350-n	slk:lemma	náboj
 10315837-n	slk:lemma	militant
 06727758-n	slk:lemma	Listina práv
-01977669-s	slk:lemma	pripomínajúci
+01977669-a	slk:lemma	pripomínajúci
 07522729-n	slk:lemma	ostýchavosť
 01481612-a	slk:lemma	vydatá
 15242955-n	slk:lemma	dlhá doba
 02167875-v	slk:lemma	pozerať sa na
-01603869-s	slk:lemma	juhozápadný
+01603869-a	slk:lemma	juhozápadný
 00104990-r	slk:lemma	pomaly
 00428270-n	slk:lemma	tanec
 00475183-v	slk:lemma	destilovať
@@ -13483,7 +13483,7 @@
 13607985-n	slk:lemma	jednotka tlaku
 04433185-n	slk:lemma	reťaz
 10476671-n	slk:lemma	detektív
-01840121-s	slk:lemma	pokročilý
+01840121-a	slk:lemma	pokročilý
 01858094-a	slk:lemma	privátny
 02699941-v	slk:lemma	patriť
 00363463-r	slk:lemma	správne
@@ -13497,7 +13497,7 @@
 00126264-v	slk:lemma	meniť
 13737089-n	slk:lemma	polovica
 08511970-n	slk:lemma	dno
-01395028-s	slk:lemma	drobný
+01395028-a	slk:lemma	drobný
 03309808-n	slk:lemma	tkanina
 04709585-n	slk:lemma	snaživosť
 00214020-v	slk:lemma	zvlhčiť
@@ -13512,9 +13512,9 @@
 14441714-n	slk:lemma	hanba
 05146055-n	slk:lemma	odhadovaná hodnota
 04633453-n	slk:lemma	vzletnosť
-01623744-s	slk:lemma	vyplnený
+01623744-a	slk:lemma	vyplnený
 03966976-n	slk:lemma	kombinačky
-00977699-s	slk:lemma	expresný
+00977699-a	slk:lemma	expresný
 01743223-n	slk:lemma	podčeľaď Pythoninae
 05549830-n	slk:lemma	trup
 00087423-n	slk:lemma	dotácia
@@ -13525,7 +13525,7 @@
 13775706-n	slk:lemma	záplava
 03779370-n	slk:lemma	tvar
 00003380-r	slk:lemma	otravne
-01947741-s	slk:lemma	vyberaný
+01947741-a	slk:lemma	vyberaný
 07531105-n	slk:lemma	spokojnosť
 01812720-v	slk:lemma	povznášať
 01497736-a	slk:lemma	bezdôvodný
@@ -13538,9 +13538,9 @@
 09306031-n	slk:lemma	Housatonic
 01570935-v	slk:lemma	hrdúsiť
 00065070-v	slk:lemma	bolieť
-00015720-s	slk:lemma	nadmerný
+00015720-a	slk:lemma	nadmerný
 06195839-n	slk:lemma	rozhľad
-01987646-s	slk:lemma	rezervovaný
+01987646-a	slk:lemma	rezervovaný
 00713167-v	slk:lemma	uviesť do súvislosti
 14826613-n	slk:lemma	kyselina kyanatá
 10409011-n	slk:lemma	úbožiak
@@ -13550,7 +13550,7 @@
 00927017-a	slk:lemma	súčasný
 02951843-n	slk:lemma	prístrešok
 06594505-n	slk:lemma	mesačník
-00193480-s	slk:lemma	desivý
+00193480-a	slk:lemma	desivý
 04941325-n	slk:lemma	kompaktnosť
 02469835-v	slk:lemma	zjednotiť
 00617748-v	slk:lemma	chybiť
@@ -13563,23 +13563,23 @@
 01230350-v	slk:lemma	bodať
 09877951-n	slk:lemma	dobrý priateľ
 06481320-n	slk:lemma	výpočet
-01603179-s	slk:lemma	južný
-00528629-s	slk:lemma	celoštátny
+01603179-a	slk:lemma	južný
+00528629-a	slk:lemma	celoštátny
 02467662-v	slk:lemma	rozdeliť si
 03892891-n	slk:lemma	časť
 00099089-v	slk:lemma	hojiť sa
-02119716-s	slk:lemma	ozajstný
+02119716-a	slk:lemma	ozajstný
 00044861-r	slk:lemma	zoči-voči
 00024814-v	slk:lemma	osviežiť sa
 05000809-n	slk:lemma	steatopygia
 13903738-n	slk:lemma	prah
 00359862-a	slk:lemma	nedobrý
-01386538-s	slk:lemma	obrovský
-00053032-s	slk:lemma	pripevnený
+01386538-a	slk:lemma	obrovský
+00053032-a	slk:lemma	pripevnený
 02822064-n	slk:lemma	obývacia izba
 05282339-n	slk:lemma	trvalé zuby
 12268918-n	slk:lemma	dub
-00854255-s	slk:lemma	citový
+00854255-a	slk:lemma	citový
 02285205-v	slk:lemma	uhradiť
 10229498-n	slk:lemma	dozorca
 02706816-v	slk:lemma	odolať
@@ -13589,7 +13589,7 @@
 01762283-v	slk:lemma	vzrušiť
 10490699-n	slk:lemma	komentátor
 00006105-r	slk:lemma	hlavne
-02298152-s	slk:lemma	antický
+02298152-a	slk:lemma	antický
 03547054-n	slk:lemma	búda
 09799461-n	slk:lemma	prívrženec
 01697816-v	slk:lemma	vytvoriť
@@ -13600,14 +13600,14 @@
 03306610-n	slk:lemma	diaľničná komunikácia
 00448466-n	slk:lemma	korčuľovanie
 07572957-n	slk:lemma	strava v konzervách
-02587738-s	slk:lemma	vzácny
-01036874-s	slk:lemma	doma vypestovaný
+02587738-a	slk:lemma	vzácny
+01036874-a	slk:lemma	doma vypestovaný
 01810700-n	slk:lemma	holubotvarý vták
 02015571-a	slk:lemma	výnosný
 05614657-n	slk:lemma	zdravý sedliacky rozum
-00624576-s	slk:lemma	pekný
+00624576-a	slk:lemma	pekný
 08988216-n	slk:lemma	Nevis
-00743183-s	slk:lemma	pravý
+00743183-a	slk:lemma	pravý
 00390581-n	slk:lemma	tvorba slabík
 01484850-n	slk:lemma	žralok belasý
 00100592-r	slk:lemma	zavčasu
@@ -13616,7 +13616,7 @@
 02611630-v	slk:lemma	ohraničiť
 02420789-v	slk:lemma	odbrigádovať
 09983572-n	slk:lemma	farár
-00961908-s	slk:lemma	psí
+00961908-a	slk:lemma	psí
 04544138-n	slk:lemma	rôzne upravená časť steny
 01822248-v	slk:lemma	vyjadrovať účasť
 14333058-n	slk:lemma	bolesť spôsobovaná teplom
@@ -13634,7 +13634,7 @@
 13833886-n	slk:lemma	juhozápad
 10641755-n	slk:lemma	špión
 13811900-n	slk:lemma	vzťah
-01822563-s	slk:lemma	uskutočniteľný
+01822563-a	slk:lemma	uskutočniteľný
 03048883-n	slk:lemma	uzavretý okruh
 05437785-n	slk:lemma	alela
 01654377-a	slk:lemma	otvorený
@@ -13646,10 +13646,10 @@
 01116447-v	slk:lemma	poddať sa
 00273445-v	slk:lemma	navyknúť
 06798750-n	slk:lemma	značka
-00168694-s	slk:lemma	ľudský
+00168694-a	slk:lemma	ľudský
 00601043-v	slk:lemma	pohlcovať
 06832788-n	slk:lemma	p
-02476485-s	slk:lemma	spolkový
+02476485-a	slk:lemma	spolkový
 10636598-n	slk:lemma	duch
 11446067-n	slk:lemma	žila
 02815950-n	slk:lemma	brvno
@@ -13665,12 +13665,12 @@
 01437254-v	slk:lemma	zasielať
 00024279-v	slk:lemma	oživiť
 01992503-v	slk:lemma	ísť ďalej
-01199083-s	slk:lemma	miešaný
+01199083-a	slk:lemma	miešaný
 00110533-r	slk:lemma	vnútri
 01391351-a	slk:lemma	drobný
 01020005-v	slk:lemma	nadhodiť
-01076145-s	slk:lemma	dôverný
-01533974-s	slk:lemma	prílišný
+01076145-a	slk:lemma	dôverný
+01533974-a	slk:lemma	prílišný
 00775831-v	slk:lemma	nesúhlasiť
 02898093-n	slk:lemma	tehlárska pec
 04921417-n	slk:lemma	zázemie
@@ -13712,7 +13712,7 @@
 03313873-n	slk:lemma	povrch
 03275864-n	slk:lemma	elektrolyzér
 00888786-v	slk:lemma	dohodnúť sa
-01252714-s	slk:lemma	ostrý
+01252714-a	slk:lemma	ostrý
 01780202-v	slk:lemma	obávať sa
 05139561-n	slk:lemma	bezcennosť
 06490451-n	slk:lemma	priečinok
@@ -13729,10 +13729,10 @@
 02467662-v	slk:lemma	rozdeľovať
 00390842-v	slk:lemma	zmierniť
 06833890-n	slk:lemma	z
-02499301-s	slk:lemma	logický
+02499301-a	slk:lemma	logický
 00863417-n	slk:lemma	dlhé vedenie
 03345487-n	slk:lemma	požiarne vozidlo
-00937616-s	slk:lemma	necvičený
+00937616-a	slk:lemma	necvičený
 05121418-n	slk:lemma	množstvo
 05629682-n	slk:lemma	zatratenie
 00252430-n	slk:lemma	čistenie
@@ -13742,10 +13742,10 @@
 14033185-n	slk:lemma	kritický okamih
 05520699-n	slk:lemma	placenta
 12318164-n	slk:lemma	Juglans
-00250739-s	slk:lemma	riskantný
-00798103-s	slk:lemma	sfetovaný
+00250739-a	slk:lemma	riskantný
+00798103-a	slk:lemma	sfetovaný
 00621058-v	slk:lemma	ujasňovať
-00968730-s	slk:lemma	divoký
+00968730-a	slk:lemma	divoký
 07317519-n	slk:lemma	zakopnutie
 06740919-n	slk:lemma	obrana
 15280695-n	slk:lemma	tep
@@ -13793,9 +13793,9 @@
 07893528-n	slk:lemma	sekt
 13083586-n	slk:lemma	cievnaté
 05685879-n	slk:lemma	zmätok
-02406370-s	slk:lemma	nabrúsený
+02406370-a	slk:lemma	nabrúsený
 10398176-n	slk:lemma	zdravotnícky asistent
-00878086-s	slk:lemma	prípravný
+00878086-a	slk:lemma	prípravný
 02735753-v	slk:lemma	sedieť
 02269767-v	slk:lemma	obmedziť
 07887461-n	slk:lemma	bock
@@ -13822,7 +13822,7 @@
 13346209-n	slk:lemma	poistná spoluúčasť
 08794798-n	slk:lemma	Jeruzalem
 00022099-v	slk:lemma	priviesť k vedomiu
-00194357-s	slk:lemma	neblahý
+00194357-a	slk:lemma	neblahý
 00172710-n	slk:lemma	forma
 02888968-a	slk:lemma	chirurgický
 00315390-n	slk:lemma	plavba na člne
@@ -13844,9 +13844,9 @@
 05987835-n	slk:lemma	poučenie
 00166375-r	slk:lemma	en passant
 00960734-v	slk:lemma	synchronizovať
-00126830-s	slk:lemma	prípravný
+00126830-a	slk:lemma	prípravný
 15085682-n	slk:lemma	kyselina močová
-01729566-s	slk:lemma	dávny
+01729566-a	slk:lemma	dávny
 08107499-n	slk:lemma	čeľaď
 00031921-n	slk:lemma	spojitosť
 00833575-a	slk:lemma	neúčinný
@@ -13857,14 +13857,14 @@
 01874875-v	slk:lemma	vziať (vodou)
 04164529-n	slk:lemma	druhý prevodový stupeň
 07430211-n	slk:lemma	šum
-00746451-s	slk:lemma	záhadný
+00746451-a	slk:lemma	záhadný
 07423365-n	slk:lemma	zvrat
 00082754-n	slk:lemma	preberanie
 05165904-n	slk:lemma	deštruktívnosť
 13404248-n	slk:lemma	účtovná kniha
 10099375-n	slk:lemma	prívrženec
 11664929-n	slk:lemma	Magnoliophyta
-02413851-s	slk:lemma	nitkovitý
+02413851-a	slk:lemma	nitkovitý
 00671335-v	slk:lemma	odhadnúť nízko
 04548362-n	slk:lemma	taška na peniaze
 13319032-n	slk:lemma	úroková sadzba
@@ -13893,7 +13893,7 @@
 05138488-n	slk:lemma	hodnota
 08296196-n	slk:lemma	Sekretariát OSN
 07747055-n	slk:lemma	citrus
-00422168-s	slk:lemma	mastný
+00422168-a	slk:lemma	mastný
 03384535-n	slk:lemma	forma
 10337488-n	slk:lemma	nezávislý
 02381726-v	slk:lemma	prebrať zodpovednosť
@@ -13905,7 +13905,7 @@
 01196364-v	slk:lemma	nepiť (alkohol)
 00037226-r	slk:lemma	skutočne
 15141213-n	slk:lemma	milénium
-01386538-s	slk:lemma	obrí
+01386538-a	slk:lemma	obrí
 02372605-v	slk:lemma	podrobiť sa
 00240938-n	slk:lemma	inštalovanie
 00415743-v	slk:lemma	nastať
@@ -13913,18 +13913,18 @@
 10340312-n	slk:lemma	muzikant
 02330830-n	slk:lemma	Muroidea
 00178342-r	slk:lemma	radikálne
-01987646-s	slk:lemma	odmeraný
+01987646-a	slk:lemma	odmeraný
 07583197-n	slk:lemma	polievka
 02317548-v	slk:lemma	platiť v hotovosti
 01070187-n	slk:lemma	diéta
 01502262-n	slk:lemma	Aves
-00329034-s	slk:lemma	rozdelený na oddiely
+00329034-a	slk:lemma	rozdelený na oddiely
 07339329-n	slk:lemma	spojenie
 08209687-n	slk:lemma	polícia
 00620752-n	slk:lemma	práca
 00509846-n	slk:lemma	radovánky
 10024362-n	slk:lemma	partner
-02384077-s	slk:lemma	džavotavý
+02384077-a	slk:lemma	džavotavý
 00268112-n	slk:lemma	prehliadka
 09752519-n	slk:lemma	človek narodený v znamení Blížencov
 01108148-v	slk:lemma	premôcť
@@ -13942,7 +13942,7 @@
 01811736-v	slk:lemma	nadchýnať
 02269143-v	slk:lemma	uchovať si
 00262881-v	slk:lemma	zoslabovať
-00793592-s	slk:lemma	podradný
+00793592-a	slk:lemma	podradný
 00489108-a	slk:lemma	obyčajný
 00369399-n	slk:lemma	kontrakcia
 09192973-n	slk:lemma	Allegheny
@@ -13953,8 +13953,8 @@
 15116283-n	slk:lemma	geologický čas
 09807754-n	slk:lemma	aristokrat
 02295979-v	slk:lemma	podriaďovať právomoci
-00951003-s	slk:lemma	povrchný
-00218950-s	slk:lemma	pekný
+00951003-a	slk:lemma	povrchný
+00218950-a	slk:lemma	pekný
 00038573-n	slk:lemma	slepá ulica
 00082308-v	slk:lemma	povoľovať
 04648207-n	slk:lemma	frivolnosť
@@ -13980,7 +13980,7 @@
 02530770-v	slk:lemma	skúšať to
 02421199-v	slk:lemma	zotročiť
 10032190-n	slk:lemma	obchodník s textilom
-01763159-s	slk:lemma	mierny
+01763159-a	slk:lemma	mierny
 00783902-n	slk:lemma	krádež veľkého rozsahu
 05358944-n	slk:lemma	žila bazilárna
 01556921-v	slk:lemma	oddeliť sa
@@ -13988,7 +13988,7 @@
 02034300-v	slk:lemma	zmeniť smer
 05129565-n	slk:lemma	rozpätie
 01649999-v	slk:lemma	podnietiť
-00974697-s	slk:lemma	hlúpy
+00974697-a	slk:lemma	hlúpy
 08992181-n	slk:lemma	Republika San Marino
 00998886-v	slk:lemma	zapísať
 05614657-n	slk:lemma	vrodená inteligencia
@@ -13999,7 +13999,7 @@
 15267536-n	slk:lemma	koniec
 01668603-v	slk:lemma	opracúvať
 00951781-n	slk:lemma	komercionalizácia
-01175741-s	slk:lemma	trpiaci kolikou
+01175741-a	slk:lemma	trpiaci kolikou
 02847894-a	slk:lemma	fiškálny
 09999532-n	slk:lemma	insolventný dlžník
 05579753-n	slk:lemma	triceps
@@ -14008,8 +14008,8 @@
 10100761-n	slk:lemma	truľo
 02492362-v	slk:lemma	rozptlýliť
 02881567-a	slk:lemma	pohlavný
-02394793-s	slk:lemma	hrubý
-00608791-s	slk:lemma	divný
+02394793-a	slk:lemma	hrubý
+00608791-a	slk:lemma	divný
 08240633-n	slk:lemma	kotéria
 05434927-n	slk:lemma	jadro (bunky)
 00552815-v	slk:lemma	spráchnivieť
@@ -14019,13 +14019,13 @@
 02696165-n	slk:lemma	piváreň
 00008007-r	slk:lemma	úplne
 06660224-n	slk:lemma	obchodné prekážky
-02394793-s	slk:lemma	nemiestny
+02394793-a	slk:lemma	nemiestny
 09086173-n	slk:lemma	IA
 11524662-n	slk:lemma	počasie
 00371264-v	slk:lemma	páliť
-02121123-s	slk:lemma	zasnený
+02121123-a	slk:lemma	zasnený
 00690305-v	slk:lemma	cítiť sa
-02024928-s	slk:lemma	nákladný
+02024928-a	slk:lemma	nákladný
 06575227-n	slk:lemma	rozhranie
 07120524-n	slk:lemma	štabarc
 07172557-n	slk:lemma	čítanie
@@ -14034,7 +14034,7 @@
 00318735-n	slk:lemma	preprava
 01433294-v	slk:lemma	donášať
 00595505-v	slk:lemma	prehliadať
-00557108-s	slk:lemma	zákonný
+00557108-a	slk:lemma	zákonný
 13837667-n	slk:lemma	liečebný vzťah
 05090441-n	slk:lemma	veľkosť
 13764342-n	slk:lemma	hodnota
@@ -14047,7 +14047,7 @@
 01321579-n	slk:lemma	potomstvo
 00479176-v	slk:lemma	zavraždiť
 01808769-v	slk:lemma	odháňať
-00550574-s	slk:lemma	konečný
+00550574-a	slk:lemma	konečný
 05154241-n	slk:lemma	nespôsobilosť
 01216515-n	slk:lemma	logistická podpora
 12318965-n	slk:lemma	orech popolavý
@@ -14066,7 +14066,7 @@
 14441825-n	slk:lemma	kontrola
 00550771-n	slk:lemma	predvedenie
 02641957-v	slk:lemma	zdržať
-01306645-s	slk:lemma	skúsený
+01306645-a	slk:lemma	skúsený
 10247044-n	slk:lemma	obor
 03146687-n	slk:lemma	odkvap
 08562243-n	slk:lemma	východná hemisféra
@@ -14078,7 +14078,7 @@
 00079951-v	slk:lemma	vyplakovať
 07071483-n	slk:lemma	štýl reči
 02252053-a	slk:lemma	doprevádzaný
-01499269-s	slk:lemma	bezmedzný
+01499269-a	slk:lemma	bezmedzný
 09773245-n	slk:lemma	nepriateľ
 00010054-v	slk:lemma	pohybovať
 09176159-n	slk:lemma	Novosibírske ostrovy
@@ -14088,8 +14088,8 @@
 01237901-v	slk:lemma	netrafiť
 02394068-n	slk:lemma	Artiodactyla
 01480149-v	slk:lemma	lapať
-02281182-s	slk:lemma	radostný
-00566342-s	slk:lemma	vedľajší
+02281182-a	slk:lemma	radostný
+00566342-a	slk:lemma	vedľajší
 00385385-v	slk:lemma	konvertovať
 00858781-v	slk:lemma	jasať
 00273077-n	slk:lemma	popularizácia
@@ -14108,29 +14108,29 @@
 01278427-v	slk:lemma	vrásniť sa
 02051694-v	slk:lemma	mínať
 00705227-v	slk:lemma	mať za cieľ
-00886253-s	slk:lemma	entuziastický
+00886253-a	slk:lemma	entuziastický
 07503430-n	slk:lemma	hnus
 02575082-v	slk:lemma	podviesť
 01744657-n	slk:lemma	čeľaď Elapidae
-01719779-s	slk:lemma	bočný
-01742537-s	slk:lemma	bojujúci
-01878870-s	slk:lemma	vhodný
+01719779-a	slk:lemma	bočný
+01742537-a	slk:lemma	bojujúci
+01878870-a	slk:lemma	vhodný
 00964694-v	slk:lemma	porozprávať
 00678923-a	slk:lemma	nočný
 09345265-n	slk:lemma	Magdalena
 00240938-n	slk:lemma	inštalácia
-01826979-s	slk:lemma	silný
+01826979-a	slk:lemma	silný
 05326624-n	slk:lemma	slimák
-01167269-s	slk:lemma	preventívny
+01167269-a	slk:lemma	preventívny
 09385911-n	slk:lemma	kúsok
-00521976-s	slk:lemma	pokrývajúci celý povrch
+00521976-a	slk:lemma	pokrývajúci celý povrch
 05939636-n	slk:lemma	prelud
 13377268-n	slk:lemma	faktúra
 07654667-n	slk:lemma	kúsok
 04248607-n	slk:lemma	momentka
 04523690-n	slk:lemma	hrobka
 01973759-v	slk:lemma	podvihnúť
-01931926-s	slk:lemma	čakajúci
+01931926-a	slk:lemma	čakajúci
 05928513-n	slk:lemma	preklad
 13658998-n	slk:lemma	dm
 06831605-n	slk:lemma	E
@@ -14139,12 +14139,12 @@
 06169285-n	slk:lemma	štúdium literatúry
 01579813-v	slk:lemma	otvárať
 00172710-n	slk:lemma	spôsob
-01439072-s	slk:lemma	celodenný
-02314070-s	slk:lemma	krivý
-02087178-s	slk:lemma	otvorený
+01439072-a	slk:lemma	celodenný
+02314070-a	slk:lemma	krivý
+02087178-a	slk:lemma	otvorený
 07500159-n	slk:lemma	schvaľovanie
 04588365-n	slk:lemma	okno
-01640261-s	slk:lemma	dlhoročný
+01640261-a	slk:lemma	dlhoročný
 05686955-n	slk:lemma	prekážka
 01675963-v	slk:lemma	skrášliť
 03696568-n	slk:lemma	lugová plachta
@@ -14158,7 +14158,7 @@
 02298632-v	slk:lemma	vydražiť
 02051694-v	slk:lemma	prekĺzať
 02627753-v	slk:lemma	pochádzať z, mať pôvod v
-02462375-s	slk:lemma	vykonštruovaný
+02462375-a	slk:lemma	vykonštruovaný
 14813182-n	slk:lemma	hlina
 04024396-n	slk:lemma	punktúra
 11807979-n	slk:lemma	klinček
@@ -14168,7 +14168,7 @@
 13792579-n	slk:lemma	súvislosť
 00366521-n	slk:lemma	napínanie
 00075998-v	slk:lemma	presiliť sa
-02384077-s	slk:lemma	utáraný
+02384077-a	slk:lemma	utáraný
 03084204-n	slk:lemma	výbava počítača
 01151110-v	slk:lemma	zamieriť
 02810471-n	slk:lemma	elektrická batéria
@@ -14176,11 +14176,11 @@
 00228910-r	slk:lemma	skromne
 01257145-n	slk:lemma	priorita
 13405166-n	slk:lemma	evidencia faktúr
-00421513-s	slk:lemma	špinavý
+00421513-a	slk:lemma	špinavý
 01296462-v	slk:lemma	pripevniť
 09811712-n	slk:lemma	artikulátor
 03518305-n	slk:lemma	bielizník na vysokých nohách
-01579128-s	slk:lemma	finálny
+01579128-a	slk:lemma	finálny
 06316048-n	slk:lemma	slovné spojenie
 07456638-n	slk:lemma	športová činnosť
 00345761-v	slk:lemma	započínať sa
@@ -14205,14 +14205,14 @@
 00629997-a	slk:lemma	materiálový
 04983122-n	slk:lemma	vlastnosť zvuku
 02402559-a	slk:lemma	mierny
-00919919-s	slk:lemma	napätý
+00919919-a	slk:lemma	napätý
 15195059-n	slk:lemma	Sviatok všetkých svätých
-02378496-s	slk:lemma	súbežný
+02378496-a	slk:lemma	súbežný
 01115589-n	slk:lemma	stratový predaj
 01711445-v	slk:lemma	inscenovať
 02373336-v	slk:lemma	skúšať
 00167764-n	slk:lemma	šach-mat
-00936523-s	slk:lemma	ostrieľaný
+00936523-a	slk:lemma	ostrieľaný
 01808374-v	slk:lemma	zdvihnúť žalúdok
 00665886-v	slk:lemma	posilňovať
 04026417-n	slk:lemma	peňaženka
@@ -14226,7 +14226,7 @@
 00249300-r	slk:lemma	zvonku
 13381734-n	slk:lemma	šek
 03297735-n	slk:lemma	sídlo
-01625063-s	slk:lemma	ohavný
+01625063-a	slk:lemma	ohavný
 01115585-v	slk:lemma	vzdať sa
 01597096-v	slk:lemma	stiahnuť dolu
 00836236-v	slk:lemma	predstavovať
@@ -14257,10 +14257,10 @@
 09538915-n	slk:lemma	anjel
 09459393-n	slk:lemma	rieka Tocantins
 00757544-v	slk:lemma	zriekať sa
-00505853-s	slk:lemma	neprekonaný
+00505853-a	slk:lemma	neprekonaný
 01230350-v	slk:lemma	prebodať
 02700767-n	slk:lemma	hliníková fólia
-01728919-s	slk:lemma	predošlý
+01728919-a	slk:lemma	predošlý
 00483935-n	slk:lemma	detská hra
 07517550-n	slk:lemma	pocit krivdy
 04847600-n	slk:lemma	hlavná cnosť
@@ -14287,11 +14287,11 @@
 00813790-v	slk:lemma	moderovať
 03287733-n	slk:lemma	motor
 11876976-n	slk:lemma	kel
-01916784-s	slk:lemma	problematický
+01916784-a	slk:lemma	problematický
 00250259-n	slk:lemma	zdokonalenie
 05949726-n	slk:lemma	verejná mienka
 01552519-v	slk:lemma	odťať
-02123007-s	slk:lemma	ako mača
+02123007-a	slk:lemma	ako mača
 05926358-n	slk:lemma	nezrozumiteľnosť
 08757569-n	slk:lemma	Československo
 00431826-v	slk:lemma	minúť sa
@@ -14306,7 +14306,7 @@
 08927186-n	slk:lemma	Jordánsko
 03159535-n	slk:lemma	mliečna farma
 02234087-v	slk:lemma	vymerať
-02460964-s	slk:lemma	reálny
+02460964-a	slk:lemma	reálny
 00123170-v	slk:lemma	upraviť sa
 00859325-v	slk:lemma	rozptyľovať sa
 05048301-n	slk:lemma	súbežnosť
@@ -14314,8 +14314,8 @@
 01775879-n	slk:lemma	rad Acarina
 04606574-n	slk:lemma	francúzsky kľúč
 12321873-n	slk:lemma	orechovec biely
-02500590-s	slk:lemma	nulitný
-00012362-s	slk:lemma	abstraktný
+02500590-a	slk:lemma	nulitný
+00012362-a	slk:lemma	abstraktný
 03482128-n	slk:lemma	čelo kladiva
 00688768-v	slk:lemma	prehodnocovať
 08072837-n	slk:lemma	trh
@@ -14325,7 +14325,7 @@
 15091846-n	slk:lemma	vitamín B9
 01332730-v	slk:lemma	prikryť
 00871781-v	slk:lemma	hroziť
-00097768-s	slk:lemma	mŕtvy
+00097768-a	slk:lemma	mŕtvy
 13661045-n	slk:lemma	hodnota pol pence
 06615026-n	slk:lemma	celovečerný film
 02758134-n	slk:lemma	auditórium
@@ -14339,7 +14339,7 @@
 00159620-n	slk:lemma	vábenie
 06711855-n	slk:lemma	pokarhanie
 01378556-v	slk:lemma	šíriť sa
-00552089-s	slk:lemma	splnený
+00552089-a	slk:lemma	splnený
 04051825-n	slk:lemma	záštita
 00373544-n	slk:lemma	politická expanzia
 00220869-v	slk:lemma	spevňovať
@@ -14355,15 +14355,15 @@
 07251779-n	slk:lemma	pokrikovanie
 10449412-n	slk:lemma	policajtka
 00165298-n	slk:lemma	vysvätenie
-01178458-s	slk:lemma	varikózny
+01178458-a	slk:lemma	varikózny
 10142391-n	slk:lemma	deduško
 06557585-n	slk:lemma	zákon obmedzujúci čas určený na diskusiu o určitých otázkach
-00363031-s	slk:lemma	úsmevný
+00363031-a	slk:lemma	úsmevný
 01921964-v	slk:lemma	liezť
 11666854-n	slk:lemma	dvojklíčnolistové rastliny
-00065667-s	slk:lemma	záporný
+00065667-a	slk:lemma	záporný
 06832464-n	slk:lemma	M
-00840212-s	slk:lemma	ekonomický
+00840212-a	slk:lemma	ekonomický
 02091689-v	slk:lemma	postúpiť
 07827750-n	slk:lemma	mak
 10132145-n	slk:lemma	sklár
@@ -14389,15 +14389,15 @@
 00494100-n	slk:lemma	binokel
 00512261-a	slk:lemma	neschopný
 00541479-n	slk:lemma	rituálny tanec
-01166656-s	slk:lemma	liečivý
-01645678-s	slk:lemma	sivý
+01166656-a	slk:lemma	liečivý
+01645678-a	slk:lemma	sivý
 08398773-n	slk:lemma	kolekcia
-01732131-s	slk:lemma	novodobý
+01732131-a	slk:lemma	novodobý
 09304750-n	slk:lemma	priehlbina
-02403505-s	slk:lemma	pevný
+02403505-a	slk:lemma	pevný
 14446161-n	slk:lemma	útecha
 02976350-n	slk:lemma	okno
-00526062-s	slk:lemma	globálny
+00526062-a	slk:lemma	globálny
 08182379-n	slk:lemma	tlačenica
 05207570-n	slk:lemma	neschopnosť
 03091374-n	slk:lemma	spojenie
@@ -14414,7 +14414,7 @@
 02716739-a	slk:lemma	ekonomický
 02756098-n	slk:lemma	úbor
 02873811-a	slk:lemma	vaskulárny
-01580775-s	slk:lemma	dôležitý
+01580775-a	slk:lemma	dôležitý
 00947077-v	slk:lemma	vymedzovať
 02294436-v	slk:lemma	distribuovať
 00397953-n	slk:lemma	segmentovanie
@@ -14431,7 +14431,7 @@
 09475292-n	slk:lemma	vodopád
 02062209-n	slk:lemma	Cetacea
 07331210-n	slk:lemma	vyčerpanie
-01280908-s	slk:lemma	malý
+01280908-a	slk:lemma	malý
 06444959-n	slk:lemma	Prvý list apoštola Pavla Solúnčanom
 00419375-v	slk:lemma	uvoľniť sa
 13447361-n	slk:lemma	reakcia
@@ -14454,10 +14454,10 @@
 04274530-n	slk:lemma	guľa
 02984781-a	slk:lemma	podnikový
 04390156-n	slk:lemma	taviaca vaňová pec
-01344171-s	slk:lemma	pútavý
+01344171-a	slk:lemma	pútavý
 00970249-a	slk:lemma	klasický
 00074038-v	slk:lemma	kakať
-01010271-s	slk:lemma	finálny
+01010271-a	slk:lemma	finálny
 00276987-n	slk:lemma	znečistenie
 00466053-v	slk:lemma	usporadúvať sa, usporadovať sa
 00072012-v	slk:lemma	močiť
@@ -14471,7 +14471,7 @@
 11441416-n	slk:lemma	medzihviezdny prach
 01873784-v	slk:lemma	podporiť
 00475819-v	slk:lemma	zbavovať viny
-01153141-s	slk:lemma	jemný
+01153141-a	slk:lemma	jemný
 10298912-n	slk:lemma	námorný kapitán
 12581381-n	slk:lemma	čeľaď palmové
 01523520-v	slk:lemma	odmotávať
@@ -14480,15 +14480,15 @@
 08069878-n	slk:lemma	obchod s akciami
 02665617-v	slk:lemma	vyzerať
 13925752-n	slk:lemma	situácia
-00651039-s	slk:lemma	vážny
+00651039-a	slk:lemma	vážny
 10309896-n	slk:lemma	kupec
-01990653-s	slk:lemma	tvrdý
+01990653-a	slk:lemma	tvrdý
 09050244-n	slk:lemma	Konfederácia amerických štátov
 01434278-v	slk:lemma	odviezť si
-01441866-s	slk:lemma	časovo náročný
+01441866-a	slk:lemma	časovo náročný
 00305431-r	slk:lemma	proti svojej vôli
 07121157-n	slk:lemma	krik
-00193480-s	slk:lemma	strašný
+00193480-a	slk:lemma	strašný
 00785008-v	slk:lemma	klásť otázky
 07546973-n	slk:lemma	mizogamia
 02294056-v	slk:lemma	predať pod cenu
@@ -14513,9 +14513,9 @@
 00822970-n	slk:lemma	obozretnosť
 01556921-v	slk:lemma	rozdeľovať
 09326467-n	slk:lemma	rieka Klamath
-00521811-s	slk:lemma	podrobný
+00521811-a	slk:lemma	podrobný
 01438304-v	slk:lemma	doručiť
-02130821-s	slk:lemma	nerozhodnutý
+02130821-a	slk:lemma	nerozhodnutý
 00674607-v	slk:lemma	zvoliť
 01021889-n	slk:lemma	zotrvanie
 05249636-n	slk:lemma	priechod
@@ -14524,7 +14524,7 @@
 05697135-n	slk:lemma	istota
 03696065-n	slk:lemma	kufor
 00635012-n	slk:lemma	kriminálne vyšetrovanie
-00168694-s	slk:lemma	príjemný
+00168694-a	slk:lemma	príjemný
 01768969-n	slk:lemma	pavúkovce
 04744814-n	slk:lemma	podoba
 05138958-n	slk:lemma	dobrá vlastnosť
@@ -14532,7 +14532,7 @@
 00053913-n	slk:lemma	odsun
 00508032-v	slk:lemma	označkovať
 13878306-n	slk:lemma	ovál
-00440292-s	slk:lemma	pomaly chápajúci
+00440292-a	slk:lemma	pomaly chápajúci
 11473954-n	slk:lemma	svetlo
 00235208-n	slk:lemma	regres
 10186578-n	slk:lemma	obchodník s pleteným tovarom
@@ -14541,7 +14541,7 @@
 08320052-n	slk:lemma	duma
 03933529-n	slk:lemma	dok
 00888786-v	slk:lemma	kontrahovať
-02030562-s	slk:lemma	ultra pravicový
+02030562-a	slk:lemma	ultra pravicový
 14866889-n	slk:lemma	tkanina
 01690294-v	slk:lemma	kresliť
 01985923-v	slk:lemma	klesnúť
@@ -14562,8 +14562,8 @@
 00067274-v	slk:lemma	zavzlykať
 09178821-n	slk:lemma	racionálny motív
 01782650-v	slk:lemma	zhroziť sa
-02400628-s	slk:lemma	na preclenie
-02119213-s	slk:lemma	rozvážny
+02400628-a	slk:lemma	na preclenie
+02119213-a	slk:lemma	rozvážny
 03546766-n	slk:lemma	opláštenie
 06143154-n	slk:lemma	spoločenská veda
 09229409-n	slk:lemma	potok
@@ -14573,7 +14573,7 @@
 11408559-n	slk:lemma	prírodný fenomén
 15245829-n	slk:lemma	príležitosť
 09281545-n	slk:lemma	Flint
-00523867-s	slk:lemma	samostatný
+00523867-a	slk:lemma	samostatný
 09286318-n	slk:lemma	Galvestonský záliv
 07154046-n	slk:lemma	klišé
 00033922-r	slk:lemma	čoskoro
@@ -14581,7 +14581,7 @@
 15254028-n	slk:lemma	éra
 15248564-n	slk:lemma	obdobie
 00426958-v	slk:lemma	zmiznúť
-00421875-s	slk:lemma	úbohý
+00421875-a	slk:lemma	úbohý
 00590047-n	slk:lemma	vedenie
 13737480-n	slk:lemma	štvrť
 04695963-n	slk:lemma	škvrna
@@ -14589,7 +14589,7 @@
 02952622-a	slk:lemma	evanjelický
 08599792-n	slk:lemma	dátumová čiara
 04910135-n	slk:lemma	manier
-00195684-s	slk:lemma	odporný
+00195684-a	slk:lemma	odporný
 00386676-n	slk:lemma	rozkol
 09361816-n	slk:lemma	Hora Karmel
 02372251-n	slk:lemma	rad damany
@@ -14611,7 +14611,7 @@
 06664213-n	slk:lemma	veková hranica
 01163047-n	slk:lemma	výprask
 01679459-a	slk:lemma	organický
-02035086-s	slk:lemma	etický
+02035086-a	slk:lemma	etický
 02372251-n	slk:lemma	Hyracoidea
 01319874-a	slk:lemma	nevediaci
 00746232-n	slk:lemma	nedodržanie
@@ -14619,7 +14619,7 @@
 02034511-v	slk:lemma	odvrátiť sa
 04689660-n	slk:lemma	vnadidlo
 10657969-n	slk:lemma	vlastník akcií
-00660809-s	slk:lemma	trojdimenzionálny
+00660809-a	slk:lemma	trojdimenzionálny
 05680982-n	slk:lemma	apatia
 10569411-n	slk:lemma	tajný agent
 01888520-n	slk:lemma	Insectivora
@@ -14640,35 +14640,35 @@
 05579436-n	slk:lemma	dvojhlavý sval ramena
 04003982-n	slk:lemma	kópia
 15049902-n	slk:lemma	spermacetový olej
-01308736-s	slk:lemma	bezradný
+01308736-a	slk:lemma	bezradný
 06316048-n	slk:lemma	fráza
 01338368-v	slk:lemma	obkladať (bridlicami)
 00859325-v	slk:lemma	obveseľovať
 00024814-v	slk:lemma	ochladiť sa
 02014553-v	slk:lemma	odštartovať
-00859949-s	slk:lemma	experimentálny
+00859949-a	slk:lemma	experimentálny
 05442131-n	slk:lemma	chromozóm
-02048247-s	slk:lemma	rohový
+02048247-a	slk:lemma	rohový
 14849789-n	slk:lemma	brúsne plátno
 00048138-r	slk:lemma	konečne
 00151105-a	slk:lemma	nezrozumiteľný
 02483267-v	slk:lemma	popraviť
 04400289-n	slk:lemma	telekomunikačné vybavenie
 13327676-n	slk:lemma	strata
-01625492-s	slk:lemma	príšerný
+01625492-a	slk:lemma	príšerný
 01000068-n	slk:lemma	vyrovnanie
 14066203-n	slk:lemma	kolaps
-01045518-s	slk:lemma	literárny
+01045518-a	slk:lemma	literárny
 02452885-v	slk:lemma	zabraňovať
-00349894-s	slk:lemma	definitívny
-01484651-s	slk:lemma	panenský
+00349894-a	slk:lemma	definitívny
+01484651-a	slk:lemma	panenský
 01769347-n	slk:lemma	pavúkovec
 05554804-n	slk:lemma	dvorec
 01814074-v	slk:lemma	potešiť
 05832745-n	slk:lemma	záťaž
 00257770-n	slk:lemma	kúpeľ
 10142391-n	slk:lemma	dedko
-01136248-s	slk:lemma	nevrlý
+01136248-a	slk:lemma	nevrlý
 07373602-n	slk:lemma	splynutie
 10463714-n	slk:lemma	podvodník
 06083243-n	slk:lemma	zoológia
@@ -14680,19 +14680,19 @@
 06453849-n	slk:lemma	Nový zákon
 01811736-v	slk:lemma	povznášať
 00477941-v	slk:lemma	uškodiť
-02542148-s	slk:lemma	sužovaný
+02542148-a	slk:lemma	sužovaný
 08751126-n	slk:lemma	Guadelupy
 01814266-v	slk:lemma	ťažiť
 01158690-n	slk:lemma	normalizácia
-00194357-s	slk:lemma	skazonosný
+00194357-a	slk:lemma	skazonosný
 01437254-v	slk:lemma	poslať
 01147060-v	slk:lemma	odvrátiť
-01116118-s	slk:lemma	nefalšovaný
+01116118-a	slk:lemma	nefalšovaný
 02977438-n	slk:lemma	kontrolná pokladňa
 01633343-v	slk:lemma	mať nápad
 02163746-v	slk:lemma	vyzvedieť
 00384620-v	slk:lemma	polepšovať
-01998730-s	slk:lemma	nezodpovedný
+01998730-a	slk:lemma	nezodpovedný
 04760771-n	slk:lemma	telesnosť
 04262161-n	slk:lemma	ozvučná doska
 13278375-n	slk:lemma	platba
@@ -14720,17 +14720,17 @@
 01036996-n	slk:lemma	svadobný obrad
 02653706-v	slk:lemma	náležať
 07109196-n	slk:lemma	ústna komunikácia
-01314537-s	slk:lemma	rodinný
+01314537-a	slk:lemma	rodinný
 02492362-v	slk:lemma	baviť sa
 06546261-n	slk:lemma	nadobúdacia listina
 10657969-n	slk:lemma	akcionár
 08972920-n	slk:lemma	Auckland
-01344171-s	slk:lemma	zaujímavý
+01344171-a	slk:lemma	zaujímavý
 00298161-n	slk:lemma	turizmus
 00067265-r	slk:lemma	vpredu
 15165490-n	slk:lemma	pravé poludnie
 00064643-v	slk:lemma	poškodzovať
-00393683-s	slk:lemma	sýty
+00393683-a	slk:lemma	sýty
 09418169-n	slk:lemma	rieka Saale
 09722658-n	slk:lemma	Mexičan
 00331655-n	slk:lemma	posúvanie
@@ -14742,17 +14742,17 @@
 02005948-v	slk:lemma	prísť
 08110373-n	slk:lemma	druh
 01280488-v	slk:lemma	zohýnať sa
-01346978-s	slk:lemma	interný
+01346978-a	slk:lemma	interný
 01091427-v	slk:lemma	oponovať
 00059989-n	slk:lemma	útek
 01843055-v	slk:lemma	prejsť
 04182322-n	slk:lemma	tyčka
 02400218-a	slk:lemma	zdaniteľný
 00279534-n	slk:lemma	škrípanie zubami
-01335458-s	slk:lemma	chápavý
+01335458-a	slk:lemma	chápavý
 02673965-v	slk:lemma	vyniknúť
-00195684-s	slk:lemma	údesný
-02279900-s	slk:lemma	odvážny
+00195684-a	slk:lemma	údesný
+02279900-a	slk:lemma	odvážny
 02663141-v	slk:lemma	poprieť
 06999233-n	slk:lemma	ilustrácia
 05240211-n	slk:lemma	pokožka
@@ -14773,7 +14773,7 @@
 02145814-v	slk:lemma	ukrývať sa
 13356569-n	slk:lemma	zvitok bankoviek
 00020090-n	slk:lemma	materiál
-02112701-s	slk:lemma	kolektívny
+02112701-a	slk:lemma	kolektívny
 02053941-v	slk:lemma	priblížiť sa
 06545843-n	slk:lemma	zložená listina
 03892425-n	slk:lemma	vlysová podlaha
@@ -14781,7 +14781,7 @@
 04357314-n	slk:lemma	krém na opaľovanie
 09024668-n	slk:lemma	Baleárske ostrovy
 13374426-n	slk:lemma	spotrebný úver
-00922051-s	slk:lemma	kúzelný
+00922051-a	slk:lemma	kúzelný
 10254965-n	slk:lemma	lesbička
 01072262-v	slk:lemma	súperiť
 01332730-v	slk:lemma	pokryť
@@ -14792,12 +14792,12 @@
 00102736-r	slk:lemma	prv
 13286801-n	slk:lemma	podiel
 00365709-n	slk:lemma	rozšírenie
-02076988-s	slk:lemma	chorej mysle
-01082714-s	slk:lemma	nepodarený
+02076988-a	slk:lemma	chorej mysle
+01082714-a	slk:lemma	nepodarený
 07499615-n	slk:lemma	náklonnosť
-00592880-s	slk:lemma	opätovný
-01993408-s	slk:lemma	decentný
-00464068-s	slk:lemma	vnútrozemský
+00592880-a	slk:lemma	opätovný
+01993408-a	slk:lemma	decentný
+00464068-a	slk:lemma	vnútrozemský
 11565040-n	slk:lemma	čeľaď dvojklíčnolistových klinčekových rastlín
 05590366-n	slk:lemma	sternomastoidálny sval
 03279508-n	slk:lemma	elektrónový mikroskop
@@ -14807,8 +14807,8 @@
 07938149-n	slk:lemma	vitamínová tabletka
 00463080-r	slk:lemma	ťažko
 02931227-a	slk:lemma	sviatostný
-02096923-s	slk:lemma	poistiteľný
-02029047-s	slk:lemma	pravý
+02096923-a	slk:lemma	poistiteľný
+02029047-a	slk:lemma	pravý
 00660730-v	slk:lemma	podceňovať
 02611630-v	slk:lemma	vymedzovať
 01874875-v	slk:lemma	plaviť sa
@@ -14824,46 +14824,46 @@
 04033082-n	slk:lemma	prístavná hrádza
 09130076-n	slk:lemma	OH
 02062212-v	slk:lemma	strčiť
-02161982-s	slk:lemma	významný
+02161982-a	slk:lemma	významný
 03137044-n	slk:lemma	križiak
 12874429-n	slk:lemma	čeľaď sezamovité
 00365709-n	slk:lemma	rozpínanie
-01619475-s	slk:lemma	jasný
+01619475-a	slk:lemma	jasný
 03463561-n	slk:lemma	plán prízemia
 08582157-n	slk:lemma	oblasť D
 01400044-v	slk:lemma	udrieť
 14724645-n	slk:lemma	antioxidant
 01734884-a	slk:lemma	materinský
-02397496-s	slk:lemma	okorenený
+02397496-a	slk:lemma	okorenený
 04921417-n	slk:lemma	pozadie
 09326662-n	slk:lemma	kopec
 03452594-n	slk:lemma	vysoké stojacie hodiny
 01461328-v	slk:lemma	zlučovať sa
 00868097-v	slk:lemma	odvážiť sa
 00511817-n	slk:lemma	vyvádzanie
-01950198-s	slk:lemma	spustnutý
-01496311-s	slk:lemma	neurčitý
-01207546-s	slk:lemma	spodný
+01950198-a	slk:lemma	spustnutý
+01496311-a	slk:lemma	neurčitý
+01207546-a	slk:lemma	spodný
 06060049-n	slk:lemma	mikroskopická anatómia
 09174908-n	slk:lemma	Fuego
 09419281-n	slk:lemma	Saint Francis
 04205759-n	slk:lemma	guľka
 04882968-n	slk:lemma	obmedzenie
-00143854-s	slk:lemma	obrnený
+00143854-a	slk:lemma	obrnený
 14474435-n	slk:lemma	šťastie
 09927451-n	slk:lemma	reverend
 02837416-n	slk:lemma	herák
-01168166-s	slk:lemma	zmrzačujúci
+01168166-a	slk:lemma	zmrzačujúci
 02299801-v	slk:lemma	predražiť ponuku
-00750054-s	slk:lemma	nenáročný
+00750054-a	slk:lemma	nenáročný
 02382367-v	slk:lemma	vzdať sa funkcie
-01523249-s	slk:lemma	manévrovateľný
+01523249-a	slk:lemma	manévrovateľný
 00799798-v	slk:lemma	brať späť
 00311687-n	slk:lemma	putovanie
 08212347-n	slk:lemma	páni
-02465115-s	slk:lemma	dôveryhodný
+02465115-a	slk:lemma	dôveryhodný
 05308950-n	slk:lemma	zubná dreň
-01572171-s	slk:lemma	farbený
+01572171-a	slk:lemma	farbený
 03332173-n	slk:lemma	fižé
 01609287-v	slk:lemma	potiahnuť
 01577635-v	slk:lemma	namočiť sa
@@ -14873,7 +14873,7 @@
 00198793-n	slk:lemma	degradácia
 00539936-v	slk:lemma	otvoriť nové možnosti
 05715283-n	slk:lemma	chuťový vnem
-01936184-s	slk:lemma	mýtický
+01936184-a	slk:lemma	mýtický
 07019633-n	slk:lemma	bábková hra
 02119241-v	slk:lemma	nevšimnúť si
 02973392-a	slk:lemma	komediálny
@@ -14881,7 +14881,7 @@
 00162632-n	slk:lemma	určenie
 14326607-n	slk:lemma	bolesť hlavy
 01071328-v	slk:lemma	poslať (správu, odkaz, poštu)
-00890874-s	slk:lemma	rovnocenný
+00890874-a	slk:lemma	rovnocenný
 00655779-a	slk:lemma	dôležitý
 15140405-n	slk:lemma	čas života
 02395694-n	slk:lemma	brav
@@ -14926,12 +14926,12 @@
 01807770-v	slk:lemma	zviesť
 01835496-v	slk:lemma	presunúť sa
 10059582-n	slk:lemma	fanúšik
-01690606-s	slk:lemma	bežný
+01690606-a	slk:lemma	bežný
 03099454-n	slk:lemma	konvent
 02888659-a	slk:lemma	litorálny
 02346136-v	slk:lemma	doviezť
 02357228-v	slk:lemma	hospodáriť
-01149358-s	slk:lemma	veselý
+01149358-a	slk:lemma	veselý
 00066025-v	slk:lemma	zavzlykať
 02096167-v	slk:lemma	točiť sa
 01628449-v	slk:lemma	začať
@@ -14949,11 +14949,11 @@
 13265904-n	slk:lemma	finančná podpora
 00392588-v	slk:lemma	zlepšiť
 01042228-v	slk:lemma	šíriť reči
-01443097-s	slk:lemma	kratučký
+01443097-a	slk:lemma	kratučký
 00456199-n	slk:lemma	hra
-01637371-s	slk:lemma	naivný
+01637371-a	slk:lemma	naivný
 06143454-n	slk:lemma	občianska výchova
-02018649-s	slk:lemma	obyčajný
+02018649-a	slk:lemma	obyčajný
 05024931-n	slk:lemma	pokojová hmota
 03417345-n	slk:lemma	háj
 01176335-n	slk:lemma	bitka
@@ -14973,12 +14973,12 @@
 13144303-n	slk:lemma	Vitaceae
 12712820-n	slk:lemma	rod Fortunella
 10595647-n	slk:lemma	nemocná osoba
-01888554-s	slk:lemma	konzervačný
+01888554-a	slk:lemma	konzervačný
 02803934-n	slk:lemma	basa
 10577284-n	slk:lemma	maloobchodník
 02742753-n	slk:lemma	šíp
 07560652-n	slk:lemma	jedlo
-00014490-s	slk:lemma	plodný
+00014490-a	slk:lemma	plodný
 02742322-n	slk:lemma	háv
 03058726-n	slk:lemma	heraldika
 03594277-n	slk:lemma	záchytná čeľusť
@@ -14986,14 +14986,14 @@
 02492362-v	slk:lemma	zabaviť
 00827730-v	slk:lemma	obhajovať
 11493827-n	slk:lemma	napätie
-00907400-s	slk:lemma	nadutý
+00907400-a	slk:lemma	nadutý
 01778212-a	slk:lemma	fyzický
 05462315-n	slk:lemma	nervový systém
 05325378-n	slk:lemma	fenestra
 02932227-n	slk:lemma	kajuta
 09610405-n	slk:lemma	obyčajný človek
 07487375-n	slk:lemma	clivá túžba
-01804728-s	slk:lemma	ostrý
+01804728-a	slk:lemma	ostrý
 15049096-n	slk:lemma	živec
 05308141-n	slk:lemma	korunka
 13585429-n	slk:lemma	konštanta
@@ -15006,16 +15006,16 @@
 02297142-v	slk:lemma	predkladať
 00210259-v	slk:lemma	kaziť sa
 00232862-r	slk:lemma	vonku
-01483677-s	slk:lemma	mužský
+01483677-a	slk:lemma	mužský
 01486312-v	slk:lemma	uzatvárať (do niečoho)
 03576955-n	slk:lemma	nasávací ventil
 08050385-n	slk:lemma	politické zriadenie
 01005063-a	slk:lemma	pabaigtas
-01562416-s	slk:lemma	približujúci sa
+01562416-a	slk:lemma	približujúci sa
 02299801-v	slk:lemma	ponúknuť vyššiu cenu
 05233741-n	slk:lemma	mandibulárny zárez
 01973125-v	slk:lemma	spustiť
-01977669-s	slk:lemma	spomienkový
+01977669-a	slk:lemma	spomienkový
 15110956-n	slk:lemma	rastlinná hmota
 01364008-a	slk:lemma	žalostný
 00182406-v	slk:lemma	doplniť
@@ -15040,17 +15040,17 @@
 00958896-n	slk:lemma	zápas
 15020974-n	slk:lemma	železný odpad
 13275847-n	slk:lemma	náklady
-01263445-s	slk:lemma	hnusný
+01263445-a	slk:lemma	hnusný
 00435103-v	slk:lemma	podvoľovať sa
 14497763-n	slk:lemma	nečistota
 00695761-v	slk:lemma	podhodnotiť
-01993693-s	slk:lemma	čestný
+01993693-a	slk:lemma	čestný
 05687958-n	slk:lemma	hlboká voda
 05748054-n	slk:lemma	výberovosť
 05993622-n	slk:lemma	filozofia Augusta Comta
 08223688-n	slk:lemma	farnosť
 00308370-n	slk:lemma	cesta
-02096923-s	slk:lemma	poistný
+02096923-a	slk:lemma	poistný
 06892775-n	slk:lemma	koncert
 04209613-n	slk:lemma	sprchový kút
 00095121-n	slk:lemma	vykúpenie
@@ -15059,9 +15059,9 @@
 00088481-n	slk:lemma	zabavenie
 03144592-n	slk:lemma	kocka
 09831962-n	slk:lemma	zlosyn
-01744515-s	slk:lemma	prudký
+01744515-a	slk:lemma	prudký
 00106921-r	slk:lemma	bežne
-01185916-s	slk:lemma	obrovský
+01185916-a	slk:lemma	obrovský
 13393599-n	slk:lemma	peniaze s núteným obehom
 04486054-n	slk:lemma	víťazný oblúk
 00335182-r	slk:lemma	nepripravene
@@ -15093,7 +15093,7 @@
 11501381-n	slk:lemma	dažďové zrážky
 06431740-n	slk:lemma	Slovo
 00531489-v	slk:lemma	pokoriť sa
-01486854-s	slk:lemma	rovnaký
+01486854-a	slk:lemma	rovnaký
 06946497-n	slk:lemma	germánčina
 13251289-n	slk:lemma	konkurzná podstata
 01574446-a	slk:lemma	nadprirodzený
@@ -15104,7 +15104,7 @@
 00075021-v	slk:lemma	vyčerpať
 02683692-n	slk:lemma	zadná paluba
 00607114-v	slk:lemma	púšťať sa do štúdia
-01366062-s	slk:lemma	trúchlivý
+01366062-a	slk:lemma	trúchlivý
 11807979-n	slk:lemma	klinec
 10405694-n	slk:lemma	pacientka
 00664483-v	slk:lemma	overovať
@@ -15134,7 +15134,7 @@
 01019901-n	slk:lemma	reprodukovanie
 01523654-v	slk:lemma	odvíjať
 09246660-n	slk:lemma	Clinch River
-00010726-s	slk:lemma	pažravý
+00010726-a	slk:lemma	pažravý
 02083038-n	slk:lemma	Canidae
 02914813-n	slk:lemma	stavebný dielec
 03181293-n	slk:lemma	detektor
@@ -15145,16 +15145,16 @@
 02406585-v	slk:lemma	nastúpiť
 05158431-n	slk:lemma	účelné opatrenie
 00192836-v	slk:lemma	oživovať
-00438909-s	slk:lemma	bystrý
+00438909-a	slk:lemma	bystrý
 02284951-v	slk:lemma	nahrádzať
 01973125-v	slk:lemma	klesať
 14414715-n	slk:lemma	izolovanosť
-00305700-s	slk:lemma	nárazový
+00305700-a	slk:lemma	nárazový
 04845475-n	slk:lemma	krutosť
 13383090-n	slk:lemma	overený šek
-02285278-s	slk:lemma	grafický
+02285278-a	slk:lemma	grafický
 02548588-v	slk:lemma	splniť si úlohu
-02550333-s	slk:lemma	daždivý
+02550333-a	slk:lemma	daždivý
 06759776-n	slk:lemma	zámienka
 08900535-n	slk:lemma	India
 07527352-n	slk:lemma	radosť
@@ -15178,7 +15178,7 @@
 04446276-n	slk:lemma	záchod
 01921964-v	slk:lemma	šplhať sa
 04845312-n	slk:lemma	nemilosť
-00609564-s	slk:lemma	svojrázny
+00609564-a	slk:lemma	svojrázny
 00227595-n	slk:lemma	prinášať obeť
 02784218-n	slk:lemma	pás
 08406619-n	slk:lemma	charita
@@ -15197,7 +15197,7 @@
 00544136-v	slk:lemma	upiecť na ražni
 08588294-n	slk:lemma	vnútro
 00370920-r	slk:lemma	jasne
-01388062-s	slk:lemma	obrovský
+01388062-a	slk:lemma	obrovský
 05697789-n	slk:lemma	tvrdošijnosť
 00339934-v	slk:lemma	odohrávať sa
 00353100-n	slk:lemma	zníženie daní
@@ -15207,19 +15207,19 @@
 10000945-n	slk:lemma	delikvent
 07227772-n	slk:lemma	záväzok
 00071456-r	slk:lemma	celý čas
-00602117-s	slk:lemma	diskutabilný
+00602117-a	slk:lemma	diskutabilný
 09865398-n	slk:lemma	sluha bez úväzku
 00397760-n	slk:lemma	vyškrabanie
-01327205-s	slk:lemma	izolovaný
+01327205-a	slk:lemma	izolovaný
 02205272-v	slk:lemma	brávať
 05822746-n	slk:lemma	hľadisko
 14442530-n	slk:lemma	nadvláda
 00531355-n	slk:lemma	vejárovitý tanec
-00541935-s	slk:lemma	na lístky
+00541935-a	slk:lemma	na lístky
 06729499-n	slk:lemma	prísažné potvrdenie
 00294868-n	slk:lemma	plazenie sa
 00415743-v	slk:lemma	začínať sa
-02412880-s	slk:lemma	tenký ako vlas
+02412880-a	slk:lemma	tenký ako vlas
 08643933-n	slk:lemma	úkryt
 02255268-v	slk:lemma	poskytnúť
 01794340-a	slk:lemma	vzorovaný
@@ -15240,7 +15240,7 @@
 15281329-n	slk:lemma	investičná návratnosť
 13873917-n	slk:lemma	kruh
 04051825-n	slk:lemma	ochrana
-02343110-s	slk:lemma	úžasný
+02343110-a	slk:lemma	úžasný
 02090435-v	slk:lemma	točiť
 09619168-n	slk:lemma	žena
 01381549-v	slk:lemma	zbierať
@@ -15256,11 +15256,11 @@
 01984317-v	slk:lemma	padať
 13408023-n	slk:lemma	dividenda
 01768969-n	slk:lemma	trieda pavúkovce
-02341864-s	slk:lemma	dôkladný
-02499148-s	slk:lemma	zákonný
-02114746-s	slk:lemma	prenosný
+02341864-a	slk:lemma	dôkladný
+02499148-a	slk:lemma	zákonný
+02114746-a	slk:lemma	prenosný
 10533013-n	slk:lemma	súper
-00463399-s	slk:lemma	prímorský
+00463399-a	slk:lemma	prímorský
 13309956-n	slk:lemma	daňový dlh
 02428924-v	slk:lemma	zísť sa
 00064889-v	slk:lemma	vzbudzovať nechuť
@@ -15268,7 +15268,7 @@
 13669860-n	slk:lemma	kuvajtský dinár
 06581410-n	slk:lemma	pomocný program
 02062212-v	slk:lemma	kopať (kôň)
-00194357-s	slk:lemma	zhubný
+00194357-a	slk:lemma	zhubný
 00728641-n	slk:lemma	školská úloha
 02118933-v	slk:lemma	poznamenávať
 01194711-n	slk:lemma	skutočné odňatie držby
@@ -15301,18 +15301,18 @@
 00035491-r	slk:lemma	čudne
 05806623-n	slk:lemma	pochopenie
 00017881-r	slk:lemma	ako tak
-02038994-s	slk:lemma	odvážny
+02038994-a	slk:lemma	odvážny
 00939628-n	slk:lemma	spracovať
 01871949-a	slk:lemma	nerentabilný
 14033802-n	slk:lemma	bod vzplanutia
 10546850-n	slk:lemma	anjel
 05100751-n	slk:lemma	svietivosť
 03025250-n	slk:lemma	chopine
-01028163-s	slk:lemma	prispôsobivý
+01028163-a	slk:lemma	prispôsobivý
 08274565-n	slk:lemma	stádo
 01955508-v	slk:lemma	poslať (vopred, dopredu, na novú adresu)
 07831267-n	slk:lemma	rajčinová omáčka
-00599005-s	slk:lemma	ovládnutý
+00599005-a	slk:lemma	ovládnutý
 12683950-n	slk:lemma	čeľaď Balsaminaceae
 05698247-n	slk:lemma	neistota
 10448983-n	slk:lemma	policajt
@@ -15329,30 +15329,30 @@
 00889740-v	slk:lemma	poistiť
 05650820-n	slk:lemma	reč
 03545150-n	slk:lemma	sídlo
-00561896-s	slk:lemma	zhodný
+00561896-a	slk:lemma	zhodný
 00709205-v	slk:lemma	chcieť
 04627000-n	slk:lemma	náklonnosť
 00752431-n	slk:lemma	pretvárka
 10630188-n	slk:lemma	prednášajúci
 01636221-v	slk:lemma	predstavovať si niečo ako možné
-00506601-s	slk:lemma	starostlivý
+00506601-a	slk:lemma	starostlivý
 04867871-n	slk:lemma	nepriamosť
 02829565-a	slk:lemma	poslanecký
 06740183-n	slk:lemma	zdôvodnenie
 10298647-n	slk:lemma	majster
 02234087-v	slk:lemma	vymedziť
 11524662-n	slk:lemma	poveternostné podmienky
-00800597-s	slk:lemma	oslabený
+00800597-a	slk:lemma	oslabený
 04258982-n	slk:lemma	podošva
-02111095-s	slk:lemma	izolovaný
+02111095-a	slk:lemma	izolovaný
 00807178-v	slk:lemma	odmietať
 05582305-n	slk:lemma	základná hmota
 00005779-r	slk:lemma	úžasne
-00915420-s	slk:lemma	fotogenický
+00915420-a	slk:lemma	fotogenický
 00858631-n	slk:lemma	odpočinok
 05899087-n	slk:lemma	pracovný plán
 04025350-n	slk:lemma	bábka
-01761375-s	slk:lemma	nedovolený
+01761375-a	slk:lemma	nedovolený
 01721556-v	slk:lemma	hrať
 09248477-n	slk:lemma	pobrežný horský hrebeň
 05162985-n	slk:lemma	ujma
@@ -15371,14 +15371,14 @@
 00851744-a	slk:lemma	spôsobilý
 00733044-v	slk:lemma	vyriešiť
 08633957-n	slk:lemma	port
-01036874-s	slk:lemma	domáci
+01036874-a	slk:lemma	domáci
 00998399-v	slk:lemma	zaznamenávať
 02549581-v	slk:lemma	dohliadnuť
 15211484-n	slk:lemma	máj
 09875540-n	slk:lemma	brigádny generál
-01397998-s	slk:lemma	porézny
+01397998-a	slk:lemma	porézny
 02619612-v	slk:lemma	mať zmysel
-02164913-s	slk:lemma	riedky
+02164913-a	slk:lemma	riedky
 06440489-n	slk:lemma	Kniha proroka Habakuka
 05736002-n	slk:lemma	zaradenie
 08168978-n	slk:lemma	krajina
@@ -15406,7 +15406,7 @@
 11426125-n	slk:lemma	atómová energia
 02575723-v	slk:lemma	prekabátiť
 01888511-v	slk:lemma	chvieť sa
-00527188-s	slk:lemma	všeobecný
+00527188-a	slk:lemma	všeobecný
 15086545-n	slk:lemma	tungový olej
 01234090-n	slk:lemma	nezúčastňovanie sa
 06502192-n	slk:lemma	kniha pozemkov
@@ -15414,13 +15414,13 @@
 06759349-n	slk:lemma	klam
 00249852-v	slk:lemma	dozrieť
 00219856-n	slk:lemma	usmrtenie z milosti
-01640124-s	slk:lemma	dávno minulý
+01640124-a	slk:lemma	dávno minulý
 02458943-v	slk:lemma	lobovať
-00972642-s	slk:lemma	priekopnícky (technológia)
+00972642-a	slk:lemma	priekopnícky (technológia)
 04695963-n	slk:lemma	matnosť
 14971519-n	slk:lemma	kysličník
 09370168-n	slk:lemma	Nová rieka
-00148852-s	slk:lemma	intrigánsky
+00148852-a	slk:lemma	intrigánsky
 01212572-v	slk:lemma	zdrapiť
 00281132-n	slk:lemma	vchod
 09679316-n	slk:lemma	protestant
@@ -15429,7 +15429,7 @@
 00248977-n	slk:lemma	zdokonalenie
 08852843-n	slk:lemma	Bolívijská republika
 09955781-n	slk:lemma	poslankyňa
-01435060-s	slk:lemma	diaľkový
+01435060-a	slk:lemma	diaľkový
 02559752-v	slk:lemma	zablokovať
 15295045-n	slk:lemma	rozkvet
 00752954-n	slk:lemma	klam
@@ -15443,10 +15443,10 @@
 00300247-r	slk:lemma	azda
 00376400-n	slk:lemma	lom
 09321901-n	slk:lemma	rieka Jordán
-01383582-s	slk:lemma	obrovitánsky
+01383582-a	slk:lemma	obrovitánsky
 07515790-n	slk:lemma	vyrovnanosť
 07157273-n	slk:lemma	slang
-01882292-s	slk:lemma	apokalyptický
+01882292-a	slk:lemma	apokalyptický
 00411570-r	slk:lemma	nijakým činom
 01953810-v	slk:lemma	dopraviť
 15064053-n	slk:lemma	oxid siričitý
@@ -15458,10 +15458,10 @@
 05000913-n	slk:lemma	baculatosť
 05858936-n	slk:lemma	nemenné množstvo
 02847894-a	slk:lemma	finančný
-00510644-s	slk:lemma	schopný
+00510644-a	slk:lemma	schopný
 09079875-n	slk:lemma	ostrov Kauai
 05502375-n	slk:lemma	retikulárny aktivačný systém
-00363031-s	slk:lemma	žiariaci
+00363031-a	slk:lemma	žiariaci
 09129442-n	slk:lemma	ND
 01138102-v	slk:lemma	ochraňovať
 04449290-n	slk:lemma	mýtny domček
@@ -15483,12 +15483,12 @@
 00157462-v	slk:lemma	nabrať (rýchlosť)
 00492724-n	slk:lemma	faraón
 06687358-n	slk:lemma	súhlas
-00938659-s	slk:lemma	platný
+00938659-a	slk:lemma	platný
 00392848-n	slk:lemma	odňatie
 12021120-n	slk:lemma	Tanacetum
 04897762-n	slk:lemma	chovanie
 04849972-n	slk:lemma	čistota
-01253254-s	slk:lemma	zamrznutý
+01253254-a	slk:lemma	zamrznutý
 05799212-n	slk:lemma	test
 09305031-n	slk:lemma	dolina
 01573515-v	slk:lemma	trhať
@@ -15497,12 +15497,12 @@
 04162998-n	slk:lemma	miesta na sedenie
 07181935-n	slk:lemma	spor
 08613472-n	slk:lemma	vonkajšia strana
-01822563-s	slk:lemma	realizovateľný
-01277097-s	slk:lemma	hlavný
+01822563-a	slk:lemma	realizovateľný
+01277097-a	slk:lemma	hlavný
 08326383-n	slk:lemma	stála komisia
 00137709-n	slk:lemma	kop z rohu
 02451370-v	slk:lemma	brániť
-02476338-s	slk:lemma	dohodnutý
+02476338-a	slk:lemma	dohodnutý
 03716327-n	slk:lemma	postavička
 13855627-n	slk:lemma	kontrast
 09161803-n	slk:lemma	Venezuelská republika
@@ -15510,14 +15510,14 @@
 00726300-v	slk:lemma	priraďovať
 01617192-v	slk:lemma	vyrábať
 02494923-a	slk:lemma	použitý
-02378872-s	slk:lemma	súbežný
+02378872-a	slk:lemma	súbežný
 06446860-n	slk:lemma	Prvý Petrov list
 01411085-v	slk:lemma	vylátať
 00027384-r	slk:lemma	a jednako
 02423762-v	slk:lemma	utajiť
 00843468-v	slk:lemma	obviniť
 10396106-n	slk:lemma	diskutér
-01732131-s	slk:lemma	moderný
+01732131-a	slk:lemma	moderný
 08414040-n	slk:lemma	obvod inšpektora
 10253611-n	slk:lemma	odkazovník
 05913275-n	slk:lemma	generalizácia
@@ -15529,7 +15529,7 @@
 01725051-v	slk:lemma	vyhrávať
 07442068-n	slk:lemma	vír
 00877327-v	slk:lemma	(vedecky) skúmať
-01769179-s	slk:lemma	osobný
+01769179-a	slk:lemma	osobný
 01311103-v	slk:lemma	kopať
 05747582-n	slk:lemma	nový odhad
 01467986-n	slk:lemma	podkmeň plášťovce
@@ -15539,7 +15539,7 @@
 01139865-v	slk:lemma	pozorovať vtáky (v prírode)
 00740336-a	slk:lemma	neurčitý
 02930766-n	slk:lemma	taxík
-00168910-s	slk:lemma	príjemný
+00168910-a	slk:lemma	príjemný
 09312231-n	slk:lemma	rieka Indus
 05057805-n	slk:lemma	VKV vlny
 04239074-n	slk:lemma	posuvné dvere
@@ -15547,7 +15547,7 @@
 08361001-n	slk:lemma	autokracia
 11744583-n	slk:lemma	rastlinná čeľaď
 00978993-n	slk:lemma	kobercové bombardovanie
-01901186-s	slk:lemma	pozdný
+01901186-a	slk:lemma	pozdný
 00317207-n	slk:lemma	doručenie
 06526291-n	slk:lemma	partnerstvo
 05425910-n	slk:lemma	kapilára
@@ -15583,7 +15583,7 @@
 02014553-v	slk:lemma	vzlietnuť
 10222822-n	slk:lemma	zamestnanec s pravidelnou prácou
 02415831-v	slk:lemma	zaneprázdniť
-00012071-s	slk:lemma	hypotetický
+00012071-a	slk:lemma	hypotetický
 02701628-v	slk:lemma	uchovať
 00020259-v	slk:lemma	zostať hore
 06434368-n	slk:lemma	Kniha Rút
@@ -15593,7 +15593,7 @@
 00034213-n	slk:lemma	jav
 10669486-n	slk:lemma	navrhovateľ
 00140967-v	slk:lemma	zmeniť tvar
-01520091-s	slk:lemma	jednoznačný
+01520091-a	slk:lemma	jednoznačný
 02964634-n	slk:lemma	skladiskový priestor
 10698970-n	slk:lemma	úradník pri bankovej priehradke
 00609683-v	slk:lemma	uchovávať v pamäti
@@ -15621,20 +15621,20 @@
 00491438-r	slk:lemma	zbytočne
 10041887-n	slk:lemma	zárobkovo činná osoba
 14395240-n	slk:lemma	pochabosť
-00414919-s	slk:lemma	triedený
+00414919-a	slk:lemma	triedený
 06341431-n	slk:lemma	p.
 04954534-n	slk:lemma	odblesk
 01752884-v	slk:lemma	produkovať
-02065958-s	slk:lemma	protichodný
+02065958-a	slk:lemma	protichodný
 01111028-v	slk:lemma	víťaziť
 09410026-n	slk:lemma	medzera
-02038126-s	slk:lemma	statný
+02038126-a	slk:lemma	statný
 00897564-v	slk:lemma	predniesť prejav
 00853633-v	slk:lemma	vtipkovať
-01797633-s	slk:lemma	vopred daný
+01797633-a	slk:lemma	vopred daný
 01252730-v	slk:lemma	pokryť slizom
 06208021-n	slk:lemma	presvedčenie
-01998730-s	slk:lemma	nespoľahlivý
+01998730-a	slk:lemma	nespoľahlivý
 02087551-n	slk:lemma	poľovnícky pes
 07466832-n	slk:lemma	záverečný zápas
 03206282-n	slk:lemma	diskotéka
@@ -15652,7 +15652,7 @@
 01787955-v	slk:lemma	naštvať
 01719921-v	slk:lemma	hrať
 06790042-n	slk:lemma	doktrína
-01443097-s	slk:lemma	strácajúci sa
+01443097-a	slk:lemma	strácajúci sa
 08723006-n	slk:lemma	červená Čína
 08274565-n	slk:lemma	kŕdeľ
 06149484-n	slk:lemma	ekonómia
@@ -15663,7 +15663,7 @@
 02257370-v	slk:lemma	zamieňať
 08397255-n	slk:lemma	garda
 00994989-n	slk:lemma	zónová paľba
-01385773-s	slk:lemma	obrovský
+01385773-a	slk:lemma	obrovský
 01820302-v	slk:lemma	tešiť sa
 02651193-v	slk:lemma	žiť spolu
 01433294-v	slk:lemma	priniesť
@@ -15726,13 +15726,13 @@
 00178909-r	slk:lemma	bohato
 01856929-a	slk:lemma	neplánovaný
 00599720-v	slk:lemma	poučiť
-01143855-s	slk:lemma	náhly
+01143855-a	slk:lemma	náhly
 00404501-r	slk:lemma	smutno
 01036319-v	slk:lemma	vystaviť nebezpečenstvu
 00249313-v	slk:lemma	vrátiť sa
 03442288-n	slk:lemma	rezbárstvo
 00704690-v	slk:lemma	plánovať
-02321809-s	slk:lemma	mocný
+02321809-a	slk:lemma	mocný
 01424456-v	slk:lemma	objímať
 07704054-n	slk:lemma	kukuričná kaša
 02348459-v	slk:lemma	zasielať
@@ -15742,16 +15742,16 @@
 00050037-n	slk:lemma	záznam
 09242389-n	slk:lemma	roklina
 09397607-n	slk:lemma	mláka
-00580684-s	slk:lemma	označený
+00580684-a	slk:lemma	označený
 00418615-n	slk:lemma	bezohľadnosť
 08651832-n	slk:lemma	špinavá štvrť
-02186338-s	slk:lemma	jedna
+02186338-a	slk:lemma	jedna
 07390945-n	slk:lemma	hrmot
 07181935-n	slk:lemma	konflikt
 01810466-n	slk:lemma	Columbiformes
 14968185-n	slk:lemma	tallový olej
 02857023-n	slk:lemma	hracia doska
-01513050-s	slk:lemma	vážny
+01513050-a	slk:lemma	vážny
 00343249-n	slk:lemma	krútenie sa
 02261888-v	slk:lemma	oceňovať
 00529266-a	slk:lemma	pokojný
@@ -15775,8 +15775,8 @@
 00925207-n	slk:lemma	tvarovanie
 13530408-n	slk:lemma	oxidovanie
 06486874-n	slk:lemma	súpis
-00719442-s	slk:lemma	vrtošivý
-00398978-s	slk:lemma	viacfarebný
+00719442-a	slk:lemma	vrtošivý
+00398978-a	slk:lemma	viacfarebný
 00363493-v	slk:lemma	pozastaviť
 11565385-n	slk:lemma	čeľaď dilleniid dicot
 03209141-n	slk:lemma	disková rýchla pamäť
@@ -15787,7 +15787,7 @@
 04120093-n	slk:lemma	bežec
 07162194-n	slk:lemma	návrh
 02542280-v	slk:lemma	podrobiť sa
-01474942-s	slk:lemma	kontrolovateľný
+01474942-a	slk:lemma	kontrolovateľný
 04811126-n	slk:lemma	nezákonnosť
 07028373-n	slk:lemma	melódia
 02631163-v	slk:lemma	kombinovať (v sebe)
@@ -15797,27 +15797,27 @@
 02382367-v	slk:lemma	odstupovať z funkcie
 02756558-v	slk:lemma	pršiavať
 00730052-v	slk:lemma	mať v úmysle
-01925708-s	slk:lemma	koherentný
+01925708-a	slk:lemma	koherentný
 02624263-v	slk:lemma	vyvinúť sa
 14480772-n	slk:lemma	pevná fáza
 00357906-n	slk:lemma	zahusťovanie
-00021110-s	slk:lemma	láskavý
+00021110-a	slk:lemma	láskavý
 03519578-n	slk:lemma	cesta
-01267632-s	slk:lemma	drsný humor
+01267632-a	slk:lemma	drsný humor
 02118933-v	slk:lemma	opatrovať poznámkami
 07303335-n	slk:lemma	vatra
 02274482-v	slk:lemma	zbavovať
 01022064-a	slk:lemma	ohybný
-00728431-s	slk:lemma	autonómny
+00728431-a	slk:lemma	autonómny
 01556921-v	slk:lemma	odštepovať sa
 00892467-v	slk:lemma	oceniť
 00260648-v	slk:lemma	zrenovovať
 00626428-v	slk:lemma	predčítať
 09503282-n	slk:lemma	bosorka
 02953673-n	slk:lemma	plátno
-02242798-s	slk:lemma	pokrytý chrastami
+02242798-a	slk:lemma	pokrytý chrastami
 02802215-n	slk:lemma	kôš
-01131454-s	slk:lemma	mrzký
+01131454-a	slk:lemma	mrzký
 00106921-r	slk:lemma	obvykle
 00896141-v	slk:lemma	potvrdiť správnosť
 02325558-v	slk:lemma	zasvätiť
@@ -15832,7 +15832,7 @@
 01241767-n	slk:lemma	ospravedlňovanie
 02559752-v	slk:lemma	pozastaviť
 04294879-n	slk:lemma	chliev
-00901969-s	slk:lemma	pevný
+00901969-a	slk:lemma	pevný
 00009631-v	slk:lemma	šklbať
 04453910-n	slk:lemma	kryt
 02387034-v	slk:lemma	trénovať sa
@@ -15848,12 +15848,12 @@
 00453803-v	slk:lemma	doplniť
 06624161-n	slk:lemma	list
 00512522-n	slk:lemma	flirt
-02342899-s	slk:lemma	vyberaný
+02342899-a	slk:lemma	vyberaný
 04934546-n	slk:lemma	konzistencia
 08993288-n	slk:lemma	Kráľovstvo Saudskej Arábie
 09091538-n	slk:lemma	Lafayette
 13982357-n	slk:lemma	nezhoda
-00808822-s	slk:lemma	striedajúci
+00808822-a	slk:lemma	striedajúci
 08426816-n	slk:lemma	vojenská jednotka
 03096593-n	slk:lemma	antikoncepčný prostriedok
 01774426-v	slk:lemma	zhroziť sa
@@ -15870,11 +15870,11 @@
 01145359-n	slk:lemma	znemožnenie
 06862562-n	slk:lemma	hudobný kľúč
 01187810-n	slk:lemma	rozsudok
-00169056-s	slk:lemma	pôvabný
+00169056-a	slk:lemma	pôvabný
 05710687-n	slk:lemma	detekcia
 02075049-v	slk:lemma	utiecť
 14991712-n	slk:lemma	rastlinný materiál
-00505410-s	slk:lemma	nevídaný
+00505410-a	slk:lemma	nevídaný
 02988402-a	slk:lemma	národný
 01338368-v	slk:lemma	pokryť bridlicou
 05325786-n	slk:lemma	fenestra rotunda
@@ -15888,7 +15888,7 @@
 07138085-n	slk:lemma	prejav
 05100269-n	slk:lemma	intenzita poľa
 05784831-n	slk:lemma	úvaha
-02090228-s	slk:lemma	tajný
+02090228-a	slk:lemma	tajný
 08740022-n	slk:lemma	Yucatán
 07734017-n	slk:lemma	rajčina
 01577093-v	slk:lemma	zmáčať
@@ -15899,7 +15899,7 @@
 01099592-v	slk:lemma	nevyhrávať
 02304982-v	slk:lemma	nakopiť sa
 00065575-r	slk:lemma	detailne
-02038126-s	slk:lemma	veľký
+02038126-a	slk:lemma	veľký
 00257228-n	slk:lemma	umývanie
 15026963-n	slk:lemma	hemosiderin
 03401500-n	slk:lemma	benzínové potrubie
@@ -15914,15 +15914,15 @@
 02387486-v	slk:lemma	vychovávať sa
 02393086-v	slk:lemma	prekladať
 13914608-n	slk:lemma	kocka
-00193480-s	slk:lemma	odporný
+00193480-a	slk:lemma	odporný
 00989602-v	slk:lemma	prednášať reč
 01101734-v	slk:lemma	vyhrať
 01401854-a	slk:lemma	nelegálny
 00273445-v	slk:lemma	zvyknúť
 00227165-v	slk:lemma	vystupňovať sa
-02279723-s	slk:lemma	veselý
+02279723-a	slk:lemma	veselý
 00804476-v	slk:lemma	podliehať
-00018850-s	slk:lemma	napadnuteľný
+00018850-a	slk:lemma	napadnuteľný
 00678010-n	slk:lemma	chirurgický rez
 04747445-n	slk:lemma	podobnosť
 07368256-n	slk:lemma	zoslabenie
@@ -15930,14 +15930,14 @@
 08506641-n	slk:lemma	bojisko
 00228283-n	slk:lemma	zrušenie
 15140405-n	slk:lemma	doba existencie
-02573443-s	slk:lemma	porastený húštinou
+02573443-a	slk:lemma	porastený húštinou
 00317207-n	slk:lemma	dodanie
 06687358-n	slk:lemma	oprávnenie
 04262010-n	slk:lemma	otvor v stene zvonice
 00159396-n	slk:lemma	úplatok
 01295275-v	slk:lemma	spájať
 10638385-n	slk:lemma	hlas
-02068730-s	slk:lemma	vyššie spomenutý
+02068730-a	slk:lemma	vyššie spomenutý
 13281130-n	slk:lemma	poplatok
 00910555-v	slk:lemma	dohovoriť
 09610660-n	slk:lemma	účastník komunikácie
@@ -15946,7 +15946,7 @@
 09005153-n	slk:lemma	Kaluga
 13318584-n	slk:lemma	úrok
 07085375-n	slk:lemma	akcent
-00978199-s	slk:lemma	rýchly
+00978199-a	slk:lemma	rýchly
 05798043-n	slk:lemma	experimentovanie
 13508183-n	slk:lemma	posun riadka
 00664276-v	slk:lemma	overiť
@@ -15957,26 +15957,26 @@
 06695227-n	slk:lemma	poklona
 06671484-n	slk:lemma	pokyn
 02236124-v	slk:lemma	brať
-00935103-s	slk:lemma	lacný
+00935103-a	slk:lemma	lacný
 07463733-n	slk:lemma	preteky v lyžovaní
 03759243-n	slk:lemma	mikrofiše
 10225219-n	slk:lemma	sudca
 00559690-a	slk:lemma	plný ľudí
 07321772-n	slk:lemma	objavenie sa
 00358985-r	slk:lemma	každú hodinu
-02114613-s	slk:lemma	purulentný
+02114613-a	slk:lemma	purulentný
 00099712-r	slk:lemma	väčšmi
 10104209-n	slk:lemma	dozorca
 02743050-n	slk:lemma	hrot šípu
 00712225-n	slk:lemma	nasadenie
-01894324-s	slk:lemma	overený
+01894324-a	slk:lemma	overený
 02122164-v	slk:lemma	pobolievať
 03097890-n	slk:lemma	kontrolovaná látka
 00300761-v	slk:lemma	kvalifikovať
 03079230-n	slk:lemma	cédečko
 00169298-v	slk:lemma	obnoviť sa
 01900349-a	slk:lemma	presný
-01384730-s	slk:lemma	ohromujúci
+01384730-a	slk:lemma	ohromujúci
 03137579-n	slk:lemma	priečna podpera
 00417643-n	slk:lemma	chovanie v náručí
 10175507-n	slk:lemma	bandita
@@ -15997,13 +15997,13 @@
 09293340-n	slk:lemma	Východoafrikcká priekopová prepadlina
 07502669-n	slk:lemma	odpor
 02582615-v	slk:lemma	spáchať
-01385773-s	slk:lemma	gigantický
-00837415-s	slk:lemma	lopotný
+01385773-a	slk:lemma	gigantický
+00837415-a	slk:lemma	lopotný
 01523986-v	slk:lemma	zvinúť
 00908909-n	slk:lemma	tvorba zo surového, nespracovaného materiálu
 09198574-n	slk:lemma	Južný oceán
 02575723-v	slk:lemma	obabrať
-00533221-s	slk:lemma	dostupný
+00533221-a	slk:lemma	dostupný
 00631887-n	slk:lemma	štúdium vzhľadu
 03154073-n	slk:lemma	krájač
 00084223-r	slk:lemma	zvlášť
@@ -16020,7 +16020,7 @@
 03209141-n	slk:lemma	pamäť cache
 07500741-n	slk:lemma	obdiv
 00637259-v	slk:lemma	vyčísliť
-00022437-s	slk:lemma	úplne správny
+00022437-a	slk:lemma	úplne správny
 00259019-r	slk:lemma	naživo
 00065822-r	slk:lemma	napokon
 07965085-n	slk:lemma	administratívny orgán
@@ -16050,7 +16050,7 @@
 10069427-n	slk:lemma	kat
 09050730-n	slk:lemma	americký Juh
 08253141-n	slk:lemma	tanečná zábava
-01993693-s	slk:lemma	vážny
+01993693-a	slk:lemma	vážny
 13086908-n	slk:lemma	časť rastliny
 00628491-v	slk:lemma	zamyslieť sa
 15142025-n	slk:lemma	priemerná dĺžka života
@@ -16060,9 +16060,9 @@
 05284333-n	slk:lemma	stavec
 01211019-n	slk:lemma	podpora
 00625774-a	slk:lemma	nepodstatný
-02467559-s	slk:lemma	obrátený
+02467559-a	slk:lemma	obrátený
 02993546-n	slk:lemma	centrum
-00516231-s	slk:lemma	celý
+00516231-a	slk:lemma	celý
 05579604-n	slk:lemma	trojhlavý sval
 00155621-r	slk:lemma	skôr
 04190052-n	slk:lemma	polica
@@ -16072,7 +16072,7 @@
 00467451-v	slk:lemma	integrovať sa
 14419164-n	slk:lemma	zväzok
 06652242-n	slk:lemma	pravidlo
-01139832-s	slk:lemma	plynulý
+01139832-a	slk:lemma	plynulý
 01159655-a	slk:lemma	neškodný
 08221897-n	slk:lemma	obecenstvo
 14414715-n	slk:lemma	izolácia
@@ -16086,20 +16086,20 @@
 12922600-n	slk:lemma	rod Croton
 00902424-v	slk:lemma	zbavovať zodpovednosti
 08256735-n	slk:lemma	svadba
-01442079-s	slk:lemma	ročný
+01442079-a	slk:lemma	ročný
 09292007-n	slk:lemma	Veľký austrálsky záliv
 14418662-n	slk:lemma	zlúčenie
 01194418-v	slk:lemma	hostiť
 00450070-n	slk:lemma	dostihy
 04086794-n	slk:lemma	odporník
 07918309-n	slk:lemma	stinger
-01466476-s	slk:lemma	pod papučou
+01466476-a	slk:lemma	pod papučou
 04540397-n	slk:lemma	stabilizátor napätia
 02485451-v	slk:lemma	popravovať (obesením)
 11804604-n	slk:lemma	čeľaď klinčekovité
 09436708-n	slk:lemma	obloha
-01573238-s	slk:lemma	umelý
-02436995-s	slk:lemma	tvrdý
+01573238-a	slk:lemma	umelý
+02436995-a	slk:lemma	tvrdý
 08616311-n	slk:lemma	trasa cesty
 15164354-n	slk:lemma	štvrtok
 01776214-v	slk:lemma	venovať sa niečomu
@@ -16108,12 +16108,12 @@
 05199869-n	slk:lemma	pôsobivosť
 14445226-n	slk:lemma	pohroma
 03408054-n	slk:lemma	trup lietadla
-02361848-s	slk:lemma	schopný dať sa prehovoriť
+02361848-a	slk:lemma	schopný dať sa prehovoriť
 00778958-a	slk:lemma	ležiaci uprostred
 01571744-v	slk:lemma	popraviť garotou
 01291234-a	slk:lemma	na strane diferenciálu
-00260695-s	slk:lemma	buržoázny
-01539444-s	slk:lemma	skromný
+00260695-a	slk:lemma	buržoázny
+01539444-a	slk:lemma	skromný
 01621555-v	slk:lemma	produkovať
 13954118-n	slk:lemma	penzia
 10020890-n	slk:lemma	lekár
@@ -16123,7 +16123,7 @@
 15160579-n	slk:lemma	dátum
 03855908-n	slk:lemma	spodná paluba
 06272290-n	slk:lemma	telefón
-00792641-s	slk:lemma	najvyšší
+00792641-a	slk:lemma	najvyšší
 02321391-v	slk:lemma	ozbíjať
 00220461-v	slk:lemma	zosilnievať
 06803845-n	slk:lemma	tiesňové volanie
@@ -16145,7 +16145,7 @@
 00338821-n	slk:lemma	znovuusporiadanie
 13251906-n	slk:lemma	barónstvo
 02642814-v	slk:lemma	odkladať
-00522885-s	slk:lemma	kompletný
+00522885-a	slk:lemma	kompletný
 07996149-n	slk:lemma	roj (hmyzu)
 10700517-n	slk:lemma	nájomca
 13987905-n	slk:lemma	blaho
@@ -16154,16 +16154,16 @@
 00114029-r	slk:lemma	mechanicky
 00618267-v	slk:lemma	pomýliť si
 00400449-n	slk:lemma	zalesnenie
-01600713-s	slk:lemma	na sever
+01600713-a	slk:lemma	na sever
 01106460-n	slk:lemma	rýchla doprava zásielok
-01243102-s	slk:lemma	zastrčený
+01243102-a	slk:lemma	zastrčený
 03120029-n	slk:lemma	vrstva
 01330986-a	slk:lemma	integračný
 00253070-n	slk:lemma	morálna očista
 04605726-n	slk:lemma	balenie
 00770543-n	slk:lemma	priestupok
 08986691-n	slk:lemma	Katarský poloostrov
-00119006-s	slk:lemma	vitálny
+00119006-a	slk:lemma	vitálny
 05405554-n	slk:lemma	mechanizmus tvorby sĺz
 07041451-n	slk:lemma	duet
 06142861-n	slk:lemma	kognitívna veda
@@ -16180,7 +16180,7 @@
 07635827-n	slk:lemma	maslová sušienka
 10202363-n	slk:lemma	nespôsobilá osoba
 00047392-r	slk:lemma	až príliš
-02477211-s	slk:lemma	združený
+02477211-a	slk:lemma	združený
 10672540-n	slk:lemma	svätiaci biskup
 05830059-n	slk:lemma	utrpenie
 06873252-n	slk:lemma	komunikácia zrakom
@@ -16191,7 +16191,7 @@
 07731587-n	slk:lemma	šalát lesný
 05896059-n	slk:lemma	mylná predstava
 13717155-n	slk:lemma	jednotka hmotnosti
-00891970-s	slk:lemma	stály (o teplote)
+00891970-a	slk:lemma	stály (o teplote)
 03820728-n	slk:lemma	sieť
 00388392-n	slk:lemma	vetvenie
 02292004-v	slk:lemma	vyplatiť sa
@@ -16201,7 +16201,7 @@
 04935239-n	slk:lemma	lepkavosť
 08220714-n	slk:lemma	úsek
 05833840-n	slk:lemma	idea
-00067379-s	slk:lemma	najlepší
+00067379-a	slk:lemma	najlepší
 00065575-r	slk:lemma	obšírne
 01527420-a	slk:lemma	metalický
 02486932-v	slk:lemma	zhromažďovať sa
@@ -16228,7 +16228,7 @@
 04048568-n	slk:lemma	železnice
 13282550-n	slk:lemma	kompenzácia
 00207761-n	slk:lemma	vyhnanie
-02397119-s	slk:lemma	ovocný
+02397119-a	slk:lemma	ovocný
 05316025-n	slk:lemma	buľva
 13482330-n	slk:lemma	prúd
 01280014-v	slk:lemma	ohnúť
@@ -16236,14 +16236,14 @@
 02575723-v	slk:lemma	dostať
 00048268-r	slk:lemma	momentálne
 02304982-v	slk:lemma	nahromadiť sa
-00325619-s	slk:lemma	opatrný
+00325619-a	slk:lemma	opatrný
 04294879-n	slk:lemma	stajňa
 00807178-v	slk:lemma	nesúhlasiť
 10570019-n	slk:lemma	sekretár
 00679389-v	slk:lemma	zvoliť
 02986218-a	slk:lemma	logistický
 15293435-n	slk:lemma	nočná stráž
-01655538-s	slk:lemma	stisnutý
+01655538-a	slk:lemma	stisnutý
 10780632-n	slk:lemma	vydatá žena
 13375604-n	slk:lemma	kreditný účet
 01155722-n	slk:lemma	pohyb prostriedkov uvoľnením z jednej investície a vkladom do ďalšej investície
@@ -16253,7 +16253,7 @@
 03099945-n	slk:lemma	menič
 09481523-n	slk:lemma	Yangtze Kiang
 01199755-v	slk:lemma	nadýchnuť sa
-00547317-s	slk:lemma	krátky
+00547317-a	slk:lemma	krátky
 06224657-n	slk:lemma	pohanstvo
 01686132-v	slk:lemma	zobraziť
 08236438-n	slk:lemma	syndikát
@@ -16272,14 +16272,14 @@
 02506546-v	slk:lemma	vynútiť
 00221900-n	slk:lemma	otcovražda
 00035465-a	slk:lemma	aktívny
-00595299-s	slk:lemma	neustály
-00590669-s	slk:lemma	sporný
+00595299-a	slk:lemma	neustály
+00590669-a	slk:lemma	sporný
 00800930-v	slk:lemma	nedbať (na)
 05300231-n	slk:lemma	chemoreceptor
 03719650-n	slk:lemma	ochranný štít
 00069815-n	slk:lemma	porušenie sľubu
 13872592-n	slk:lemma	konoid
-01580775-s	slk:lemma	požadovaný
+01580775-a	slk:lemma	požadovaný
 11515935-n	slk:lemma	nebo pri súmraku
 00842989-v	slk:lemma	obžalovať
 11872973-n	slk:lemma	chren obyčajný
@@ -16295,18 +16295,18 @@
 14100769-n	slk:lemma	oklúzia
 05199869-n	slk:lemma	efektívnosť
 00625774-a	slk:lemma	nehmotný
-01788048-s	slk:lemma	kockovaný
+01788048-a	slk:lemma	kockovaný
 00839834-v	slk:lemma	zveličiť
 00793785-v	slk:lemma	zviesť
 00521562-n	slk:lemma	podanie
-01638962-s	slk:lemma	starodávny
+01638962-a	slk:lemma	starodávny
 09789566-n	slk:lemma	osoba po amputácii
-01649031-s	slk:lemma	mladý
+01649031-a	slk:lemma	mladý
 01846320-v	slk:lemma	urobiť okružnú plavbu
-01723648-s	slk:lemma	pokojný
+01723648-a	slk:lemma	pokojný
 05085572-n	slk:lemma	blízkosť
-00974159-s	slk:lemma	nemoderný
-00015247-s	slk:lemma	hojný
+00974159-a	slk:lemma	nemoderný
+00015247-a	slk:lemma	hojný
 09144484-n	slk:lemma	Galveston
 02312996-v	slk:lemma	sňať bremeno
 00042936-v	slk:lemma	robiť pedikúru
@@ -16318,15 +16318,15 @@
 01822248-v	slk:lemma	ľutovať (niekoho)
 00607780-v	slk:lemma	pomyslieť
 07150023-n	slk:lemma	jednanie o kolektívnej zmluve
-00669942-s	slk:lemma	mizerný
-02571277-s	slk:lemma	idiotský
+00669942-a	slk:lemma	mizerný
+02571277-a	slk:lemma	idiotský
 13941469-n	slk:lemma	životný štandard
 01071411-n	slk:lemma	zhovievavosť
 01312371-v	slk:lemma	nabrať
 08615001-n	slk:lemma	farnosť
 05773923-n	slk:lemma	domnienka
 09974648-n	slk:lemma	tovariš
-01769378-s	slk:lemma	súkromný
+01769378-a	slk:lemma	súkromný
 13748128-n	slk:lemma	dvadsiatka
 00634906-v	slk:lemma	porozumieť
 04878861-n	slk:lemma	nevera, manželská
@@ -16335,20 +16335,20 @@
 01651896-a	slk:lemma	odvolaný
 01775879-n	slk:lemma	roztoče
 00020827-n	slk:lemma	matéria
-01601981-s	slk:lemma	severozápadný
+01601981-a	slk:lemma	severozápadný
 00989385-n	slk:lemma	paľba priamej podpory
 04099429-n	slk:lemma	projektil
 13301835-n	slk:lemma	prekročenie nákladového rozpočtu
 00959376-n	slk:lemma	zrážka
 09337686-n	slk:lemma	Lena
 10372373-n	slk:lemma	úradník
-02038994-s	slk:lemma	pevný
+02038994-a	slk:lemma	pevný
 00509607-v	slk:lemma	robiť bodky
 10004804-n	slk:lemma	rodinný príslušník
 00806049-v	slk:lemma	udeliť
 02906351-a	slk:lemma	demografický
 00085512-r	slk:lemma	zreteľne
-02065665-s	slk:lemma	rozmanitý
+02065665-a	slk:lemma	rozmanitý
 00126733-r	slk:lemma	symbolicky
 02787435-n	slk:lemma	ozdoba
 05935060-n	slk:lemma	spomienka
@@ -16357,21 +16357,21 @@
 07523180-n	slk:lemma	zdráhavosť
 04935528-n	slk:lemma	lepkavosť
 10548537-n	slk:lemma	predavač
-01533535-s	slk:lemma	abnormálny
+01533535-a	slk:lemma	abnormálny
 00004819-v	slk:lemma	kýchať
 03098140-n	slk:lemma	radiaca doska
-02397496-s	slk:lemma	korenený
+02397496-a	slk:lemma	korenený
 09764201-n	slk:lemma	nadobúdateľ
 05303232-n	slk:lemma	cervix
 01147060-v	slk:lemma	odvracať
-02250430-s	slk:lemma	osamotený
+02250430-a	slk:lemma	osamotený
 10650162-n	slk:lemma	politik
 13864153-n	slk:lemma	vypuklosť
 06444458-n	slk:lemma	List apoštola Pavla Filipanom
 00192659-v	slk:lemma	povzbudiť
 02611630-v	slk:lemma	konkretizovať
 14677778-n	slk:lemma	gyps
-01282510-s	slk:lemma	budiaci úžas
+01282510-a	slk:lemma	budiaci úžas
 07314427-n	slk:lemma	nešťastie
 00820352-v	slk:lemma	potvrdiť
 00033663-r	slk:lemma	troška
@@ -16390,11 +16390,11 @@
 00876989-a	slk:lemma	vývozný
 00960734-v	slk:lemma	zosúladiť
 04517535-n	slk:lemma	očkovacia látka
-00625055-s	slk:lemma	podstatný
+00625055-a	slk:lemma	podstatný
 00385501-n	slk:lemma	nejednotnosť
 00883297-n	slk:lemma	vyučovanie
 05289297-n	slk:lemma	sval
-02135290-s	slk:lemma	pohlavne chladný
+02135290-a	slk:lemma	pohlavne chladný
 02018049-v	slk:lemma	nasadnúť si
 05723210-n	slk:lemma	kožný cit
 02615207-a	slk:lemma	hliníkový
@@ -16405,7 +16405,7 @@
 01041968-n	slk:lemma	prosba
 02475922-v	slk:lemma	uložiť povinnosť
 02302817-v	slk:lemma	predávať ambulantne
-01475160-s	slk:lemma	riadený
+01475160-a	slk:lemma	riadený
 02803349-n	slk:lemma	basa
 01264283-v	slk:lemma	omietať
 10095664-n	slk:lemma	kontrolór
@@ -16419,32 +16419,32 @@
 04502059-n	slk:lemma	vežové hodiny
 06831391-n	slk:lemma	céčko
 02294436-v	slk:lemma	dávať
-01219007-s	slk:lemma	nájomný dom bez výťahu
+01219007-a	slk:lemma	nájomný dom bez výťahu
 01042228-v	slk:lemma	povrávať
 06090869-n	slk:lemma	fyzika
-01464700-s	slk:lemma	milujúci
+01464700-a	slk:lemma	milujúci
 00053913-n	slk:lemma	zrušenie
 05271685-n	slk:lemma	kuboidná kosť
 01240210-n	slk:lemma	zásah
 09293011-n	slk:lemma	Veľké pláne
-00232620-s	slk:lemma	opravný
+00232620-a	slk:lemma	opravný
 08720481-n	slk:lemma	Čile
 00431826-v	slk:lemma	znížiť sa
 06399503-n	slk:lemma	dodatok
-01035559-s	slk:lemma	cudzieho pôvodu
+01035559-a	slk:lemma	cudzieho pôvodu
 15063108-n	slk:lemma	stavebná oceľ
 03729402-n	slk:lemma	škatuľka zápaliek
 10753546-n	slk:lemma	naničhodník
-01564603-s	slk:lemma	pevný
+01564603-a	slk:lemma	pevný
 03908204-n	slk:lemma	ceruzka
 02416955-v	slk:lemma	podnikať
 07181713-n	slk:lemma	názorový stret
-00473243-s	slk:lemma	spáliteľný
+00473243-a	slk:lemma	spáliteľný
 11523256-n	slk:lemma	zdanlivý obraz
 00768778-v	slk:lemma	nahovoriť
 01612053-a	slk:lemma	oddaný
 02759614-v	slk:lemma	žeraviť
-00260780-s	slk:lemma	provinčný
+00260780-a	slk:lemma	provinčný
 02614023-v	slk:lemma	ísť poza školu
 14920844-n	slk:lemma	izolácia
 01359303-v	slk:lemma	uvoľniť
@@ -16464,7 +16464,7 @@
 05753564-n	slk:lemma	vzdelávanie
 02889746-a	slk:lemma	námorný
 02367363-v	slk:lemma	konať
-01804422-s	slk:lemma	odporný
+01804422-a	slk:lemma	odporný
 01752495-v	slk:lemma	zarodiť
 02662692-a	slk:lemma	bibliofilský
 00672277-v	slk:lemma	posudzovať
@@ -16472,9 +16472,9 @@
 00904046-v	slk:lemma	očistiť
 02755911-v	slk:lemma	byť ponorený v kvapaline
 00798717-v	slk:lemma	vzdať sa
-01752953-s	slk:lemma	defektný
+01752953-a	slk:lemma	defektný
 00588221-v	slk:lemma	získať obraz
-00859632-s	slk:lemma	skúsenostný
+00859632-a	slk:lemma	skúsenostný
 13353156-n	slk:lemma	materiálne zdroje
 01028748-v	slk:lemma	pomenovať
 10142747-n	slk:lemma	babka
@@ -16489,11 +16489,11 @@
 13282161-n	slk:lemma	vrátenie peňazí
 13241057-n	slk:lemma	vlastnícke právo
 05874232-n	slk:lemma	zákon
-01523724-s	slk:lemma	sťahovavý
+01523724-a	slk:lemma	sťahovavý
 00925735-v	slk:lemma	čudovať sa
 01236164-v	slk:lemma	narážať
 12396924-n	slk:lemma	konope
-00965176-s	slk:lemma	perfektne fungujúci
+00965176-a	slk:lemma	perfektne fungujúci
 00281132-n	slk:lemma	prístup
 07317144-n	slk:lemma	lotéria
 00865600-n	slk:lemma	prechod
@@ -16502,7 +16502,7 @@
 02483915-n	slk:lemma	čeľaď Cercopithecidae
 01869196-v	slk:lemma	prikradnúť sa
 01821996-v	slk:lemma	mať súcit s
-01006788-s	slk:lemma	obmedzený
+01006788-a	slk:lemma	obmedzený
 01306425-v	slk:lemma	pobiť
 09399592-n	slk:lemma	útes
 00610374-v	slk:lemma	spoznať
@@ -16514,10 +16514,10 @@
 01108971-n	slk:lemma	depozit
 02044278-v	slk:lemma	krúžiť
 05870916-n	slk:lemma	prirodzený zákon
-01320474-s	slk:lemma	oslobodený
+01320474-a	slk:lemma	oslobodený
 00406234-n	slk:lemma	zakrivenie
 03017168-n	slk:lemma	zvonkohra
-02161982-s	slk:lemma	vážny
+02161982-a	slk:lemma	vážny
 00803325-v	slk:lemma	odsúhlasiť
 07475364-n	slk:lemma	porážka
 01522276-v	slk:lemma	namotať
@@ -16529,7 +16529,7 @@
 00812298-v	slk:lemma	postaviť sa na odpor
 13920835-n	slk:lemma	status
 00653620-v	slk:lemma	porovnať
-01280908-s	slk:lemma	bezvýznamný
+01280908-a	slk:lemma	bezvýznamný
 00964911-v	slk:lemma	nadhodiť (tému)
 01918183-v	slk:lemma	vykračovať si
 06889330-n	slk:lemma	okázalosť
@@ -16541,7 +16541,7 @@
 02251509-v	slk:lemma	pripoistiť sa
 00124880-n	slk:lemma	kontakt
 01209220-n	slk:lemma	starostlivosť
-02075321-s	slk:lemma	šialený
+02075321-a	slk:lemma	šialený
 01990281-v	slk:lemma	vyplávať na hladinu
 02295842-v	slk:lemma	dať do spoločného fondu
 15244650-n	slk:lemma	chvíľka
@@ -16561,7 +16561,7 @@
 02339171-v	slk:lemma	priniesť
 10202624-n	slk:lemma	osoba v úrade
 00251520-n	slk:lemma	deratizácia
-01496311-s	slk:lemma	pochybný
+01496311-a	slk:lemma	pochybný
 00087542-r	slk:lemma	navždy
 05694791-n	slk:lemma	zvod
 06831177-n	slk:lemma	A
@@ -16580,14 +16580,14 @@
 14498843-n	slk:lemma	špina
 00512877-v	slk:lemma	opravňovať
 07537485-n	slk:lemma	melanchólia
-01789481-s	slk:lemma	fľakatý
+01789481-a	slk:lemma	fľakatý
 00034641-r	slk:lemma	najskôr
 10531227-n	slk:lemma	pravičiar
 01219893-n	slk:lemma	hana
 00088777-r	slk:lemma	provizórne
 01027379-n	slk:lemma	obrad
 15283433-n	slk:lemma	rýchlosť letu
-02421364-s	slk:lemma	šetrný
+02421364-a	slk:lemma	šetrný
 01790943-n	slk:lemma	rod kura
 08891595-n	slk:lemma	Škótska vysočina
 01812720-v	slk:lemma	osviežovať
@@ -16617,7 +16617,7 @@
 02345048-v	slk:lemma	pobiť
 02347637-v	slk:lemma	nakladať
 00340715-r	slk:lemma	ustrnuto
-00993885-s	slk:lemma	smrteľný
+00993885-a	slk:lemma	smrteľný
 00731222-n	slk:lemma	misia
 02549211-v	slk:lemma	podporiť
 02138921-n	slk:lemma	rad Chiroptera
@@ -16632,7 +16632,7 @@
 03113152-n	slk:lemma	kozmetika
 00363744-r	slk:lemma	logicky
 00051590-r	slk:lemma	otvorene
-02051616-s	slk:lemma	dedinský
+02051616-a	slk:lemma	dedinský
 06891493-n	slk:lemma	predstavenie
 00871942-v	slk:lemma	byť predzvesťou
 05518870-n	slk:lemma	vajíčkovod
@@ -16648,7 +16648,7 @@
 00332596-r	slk:lemma	naveky
 02410175-v	slk:lemma	držať
 00282858-r	slk:lemma	jednostaj
-00523867-s	slk:lemma	nezávislý
+00523867-a	slk:lemma	nezávislý
 02458103-v	slk:lemma	uviesť do vzťahu
 08101937-n	slk:lemma	línia predkov
 01213886-n	slk:lemma	záštita
@@ -16666,16 +16666,16 @@
 00772967-v	slk:lemma	uvádzať
 00908621-v	slk:lemma	podporiť
 00831074-v	slk:lemma	poučiť sa
-02344672-s	slk:lemma	skvelý
+02344672-a	slk:lemma	skvelý
 00972621-n	slk:lemma	nápor
 00330674-n	slk:lemma	spomalenie
-00967646-s	slk:lemma	groteskný
+00967646-a	slk:lemma	groteskný
 00725274-v	slk:lemma	prekvapiť
 13411005-n	slk:lemma	hrubá súvaha
 02492198-v	slk:lemma	zabaviť sa
 12485523-n	slk:lemma	Buddleia
 00838098-n	slk:lemma	konzumácia
-01161635-s	slk:lemma	katastrofálny
+01161635-a	slk:lemma	katastrofálny
 01809321-v	slk:lemma	prekonávať
 07535010-n	slk:lemma	zármutok
 00586262-n	slk:lemma	postavenie
@@ -16689,7 +16689,7 @@
 10703336-n	slk:lemma	závetca
 13926451-n	slk:lemma	národovosť
 00300247-r	slk:lemma	vari
-00926505-s	slk:lemma	zvyšný
+00926505-a	slk:lemma	zvyšný
 01630117-a	slk:lemma	defenzívny
 15289779-n	slk:lemma	perióda
 06247701-n	slk:lemma	prekážka
@@ -16708,7 +16708,7 @@
 01216191-n	slk:lemma	živobytie
 11872973-n	slk:lemma	Armoracia rusticana
 02075462-v	slk:lemma	zutekať
-01044557-s	slk:lemma	každodenný
+01044557-a	slk:lemma	každodenný
 15141486-n	slk:lemma	okupácia
 03624767-n	slk:lemma	jazdec
 02728440-n	slk:lemma	oblečenie
@@ -16724,24 +16724,24 @@
 05329215-n	slk:lemma	zažívacia sústava
 00855301-n	slk:lemma	fajka
 07351195-n	slk:lemma	zdvih vačky
-02131958-s	slk:lemma	flirtujúci
+02131958-a	slk:lemma	flirtujúci
 02518161-v	slk:lemma	správať sa
 00262596-n	slk:lemma	zdobenie
 13696652-n	slk:lemma	iránska menová jednotka
 06695227-n	slk:lemma	poručenie
 13742573-n	slk:lemma	jeden
-01722140-s	slk:lemma	oprávnený
+01722140-a	slk:lemma	oprávnený
 01850315-v	slk:lemma	odsunúť
 02669789-v	slk:lemma	vyhovovať
 09815188-n	slk:lemma	kokot
 00061014-n	slk:lemma	únik o chlp
 07522729-n	slk:lemma	nesmelosť
 02498320-v	slk:lemma	objednávať si
-00136589-s	slk:lemma	splatný na požiadanie
+00136589-a	slk:lemma	splatný na požiadanie
 00360404-n	slk:lemma	strihanie oviec
 02381089-a	slk:lemma	spojkový
 03903868-n	slk:lemma	stojan
-00440292-s	slk:lemma	nechápavý
+00440292-a	slk:lemma	nechápavý
 03921209-n	slk:lemma	zoznam liečiv
 10020890-n	slk:lemma	doktorka
 08308313-n	slk:lemma	konferencia vedenia alebo voličov politickej strany
@@ -16751,15 +16751,15 @@
 04853948-n	slk:lemma	skazenosť
 05108740-n	slk:lemma	množstvo
 00950858-n	slk:lemma	vyspelá technológia
-00969264-s	slk:lemma	trochu zvláštny
-00978754-s	slk:lemma	okamžitý
+00969264-a	slk:lemma	trochu zvláštny
+00978754-a	slk:lemma	okamžitý
 04802776-n	slk:lemma	odchýlka
 06439253-n	slk:lemma	Kniha proroka Ozeáša
 00144778-n	slk:lemma	pohladenie
 01077350-n	slk:lemma	zamedzenie
 00730247-n	slk:lemma	úloha
-02322512-s	slk:lemma	ťažký
-00672382-s	slk:lemma	šitý na mieru
+02322512-a	slk:lemma	ťažký
+00672382-a	slk:lemma	šitý na mieru
 00027384-r	slk:lemma	rovnako
 02386612-a	slk:lemma	nízky
 01712704-v	slk:lemma	vystupovať (na verejnosti)
@@ -16770,7 +16770,7 @@
 02118379-a	slk:lemma	vážny
 07324673-n	slk:lemma	rozvoj
 06476384-n	slk:lemma	formulár daňového priznania
-01757608-s	slk:lemma	dočasný
+01757608-a	slk:lemma	dočasný
 00614999-v	slk:lemma	pozabudnúť
 09984298-n	slk:lemma	správca
 05013967-n	slk:lemma	teplota topenia
@@ -16778,7 +16778,7 @@
 02988304-n	slk:lemma	CD prehrávač
 04881369-n	slk:lemma	jednoduchosť
 01893988-v	slk:lemma	pohýnať sa
-00890874-s	slk:lemma	súradnicový
+00890874-a	slk:lemma	súradnicový
 00214020-v	slk:lemma	zvlhčovať si
 14460565-n	slk:lemma	jednotnosť
 13340751-n	slk:lemma	ukladacie papiere
@@ -16788,7 +16788,7 @@
 02083806-v	slk:lemma	rozkývať
 02771020-v	slk:lemma	zastrieť oblakmi
 02139544-v	slk:lemma	prejavovať
-01439155-s	slk:lemma	rozťahaný
+01439155-a	slk:lemma	rozťahaný
 01486411-n	slk:lemma	rod Orectolobus
 09315870-n	slk:lemma	Irrawaddy
 09284015-n	slk:lemma	lesná pôda
@@ -16811,11 +16811,11 @@
 07233634-n	slk:lemma	kliatba
 00423471-r	slk:lemma	úplne
 14452151-n	slk:lemma	naplnenie
-01313649-s	slk:lemma	samotný
+01313649-a	slk:lemma	samotný
 09810983-n	slk:lemma	obchodník s umením
 00908621-v	slk:lemma	byť stálym zákazníkom
 15283097-n	slk:lemma	rýchlosť
-00511739-s	slk:lemma	neschopný
+00511739-a	slk:lemma	neschopný
 04903813-n	slk:lemma	pokojná myseľ
 09134999-n	slk:lemma	Allentown
 00928751-n	slk:lemma	urbanistické členenie mesta
@@ -16824,11 +16824,11 @@
 15037339-n	slk:lemma	antigén
 14414294-n	slk:lemma	separácia
 01080297-a	slk:lemma	plodný
-01797633-s	slk:lemma	stanovený
-01383394-s	slk:lemma	dostatočný
+01797633-a	slk:lemma	stanovený
+01383394-a	slk:lemma	dostatočný
 00067999-v	slk:lemma	vytekať
 02450505-v	slk:lemma	zabraňovať
-00195684-s	slk:lemma	špatný
+00195684-a	slk:lemma	špatný
 06094774-n	slk:lemma	akustika
 05594822-n	slk:lemma	chodidlo
 00024257-r	slk:lemma	nijako
@@ -16836,17 +16836,17 @@
 08111157-n	slk:lemma	forma
 00590366-v	slk:lemma	chytiť sa (myšlienkovo)
 13303315-n	slk:lemma	hodnota
-01265308-s	slk:lemma	veselý
+01265308-a	slk:lemma	veselý
 13386614-n	slk:lemma	peňažná hotovosť
 07338552-n	slk:lemma	náraz
 00859758-v	slk:lemma	zabávať sa
-02180277-s	slk:lemma	nepredstieraný
+02180277-a	slk:lemma	nepredstieraný
 00668099-v	slk:lemma	zvládnuť
-00042837-s	slk:lemma	pôsobiaci opačne
+00042837-a	slk:lemma	pôsobiaci opačne
 01631534-v	slk:lemma	vytvoriť za pomoci rozumu
 08630039-n	slk:lemma	región
 01041954-v	slk:lemma	rozširovať klebety
-01866812-s	slk:lemma	bezvýsledný
+01866812-a	slk:lemma	bezvýsledný
 06202686-n	slk:lemma	stranícka nezávislosť
 00306900-n	slk:lemma	úsek
 12431128-n	slk:lemma	Allium
@@ -16862,11 +16862,11 @@
 01267098-v	slk:lemma	vydláždiť
 08057633-n	slk:lemma	dovozca
 01101913-v	slk:lemma	prekonať
-02074929-s	slk:lemma	zjašený
+02074929-a	slk:lemma	zjašený
 01686439-a	slk:lemma	originálny
 00154233-n	slk:lemma	legalizácia
-00013662-s	slk:lemma	ozajstný
-00122844-s	slk:lemma	závislý
+00013662-a	slk:lemma	ozajstný
+00122844-a	slk:lemma	závislý
 00465341-r	slk:lemma	úplne
 02265979-v	slk:lemma	odložiť si
 07327805-n	slk:lemma	činiteľ
@@ -16880,11 +16880,11 @@
 00817167-v	slk:lemma	poprieť
 05146178-n	slk:lemma	určenie dane
 05849040-n	slk:lemma	atribút
-01159907-s	slk:lemma	nevinný
+01159907-a	slk:lemma	nevinný
 05333259-n	slk:lemma	močový orgán
-01523724-s	slk:lemma	schopný dopravy
+01523724-a	slk:lemma	schopný dopravy
 09191635-n	slk:lemma	vzduchová bublina
-02573443-s	slk:lemma	krovinatý
+02573443-a	slk:lemma	krovinatý
 01790020-v	slk:lemma	rozrušiť
 07738353-n	slk:lemma	koža
 14514039-n	slk:lemma	doména
@@ -16904,13 +16904,13 @@
 00743344-v	slk:lemma	kontaktovať
 07340094-n	slk:lemma	škoda
 03986562-n	slk:lemma	svetlík
-01203986-s	slk:lemma	hodnotený
+01203986-a	slk:lemma	hodnotený
 06612266-n	slk:lemma	táranina
 06392935-n	slk:lemma	odstavec
 15241186-n	slk:lemma	poľovnícka sezóna
 04678908-n	slk:lemma	zámienka
 04635104-n	slk:lemma	aktivita
-00304670-s	slk:lemma	divoký
+00304670-a	slk:lemma	divoký
 00062067-v	slk:lemma	operovať
 04248607-n	slk:lemma	snímok
 07472929-n	slk:lemma	politická kampaň
@@ -16929,7 +16929,7 @@
 10569411-n	slk:lemma	člen spravodajskej služby
 03471473-n	slk:lemma	odkvapová rúra
 00205046-v	slk:lemma	polepšiť sa
-00906655-s	slk:lemma	odmietavý
+00906655-a	slk:lemma	odmietavý
 06753299-n	slk:lemma	predpoklad
 00682592-v	slk:lemma	nanovo oceniť
 06539770-n	slk:lemma	nariadenie
@@ -16950,13 +16950,13 @@
 00621734-v	slk:lemma	popliesť
 14418395-n	slk:lemma	unifikácia
 07621618-n	slk:lemma	ozdoba
-01958259-s	slk:lemma	kvalifikovaný
+01958259-a	slk:lemma	kvalifikovaný
 07539790-n	slk:lemma	unudenosť
 14516501-n	slk:lemma	stav životného prostredia
 01090335-v	slk:lemma	škriepiť sa
 00380881-n	slk:lemma	zhluk
 08256968-n	slk:lemma	politická strana
-01797633-s	slk:lemma	vopred určený
+01797633-a	slk:lemma	vopred určený
 00009147-v	slk:lemma	zhodiť (parohy)
 05309725-n	slk:lemma	podnebie
 10314952-n	slk:lemma	tulák
@@ -16966,7 +16966,7 @@
 10001647-n	slk:lemma	veriteľ
 03901338-n	slk:lemma	pavéza
 01476483-v	slk:lemma	mariť
-00531087-s	slk:lemma	pokojný
+00531087-a	slk:lemma	pokojný
 00160415-n	slk:lemma	presviedčanie
 02536329-v	slk:lemma	manipulovať
 01236164-v	slk:lemma	vraziť
@@ -16985,13 +16985,13 @@
 02000954-n	slk:lemma	brodivý vták
 11529603-n	slk:lemma	Rastliny
 08569998-n	slk:lemma	pole
-01509367-s	slk:lemma	zdržanlivý
+01509367-a	slk:lemma	zdržanlivý
 01695259-n	slk:lemma	Archosauria
 03411544-n	slk:lemma	galéria
 00356954-v	slk:lemma	zvlniť sa
 03930313-n	slk:lemma	tyčkový plot
 00039318-r	slk:lemma	zrejme
-01492596-s	slk:lemma	pubertiacky
+01492596-a	slk:lemma	pubertiacky
 01205961-n	slk:lemma	sebazaprenie
 09419783-n	slk:lemma	rieka Saint Johns
 09506830-n	slk:lemma	morský boh
@@ -17002,33 +17002,33 @@
 02430929-n	slk:lemma	jeleň
 09287968-n	slk:lemma	geologická formácia
 09211944-n	slk:lemma	Horný Avon
-01735252-s	slk:lemma	materinský
+01735252-a	slk:lemma	materinský
 05112215-n	slk:lemma	zrazenie
-02552646-s	slk:lemma	vysušený
+02552646-a	slk:lemma	vysušený
 08743125-n	slk:lemma	Culiacan
 00983824-v	slk:lemma	vypustiť
 04753455-n	slk:lemma	istota
-02384077-s	slk:lemma	švitorivý
+02384077-a	slk:lemma	švitorivý
 09467185-n	slk:lemma	Ural
 03507963-n	slk:lemma	tepelný motor
 15205799-n	slk:lemma	päťročné obdobie
 13140535-n	slk:lemma	Rhamnales
-02229584-s	slk:lemma	laický
+02229584-a	slk:lemma	laický
 02001428-n	slk:lemma	rad Ciconiiformes
 01236173-n	slk:lemma	poručníctvo
 03259505-n	slk:lemma	obydlie
-02516148-s	slk:lemma	názorný
+02516148-a	slk:lemma	názorný
 14844693-n	slk:lemma	hlina
 01579813-v	slk:lemma	rozprestierať
 02373336-v	slk:lemma	podstúpiť riziko
 02620587-v	slk:lemma	znázorniť
 00648692-n	slk:lemma	gravimetrická analýza
 08364959-n	slk:lemma	trhové hospodárstvo
-00660809-s	slk:lemma	trojrozmerný
+00660809-a	slk:lemma	trojrozmerný
 13760316-n	slk:lemma	malé neurčité množstvo
 00024047-v	slk:lemma	oživiť
 02501738-v	slk:lemma	vykopnúť
-00864884-s	slk:lemma	vyhodený (z práce)
+00864884-a	slk:lemma	vyhodený (z práce)
 04272054-n	slk:lemma	cviker
 12432808-n	slk:lemma	cibuľa
 01441100-v	slk:lemma	prebodnúť
@@ -17041,7 +17041,7 @@
 01587062-v	slk:lemma	obklopovať
 00901103-v	slk:lemma	predstavovať
 02110927-v	slk:lemma	vystaviť
-02394793-s	slk:lemma	netaktný
+02394793-a	slk:lemma	netaktný
 00622384-v	slk:lemma	vyvádzať z konceptu
 07399452-n	slk:lemma	hlas
 06264398-n	slk:lemma	poštová prevádzka
@@ -17049,16 +17049,16 @@
 00079908-n	slk:lemma	nekrytý predaj
 08340153-n	slk:lemma	Informačná služba
 08057816-n	slk:lemma	sieť
-01674134-s	slk:lemma	štandardný
+01674134-a	slk:lemma	štandardný
 04407686-n	slk:lemma	svätyňa
 04709585-n	slk:lemma	námaha
 02528380-v	slk:lemma	nepodariť sa
 01973125-v	slk:lemma	znížiť
 08327390-n	slk:lemma	prezídium
-01625492-s	slk:lemma	ponurý
+01625492-a	slk:lemma	ponurý
 06663617-n	slk:lemma	etika
 00914632-n	slk:lemma	výnos
-01216981-s	slk:lemma	imitujúci
+01216981-a	slk:lemma	imitujúci
 05326060-n	slk:lemma	platnička
 13775093-n	slk:lemma	veľký počet
 09355850-n	slk:lemma	slatina
@@ -17080,9 +17080,9 @@
 01172114-v	slk:lemma	popíjať
 09331819-n	slk:lemma	Ladoga
 03915437-n	slk:lemma	perkusie
-01856419-s	slk:lemma	základný
+01856419-a	slk:lemma	základný
 10189776-n	slk:lemma	domáca
-02132224-s	slk:lemma	neslušný
+02132224-a	slk:lemma	neslušný
 00004492-v	slk:lemma	zadržať (dych)
 05762848-n	slk:lemma	spomienka
 12317919-n	slk:lemma	Juglandaceae
@@ -17097,9 +17097,9 @@
 09369844-n	slk:lemma	rieka Neva
 02019574-v	slk:lemma	prekračovať
 13998014-n	slk:lemma	nevoľníctvo
-01263971-s	slk:lemma	brutálny
+01263971-a	slk:lemma	brutálny
 06661562-n	slk:lemma	intervencia
-02342608-s	slk:lemma	skvelý
+02342608-a	slk:lemma	skvelý
 00682928-v	slk:lemma	cenzurovať
 13903387-n	slk:lemma	okraj
 09629752-n	slk:lemma	cestovateľ
@@ -17110,17 +17110,17 @@
 09729945-n	slk:lemma	Sanmarínčan
 00798539-v	slk:lemma	odvrhnúť
 01887787-n	slk:lemma	krava
-02544048-s	slk:lemma	spôsobujúci závraty
+02544048-a	slk:lemma	spôsobujúci závraty
 02151966-v	slk:lemma	dať si pred niekým pozor
 03790512-n	slk:lemma	motorka
 00378706-n	slk:lemma	spopolnenie
-01969150-s	slk:lemma	každoročný
+01969150-a	slk:lemma	každoročný
 03961939-n	slk:lemma	pódium
 00429048-n	slk:lemma	zábava
 13536016-n	slk:lemma	zmena skupenstva
 00057306-n	slk:lemma	ukončenie
 02709906-v	slk:lemma	rozbiehať sa
-01168166-s	slk:lemma	indisponujúci
+01168166-a	slk:lemma	indisponujúci
 04928903-n	slk:lemma	spôsob
 01097192-v	slk:lemma	prihlásiť sa
 00746232-n	slk:lemma	priestupok
@@ -17145,13 +17145,13 @@
 00085219-n	slk:lemma	konfiškácia
 00793580-v	slk:lemma	vyzývať
 00039318-r	slk:lemma	očividne
-01394075-s	slk:lemma	miniatúrny
+01394075-a	slk:lemma	miniatúrny
 02865665-n	slk:lemma	skrutka
 07358576-n	slk:lemma	premena
 13679739-n	slk:lemma	holandská menová jednotka
 11419404-n	slk:lemma	fyzikálny úkaz
 00396642-n	slk:lemma	vyplachovanie
-02415294-s	slk:lemma	tenučký
+02415294-a	slk:lemma	tenučký
 02470899-n	slk:lemma	ľudoop
 00330160-n	slk:lemma	prílišné zrýchlenie
 13853546-n	slk:lemma	mzdová stupnica
@@ -17164,7 +17164,7 @@
 02293321-v	slk:lemma	odovzdávať
 07270179-n	slk:lemma	značenie
 09224325-n	slk:lemma	pohorie Blue Ridge
-00260780-s	slk:lemma	snobský
+00260780-a	slk:lemma	snobský
 08876975-n	slk:lemma	Manchester
 00546646-a	slk:lemma	výstižný
 10660333-n	slk:lemma	luhár
@@ -17172,7 +17172,7 @@
 13379619-n	slk:lemma	obchodný úver
 07466557-n	slk:lemma	technické disciplíny
 00396029-n	slk:lemma	vysúšanie
-00981455-s	slk:lemma	dlhohrajúci
+00981455-a	slk:lemma	dlhohrajúci
 11778534-n	slk:lemma	čeľaď Araceae
 03159535-n	slk:lemma	mliekárstvo
 02782093-n	slk:lemma	balón
@@ -17182,12 +17182,12 @@
 00976953-n	slk:lemma	nájazd
 10648696-n	slk:lemma	hviezda
 13600404-n	slk:lemma	jednotka plochy
-00219389-s	slk:lemma	veľkolepý
+00219389-a	slk:lemma	veľkolepý
 08543916-n	slk:lemma	kukuričný pás
-01105042-s	slk:lemma	typický
+01105042-a	slk:lemma	typický
 13875027-n	slk:lemma	výsek
-00071242-s	slk:lemma	zasiahnutý
-00818175-s	slk:lemma	zaostalý
+00071242-a	slk:lemma	zasiahnutý
+00818175-a	slk:lemma	zaostalý
 05785885-n	slk:lemma	meditácia
 06611681-n	slk:lemma	rečičky
 02130524-v	slk:lemma	hľadieť
@@ -17202,7 +17202,7 @@
 02531625-v	slk:lemma	overiť si
 00900961-v	slk:lemma	dať zbohom
 01329239-v	slk:lemma	zašívať
-02526124-s	slk:lemma	odolný
+02526124-a	slk:lemma	odolný
 02669081-v	slk:lemma	vynikať
 01577635-v	slk:lemma	namáčať sa
 05320362-n	slk:lemma	očná šošovka
@@ -17222,7 +17222,7 @@
 13623636-n	slk:lemma	mililiter
 00088725-n	slk:lemma	chytenie
 06459450-n	slk:lemma	Kniha proroka Jeremiáša
-00107017-s	slk:lemma	obmedzený
+00107017-a	slk:lemma	obmedzený
 06142118-n	slk:lemma	IP
 08973776-n	slk:lemma	Nigéria
 02894605-n	slk:lemma	mólo
@@ -17238,8 +17238,8 @@
 08242675-n	slk:lemma	profesijné združenie
 08744750-n	slk:lemma	Oaxaca de Juarez
 05984936-n	slk:lemma	akulturácia
-01780343-s	slk:lemma	abstraktný
-01636363-s	slk:lemma	oficiálny
+01780343-a	slk:lemma	abstraktný
+01636363-a	slk:lemma	oficiálny
 00674607-v	slk:lemma	vyberať si
 03084420-n	slk:lemma	počítačový obvod
 00068215-r	slk:lemma	stále
@@ -17249,14 +17249,14 @@
 00501990-r	slk:lemma	dovnútra
 02511824-n	slk:lemma	Pisces
 04829182-n	slk:lemma	ľudomilnosť
-00491320-s	slk:lemma	nezvyčajný
+00491320-a	slk:lemma	nezvyčajný
 00258175-r	slk:lemma	zadarmo
 00428000-n	slk:lemma	slávnostná nálada
 02084071-n	slk:lemma	pes
 04213353-n	slk:lemma	kosák
 09985075-n	slk:lemma	klient
 00383606-n	slk:lemma	separácia
-00280463-s	slk:lemma	žiariaci
+00280463-a	slk:lemma	žiariaci
 07635155-n	slk:lemma	čajové pečivo
 05803379-n	slk:lemma	stanovenie
 01785971-v	slk:lemma	nazlostiť
@@ -17277,8 +17277,8 @@
 05057805-n	slk:lemma	UKV vlny
 00311809-n	slk:lemma	výlet
 02848523-n	slk:lemma	lopatka lodnej skrutky
-00390539-s	slk:lemma	mliečno biely
-00997036-s	slk:lemma	neprajný
+00390539-a	slk:lemma	mliečno biely
+00997036-a	slk:lemma	neprajný
 03680942-n	slk:lemma	miestna doprava
 09439433-n	slk:lemma	slnečná sústava
 01382083-v	slk:lemma	nazbierať
@@ -17294,7 +17294,7 @@
 06530703-n	slk:lemma	písomná objednávka
 10708454-n	slk:lemma	mysliteľ
 02269767-v	slk:lemma	znižovať
-02332845-s	slk:lemma	zaručený
+02332845-a	slk:lemma	zaručený
 09023321-n	slk:lemma	Španielsko
 08566554-n	slk:lemma	medza
 03058726-n	slk:lemma	štátny symbol
@@ -17326,7 +17326,7 @@
 00745637-n	slk:lemma	nemorálnosť
 04136333-n	slk:lemma	sarong
 00050693-n	slk:lemma	vyskytnutie sa
-02403505-s	slk:lemma	natiahnutý
+02403505-a	slk:lemma	natiahnutý
 02686568-n	slk:lemma	lietadlo
 01201021-n	slk:lemma	separácia
 00756331-n	slk:lemma	falošná prezentácia
@@ -17343,7 +17343,7 @@
 07142566-n	slk:lemma	konferencia
 09805475-n	slk:lemma	dizajnér
 00484801-r	slk:lemma	nezvyčajne
-01861776-s	slk:lemma	národný
+01861776-a	slk:lemma	národný
 06077413-n	slk:lemma	histológia
 13307784-n	slk:lemma	poplatok, zvýšený
 00641252-v	slk:lemma	odrátať
@@ -17351,7 +17351,7 @@
 00584367-n	slk:lemma	zamestnanie
 00518669-n	slk:lemma	zlet
 09346450-n	slk:lemma	plášť
-02552222-s	slk:lemma	sušený na vzduchu
+02552222-a	slk:lemma	sušený na vzduchu
 09270894-n	slk:lemma	Zem
 01295275-v	slk:lemma	pripojiť
 00184284-r	slk:lemma	samozrejme
@@ -17370,15 +17370,15 @@
 00462092-v	slk:lemma	potlačiť silou
 07469772-n	slk:lemma	skok o žrdi
 00831651-v	slk:lemma	informovať sa
-01249137-s	slk:lemma	vykúriteľný
+01249137-a	slk:lemma	vykúriteľný
 14547036-n	slk:lemma	schopnosť plávať po mori
-01263971-s	slk:lemma	neľudský
+01263971-a	slk:lemma	neľudský
 00022903-n	slk:lemma	kus
 14035298-n	slk:lemma	túžba
 08946187-n	slk:lemma	Ghanská republika
 00870213-v	slk:lemma	upozorňovať
 00206867-r	slk:lemma	narýchlo
-01106129-s	slk:lemma	federálny
+01106129-a	slk:lemma	federálny
 00872886-v	slk:lemma	radiť sa
 00106921-r	slk:lemma	normálne
 15105268-n	slk:lemma	dopisný papier
@@ -17388,10 +17388,10 @@
 00160532-n	slk:lemma	balenie
 10136959-n	slk:lemma	golfista
 08552138-n	slk:lemma	obvod
-01840880-s	slk:lemma	hlúpy
+01840880-a	slk:lemma	hlúpy
 15229300-n	slk:lemma	hodina H
 09467185-n	slk:lemma	pohorie Ural
-01367431-s	slk:lemma	radostný
+01367431-a	slk:lemma	radostný
 08166552-n	slk:lemma	zem
 00054483-n	slk:lemma	ústup
 07963711-n	slk:lemma	kombinácia
@@ -17404,7 +17404,7 @@
 09002814-n	slk:lemma	Rusko
 00068901-n	slk:lemma	porušenie
 01413871-a	slk:lemma	neuveriteľný
-00635244-s	slk:lemma	schopný zlepšenia
+00635244-a	slk:lemma	schopný zlepšenia
 09455640-n	slk:lemma	Tennessee
 10768903-n	slk:lemma	umývačka
 01761706-v	slk:lemma	vyvolávať
@@ -17434,14 +17434,14 @@
 02274482-v	slk:lemma	uchvátiť
 01097292-n	slk:lemma	trhovisko
 01233993-v	slk:lemma	pokrývať
-00798103-s	slk:lemma	napitý
+00798103-a	slk:lemma	napitý
 00058337-n	slk:lemma	vstup do lietadla
 12719277-n	slk:lemma	čeľaď Tropaeolaceae
 01543998-v	slk:lemma	posadiť
-02477557-s	slk:lemma	jednotný
+02477557-a	slk:lemma	jednotný
 07331210-n	slk:lemma	zoslabenie
 02864593-n	slk:lemma	zábrana
-01971846-s	slk:lemma	pokrvný
+01971846-a	slk:lemma	pokrvný
 03859280-n	slk:lemma	kôlňa
 01946817-v	slk:lemma	prehodiť plachtu
 07808587-n	slk:lemma	šalát z kapusty
@@ -17457,7 +17457,7 @@
 07544647-n	slk:lemma	nežnosť
 08517554-n	slk:lemma	autobusová linka
 02089984-v	slk:lemma	obracať
-01356143-s	slk:lemma	rozširujúci sa
+01356143-a	slk:lemma	rozširujúci sa
 14504726-n	slk:lemma	úchylka
 00804476-v	slk:lemma	podľahnúť
 10085736-n	slk:lemma	feudálny pán
@@ -17467,7 +17467,7 @@
 14120767-n	slk:lemma	hypertyreóza
 00185172-r	slk:lemma	šikovne
 07652052-n	slk:lemma	pečienka
-01253254-s	slk:lemma	pokrytý námrazou
+01253254-a	slk:lemma	pokrytý námrazou
 04524313-n	slk:lemma	vozidlo
 00296263-n	slk:lemma	plavba okolo sveta
 08001083-n	slk:lemma	podskupina
@@ -17475,7 +17475,7 @@
 00927017-a	slk:lemma	jestvujúci
 06408651-n	slk:lemma	pojednanie
 07060976-n	slk:lemma	jazz
-00746047-s	slk:lemma	nevhodný
+00746047-a	slk:lemma	nevhodný
 05689249-n	slk:lemma	čokoľvek, čo prekáža
 12260208-n	slk:lemma	čeľaď Fagaceae
 11423028-n	slk:lemma	vzduchová bublina
@@ -17483,10 +17483,10 @@
 05161436-n	slk:lemma	dlžoba
 02884225-n	slk:lemma	lóža
 14961722-n	slk:lemma	novinový papier
-02481012-s	slk:lemma	prerušený
-01280908-s	slk:lemma	nepatrný
+02481012-a	slk:lemma	prerušený
+01280908-a	slk:lemma	nepatrný
 02607455-a	slk:lemma	lekársky
-02214736-s	slk:lemma	opustený
+02214736-a	slk:lemma	opustený
 02237338-v	slk:lemma	odmietať
 00362610-v	slk:lemma	zastaviť sa (na chvíľu)
 00830448-n	slk:lemma	regulácia
@@ -17503,7 +17503,7 @@
 10277638-n	slk:lemma	hráč na lutnu
 13608788-n	slk:lemma	jednotka hmotnosti
 07148192-n	slk:lemma	rokovanie
-01019713-s	slk:lemma	ochabnutý
+01019713-a	slk:lemma	ochabnutý
 12100538-n	slk:lemma	Poaceae
 01548193-a	slk:lemma	mravný
 01482228-a	slk:lemma	slobodná
@@ -17516,7 +17516,7 @@
 13880102-n	slk:lemma	delta
 13953936-n	slk:lemma	pozícia
 01234090-n	slk:lemma	nezúčastnenie sa
-00213610-s	slk:lemma	operený (vtáča)
+00213610-a	slk:lemma	operený (vtáča)
 11435028-n	slk:lemma	náboj
 00739340-v	slk:lemma	rozmyslieť si
 05838176-n	slk:lemma	rozhodnutie
@@ -17535,17 +17535,17 @@
 00039021-n	slk:lemma	interakcia
 02272090-v	slk:lemma	kalkulovať
 03892557-n	slk:lemma	vikariát
-00888200-s	slk:lemma	dychtivý
+00888200-a	slk:lemma	dychtivý
 07308563-n	slk:lemma	výbuch
 09956387-n	slk:lemma	odborník v odbore
 03669094-n	slk:lemma	rameno luku
 00047534-r	slk:lemma	taktiež
-02573708-s	slk:lemma	porastený kriakmi a bodľačím
+02573708-a	slk:lemma	porastený kriakmi a bodľačím
 14917635-n	slk:lemma	atrament
 00955601-v	slk:lemma	rozvinúť
 00652069-n	slk:lemma	návšteva
 13370669-n	slk:lemma	nahromadený majetok
-00907400-s	slk:lemma	jedovatý
+00907400-a	slk:lemma	jedovatý
 01615602-v	slk:lemma	robiť vodivým
 14558995-n	slk:lemma	zníženie
 01810447-v	slk:lemma	rozhorčiť
@@ -17553,7 +17553,7 @@
 09815188-n	slk:lemma	blázon
 09451864-n	slk:lemma	Surinam
 07331400-n	slk:lemma	rozkol
-02295098-s	slk:lemma	overený
+02295098-a	slk:lemma	overený
 08053260-n	slk:lemma	pontifikát
 00714884-v	slk:lemma	debatovať
 01006056-v	slk:lemma	zapisovať si
@@ -17568,13 +17568,13 @@
 05790944-n	slk:lemma	výber
 06782019-n	slk:lemma	mienka
 07550369-n	slk:lemma	nenávisť
-01947741-s	slk:lemma	civilizovaný
+01947741-a	slk:lemma	civilizovaný
 00905386-a	slk:lemma	etický
 13758296-n	slk:lemma	limit
 03976657-n	slk:lemma	žrď
 05732756-n	slk:lemma	kategorizácia
 00754280-n	slk:lemma	lesť
-00059782-s	slk:lemma	posiaty
+00059782-a	slk:lemma	posiaty
 14429985-n	slk:lemma	trieda
 09082058-n	slk:lemma	Nampa
 06520222-n	slk:lemma	potvrdenka
@@ -17593,30 +17593,30 @@
 00720565-n	slk:lemma	úloha
 13696523-n	slk:lemma	rand
 00420218-n	slk:lemma	zneužitie dieťaťa
-00792202-s	slk:lemma	rozhodujúci
+00792202-a	slk:lemma	rozhodujúci
 08742743-n	slk:lemma	Ciudad Juarez
 09258715-n	slk:lemma	trhlina
-01698231-s	slk:lemma	snehový
+01698231-a	slk:lemma	snehový
 01235258-n	slk:lemma	odveta
 01097960-v	slk:lemma	mobilizovať
-01536094-s	slk:lemma	dnešný
-01253592-s	slk:lemma	ľadovo studený
+01536094-a	slk:lemma	dnešný
+01253592-a	slk:lemma	ľadovo studený
 00637259-v	slk:lemma	vyčísľovať
-00860932-s	slk:lemma	schopný abstrahovať
+00860932-a	slk:lemma	schopný abstrahovať
 01024190-v	slk:lemma	poukázať
 04840537-n	slk:lemma	dobročinnosť
 00733044-v	slk:lemma	riešiť
 03158885-n	slk:lemma	bodák
-01126291-s	slk:lemma	hrozný
+01126291-a	slk:lemma	hrozný
 00696414-v	slk:lemma	obzerať sa
 06870576-n	slk:lemma	celá nota
-00459330-s	slk:lemma	odhalený
-01692512-s	slk:lemma	vonkajší
+00459330-a	slk:lemma	odhalený
+01692512-a	slk:lemma	vonkajší
 01664172-v	slk:lemma	prichystať (jedlo)
 02542280-v	slk:lemma	prispôsobovať sa
 02785018-a	slk:lemma	predbežný
-01435060-s	slk:lemma	ďalekonosný
-02050841-s	slk:lemma	roľnícky
+01435060-a	slk:lemma	ďalekonosný
+02050841-a	slk:lemma	roľnícky
 05093890-n	slk:lemma	stupeň
 13875185-n	slk:lemma	disk
 00215800-v	slk:lemma	navlhčiť
@@ -17624,17 +17624,17 @@
 03028079-n	slk:lemma	kostolík
 04840715-n	slk:lemma	prejav milosti božej
 12583126-n	slk:lemma	vejárovitá palma
-02586446-s	slk:lemma	vzorový
+02586446-a	slk:lemma	vzorový
 02409412-v	slk:lemma	zamestnávať
 13748128-n	slk:lemma	číslo 20
 05585665-n	slk:lemma	kostrová štruktúra
-01673946-s	slk:lemma	normálny
+01673946-a	slk:lemma	normálny
 15098161-n	slk:lemma	drevo
 00207366-r	slk:lemma	dnes
 02118933-v	slk:lemma	zaznamenávať
 00751567-v	slk:lemma	nariaďovať
 08426461-n	slk:lemma	formácia
-00649892-s	slk:lemma	hodnotiaci
+00649892-a	slk:lemma	hodnotiaci
 06660224-n	slk:lemma	prekážky dovozu
 10245236-n	slk:lemma	prenájomca
 01207609-n	slk:lemma	pomoc
@@ -17705,7 +17705,7 @@
 03943544-n	slk:lemma	hrot
 01084637-n	slk:lemma	diel
 01120069-v	slk:lemma	útočiť (na niekoho)
-00711308-s	slk:lemma	tuhý
+00711308-a	slk:lemma	tuhý
 00386450-n	slk:lemma	rozdvojenie
 08568256-n	slk:lemma	scéna
 05902545-n	slk:lemma	plán
@@ -17724,17 +17724,17 @@
 06408779-n	slk:lemma	adaptácia
 00531489-v	slk:lemma	ponižovať
 09186709-n	slk:lemma	Acheron
-02119213-s	slk:lemma	pokojný
+02119213-a	slk:lemma	pokojný
 01982866-v	slk:lemma	postaviť
 02894605-n	slk:lemma	pobrežná hrádza
 09815790-n	slk:lemma	pomocník
-00421590-s	slk:lemma	nečistý
+00421590-a	slk:lemma	nečistý
 13554800-n	slk:lemma	postupná operácia
 00531489-v	slk:lemma	zmenšovať sa
-00864884-s	slk:lemma	prepustený
-00169692-s	slk:lemma	pochmúrny
+00864884-a	slk:lemma	prepustený
+00169692-a	slk:lemma	pochmúrny
 05929008-n	slk:lemma	divadelná postava
-01958259-s	slk:lemma	certifikovaný
+01958259-a	slk:lemma	certifikovaný
 04404412-n	slk:lemma	televízia
 11444117-n	slk:lemma	smrť
 00006238-v	slk:lemma	vykašliavať
@@ -17748,21 +17748,21 @@
 04895979-n	slk:lemma	podozrievanie
 10396337-n	slk:lemma	žobrák
 05079074-n	slk:lemma	nesprávne umiestnenie
-01515280-s	slk:lemma	činorodý
+01515280-a	slk:lemma	činorodý
 09038597-n	slk:lemma	Otomanská ríša
 13288337-n	slk:lemma	bezpodielové vlastníctvo
 08259156-n	slk:lemma	Demokratická strana
 04341686-n	slk:lemma	konštrukcia
 09011151-n	slk:lemma	Bieloruská republika
-00120784-s	slk:lemma	neznámy
+00120784-a	slk:lemma	neznámy
 12645754-n	slk:lemma	mandľový olej
 02001858-v	slk:lemma	naháňať
-01333118-s	slk:lemma	rozumový
+01333118-a	slk:lemma	rozumový
 01247647-n	slk:lemma	zúčtovanie
 02016401-v	slk:lemma	vychádzať von
 00293657-n	slk:lemma	pešia túra
 06268096-n	slk:lemma	článok
-01358534-s	slk:lemma	obsahujúci pozvanie
+01358534-a	slk:lemma	obsahujúci pozvanie
 02255081-v	slk:lemma	poukazovať
 00212414-v	slk:lemma	uchovávať sa, zachovávať sa
 09762509-n	slk:lemma	expert
@@ -17781,7 +17781,7 @@
 00079499-r	slk:lemma	dnes večer
 02274482-v	slk:lemma	prevziať
 00922438-v	slk:lemma	odlišovať
-01789117-s	slk:lemma	obložený mramorom
+01789117-a	slk:lemma	obložený mramorom
 02066510-v	slk:lemma	prúdiť
 08517127-n	slk:lemma	breh
 00366393-r	slk:lemma	osobne
@@ -17793,11 +17793,11 @@
 05325378-n	slk:lemma	okienko
 04667406-n	slk:lemma	ženskosť
 01015244-v	slk:lemma	svedčiť
-01046226-s	slk:lemma	miestny
+01046226-a	slk:lemma	miestny
 13879320-n	slk:lemma	trojuholník
 06452601-n	slk:lemma	Nebiim
 02132420-v	slk:lemma	rozhliadať sa okolo
-00657473-s	slk:lemma	zavalitý
+00657473-a	slk:lemma	zavalitý
 00593374-a	slk:lemma	zriedkavý
 11425989-n	slk:lemma	atómová energia
 04393404-n	slk:lemma	čalúnený gobelín
@@ -17806,23 +17806,23 @@
 02379753-v	slk:lemma	odísť do dôchodku
 00362103-n	slk:lemma	zľava
 09849598-n	slk:lemma	láska
-01628531-s	slk:lemma	oplzlý
+01628531-a	slk:lemma	oplzlý
 04015204-n	slk:lemma	ochranné oblečenie
 03878066-n	slk:lemma	zámok
 01888295-v	slk:lemma	uniknúť
 09351547-n	slk:lemma	rybník
-01706465-s	slk:lemma	pokútny
+01706465-a	slk:lemma	pokútny
 00851100-v	slk:lemma	robiť si srandu
 03997484-n	slk:lemma	elektrické náradie
 02936714-n	slk:lemma	klietka
 15281176-n	slk:lemma	úroková miera
 01000214-v	slk:lemma	zaznamenávať
-01612627-s	slk:lemma	poslušný
+01612627-a	slk:lemma	poslušný
 15247518-n	slk:lemma	geologická perióda
 00042484-r	slk:lemma	vďakabohu
 00909219-v	slk:lemma	šomrať
 00163779-n	slk:lemma	stanovenie
-00453053-s	slk:lemma	blízky
+00453053-a	slk:lemma	blízky
 08821319-n	slk:lemma	Laurentínska vrchovina
 08059870-n	slk:lemma	firma
 00037200-n	slk:lemma	chvála
@@ -17858,7 +17858,7 @@
 09418629-n	slk:lemma	rieka Sacramento
 00462520-r	slk:lemma	potichu
 01884539-a	slk:lemma	retroaktívny
-01742537-s	slk:lemma	súperiaci
+01742537-a	slk:lemma	súperiaci
 01011031-v	slk:lemma	dať čestné slovo
 09777353-n	slk:lemma	konateľ
 04193377-n	slk:lemma	preraďovač
@@ -17871,8 +17871,8 @@
 06619065-n	slk:lemma	šou
 00648692-n	slk:lemma	vážková analýza
 08822202-n	slk:lemma	Alberta
-02312450-s	slk:lemma	vykrivený
-01084644-s	slk:lemma	naplnený
+02312450-a	slk:lemma	vykrivený
+01084644-a	slk:lemma	naplnený
 12169526-n	slk:lemma	rad Malvales
 13953467-n	slk:lemma	občianstvo
 07475364-n	slk:lemma	prehra
@@ -17881,7 +17881,7 @@
 00059127-n	slk:lemma	útek
 01711965-v	slk:lemma	natáčať
 08210982-n	slk:lemma	bezpečnostná sila
-01706465-s	slk:lemma	skrývaný
+01706465-a	slk:lemma	skrývaný
 08436562-n	slk:lemma	remeslo
 00443984-v	slk:lemma	roztopiť
 07184735-n	slk:lemma	hádka
@@ -17891,7 +17891,7 @@
 08440630-n	slk:lemma	despotizmus
 00233203-v	slk:lemma	limitovať
 09088815-n	slk:lemma	Topeka
-02251212-s	slk:lemma	osamotený
+02251212-a	slk:lemma	osamotený
 00246672-r	slk:lemma	písomne
 05126228-n	slk:lemma	hranica
 11911591-n	slk:lemma	Compositae
@@ -17900,13 +17900,13 @@
 02571901-v	slk:lemma	brať ohľad na
 01950798-v	slk:lemma	zasielať
 02083806-v	slk:lemma	hýbať sa
-01073435-s	slk:lemma	údený
+01073435-a	slk:lemma	údený
 00072012-v	slk:lemma	vyprázdniť sa (telesne)
 00622384-v	slk:lemma	hnevať sa
 00168564-r	slk:lemma	divoko
 00756338-v	slk:lemma	tvrdiť
-02346878-s	slk:lemma	ziskový
-00650900-s	slk:lemma	akútny
+02346878-a	slk:lemma	ziskový
+00650900-a	slk:lemma	akútny
 02471467-n	slk:lemma	hominidi
 01280014-v	slk:lemma	zakriviť sa
 00358021-r	slk:lemma	voľne
@@ -17915,7 +17915,7 @@
 00805034-n	slk:lemma	regulovanie
 02251743-v	slk:lemma	preplácať
 02672371-n	slk:lemma	ubytovanie
-01050088-s	slk:lemma	zhubný
+01050088-a	slk:lemma	zhubný
 00072989-v	slk:lemma	vypudzovať
 07298715-n	slk:lemma	obrat
 02493260-v	slk:lemma	hlučne hýriť
@@ -17925,11 +17925,11 @@
 08559508-n	slk:lemma	domov
 02470451-n	slk:lemma	Anthropoidea
 10467395-n	slk:lemma	prezident spojených štátov
-01568092-s	slk:lemma	nacionalistický
+01568092-a	slk:lemma	nacionalistický
 00077419-n	slk:lemma	akvizícia
 00066397-n	slk:lemma	zlyhanie
 00246552-n	slk:lemma	toastovanie
-02384077-s	slk:lemma	zhovorčivý
+02384077-a	slk:lemma	zhovorčivý
 07183660-n	slk:lemma	polemika
 00112393-r	slk:lemma	rozhodne
 10276942-n	slk:lemma	blázon
@@ -17946,7 +17946,7 @@
 05167237-n	slk:lemma	sebapresadzovanie
 01138102-v	slk:lemma	chrániť
 10396727-n	slk:lemma	drzý bulvárny fotograf
-00511739-s	slk:lemma	neefektívny
+00511739-a	slk:lemma	neefektívny
 03525454-n	slk:lemma	držiak
 07486628-n	slk:lemma	hlad po niečom
 06410776-n	slk:lemma	kritika
@@ -17958,13 +17958,13 @@
 03072201-n	slk:lemma	farebná televízia
 14127211-n	slk:lemma	infekčné ochorenie
 04041069-n	slk:lemma	radiátor
-02336109-s	slk:lemma	náležitý
+02336109-a	slk:lemma	náležitý
 03551084-n	slk:lemma	hydraulická brzda
 00727991-v	slk:lemma	pripísať vinu
 02984104-a	slk:lemma	prezidentský
 10091012-n	slk:lemma	udavač
 03030663-n	slk:lemma	cigareta
-00891970-s	slk:lemma	izotermný
+00891970-a	slk:lemma	izotermný
 07959016-n	slk:lemma	celkové množstvo
 07337390-n	slk:lemma	fluktuácia
 12431434-n	slk:lemma	cesnakovitá rastlina
@@ -17979,7 +17979,7 @@
 14292090-n	slk:lemma	zlomenina
 02276866-v	slk:lemma	šlohnúť
 01095218-v	slk:lemma	poslúžiť
-00750602-s	slk:lemma	nesporný
+00750602-a	slk:lemma	nesporný
 08135770-n	slk:lemma	BJA
 02960690-n	slk:lemma	karabínka
 08721286-n	slk:lemma	Chiloe
@@ -17992,7 +17992,7 @@
 06832572-n	slk:lemma	N
 02016523-v	slk:lemma	vchádzať (do)
 00137313-v	slk:lemma	pôsobiť
-00012932-s	slk:lemma	ideologický
+00012932-a	slk:lemma	ideologický
 01178565-v	slk:lemma	živiť
 01651444-v	slk:lemma	organizovať
 00632236-v	slk:lemma	mať dojem
@@ -18025,7 +18025,7 @@
 04038727-n	slk:lemma	nosič
 03931044-n	slk:lemma	ikona
 00270215-v	slk:lemma	povolať do vojenskej služby
-02314070-s	slk:lemma	skrútený
+02314070-a	slk:lemma	skrútený
 13838386-n	slk:lemma	poručnícky vzťah
 06251781-n	slk:lemma	transmisia
 00394485-n	slk:lemma	odmorenie
@@ -18039,7 +18039,7 @@
 00018526-v	slk:lemma	prebudiť sa
 00795720-n	slk:lemma	úloha
 13725108-n	slk:lemma	ľahký cent
-02349274-s	slk:lemma	ležiaci hore
+02349274-a	slk:lemma	ležiaci hore
 08242799-n	slk:lemma	oddiel
 00737656-v	slk:lemma	zachvátiť
 00327683-n	slk:lemma	znižovanie
@@ -18049,7 +18049,7 @@
 13588819-n	slk:lemma	koeficient odrazu
 10450303-n	slk:lemma	politický predstaviteľ
 00755745-v	slk:lemma	požadovať si
-02344672-s	slk:lemma	výborný
+02344672-a	slk:lemma	výborný
 05119367-n	slk:lemma	hojnosť
 05892427-n	slk:lemma	nevyhnutná podmienka
 03932203-n	slk:lemma	kus
@@ -18062,9 +18062,9 @@
 00953058-v	slk:lemma	popisovať
 06111253-n	slk:lemma	náuka o harmónii
 02506546-v	slk:lemma	vynucovať
-00421513-s	slk:lemma	nečistý
+00421513-a	slk:lemma	nečistý
 10609556-n	slk:lemma	ťažko pracujúci pracovník
-01386538-s	slk:lemma	nadľudský
+01386538-a	slk:lemma	nadľudský
 06793231-n	slk:lemma	oznam
 00277209-r	slk:lemma	rovno
 14759003-n	slk:lemma	barania koža
@@ -18100,18 +18100,18 @@
 06655388-n	slk:lemma	metóda
 00247442-n	slk:lemma	pečenie
 08219059-n	slk:lemma	posádka lode
-00724397-s	slk:lemma	spoľahlivý
+00724397-a	slk:lemma	spoľahlivý
 00610167-v	slk:lemma	zabúdať
 14475661-n	slk:lemma	nepriazeň osudu
 02487217-n	slk:lemma	rod Macaca
 00941990-v	slk:lemma	vyjadriť sa
 00462092-v	slk:lemma	ukončovať silou
-01265308-s	slk:lemma	zábavný
-02557719-s	slk:lemma	výživný
+01265308-a	slk:lemma	zábavný
+02557719-a	slk:lemma	výživný
 00492745-r	slk:lemma	skutočne
 03044083-a	slk:lemma	odvolací
 01671039-v	slk:lemma	háčkovať
-01462882-s	slk:lemma	preferovaný
+01462882-a	slk:lemma	preferovaný
 03892178-n	slk:lemma	parketová dlážka
 09060768-n	slk:lemma	California
 13480541-n	slk:lemma	naplňovanie
@@ -18152,15 +18152,15 @@
 00278418-a	slk:lemma	nepreklenuteľný
 15141059-n	slk:lemma	roky (života)
 02121808-n	slk:lemma	mačka domáca
-00852197-s	slk:lemma	vhodný
+00852197-a	slk:lemma	vhodný
 15163979-n	slk:lemma	pondelok
-00123485-s	slk:lemma	neskorší
+00123485-a	slk:lemma	neskorší
 01148614-n	slk:lemma	uzavretie
 05647156-n	slk:lemma	hlúposť
 00591858-n	slk:lemma	riaditeľstvo
-00709215-s	slk:lemma	slabý
+00709215-a	slk:lemma	slabý
 02171254-n	slk:lemma	nadčeľaď Lamellicornia
-00331167-s	slk:lemma	najintímnejší
+00331167-a	slk:lemma	najintímnejší
 00205885-v	slk:lemma	vylepšiť
 00925490-v	slk:lemma	čudovať sa
 02542280-v	slk:lemma	poslúchnuť
@@ -18168,12 +18168,12 @@
 10654015-n	slk:lemma	stenograf
 02139544-v	slk:lemma	prejaviť
 04003982-n	slk:lemma	výtlačok
-01386538-s	slk:lemma	gigantický
-01971846-s	slk:lemma	spriaznený
+01386538-a	slk:lemma	gigantický
+01971846-a	slk:lemma	spriaznený
 05325786-n	slk:lemma	kruhové okienko
 00392848-n	slk:lemma	abstrahovanie
 01791756-v	slk:lemma	odlákať
-02323072-s	slk:lemma	zdrvujúci
+02323072-a	slk:lemma	zdrvujúci
 13681407-n	slk:lemma	halier
 02230795-a	slk:lemma	číselný
 00805337-n	slk:lemma	deregulácia
@@ -18193,7 +18193,7 @@
 08412749-n	slk:lemma	základná škola
 02624263-v	slk:lemma	mať počiatok
 06582085-n	slk:lemma	vývojový diagram
-00904745-s	slk:lemma	odporný
+00904745-a	slk:lemma	odporný
 01661404-n	slk:lemma	podtrieda Anapsida
 01782650-v	slk:lemma	ohromiť
 00947128-n	slk:lemma	zvyk
@@ -18202,8 +18202,8 @@
 02116118-v	slk:lemma	prebúdzať
 06224657-n	slk:lemma	pohanské názory
 09762101-n	slk:lemma	obžalovaný
-01262284-s	slk:lemma	humanitný
-00808011-s	slk:lemma	neschopný
+01262284-a	slk:lemma	humanitný
+00808011-a	slk:lemma	neschopný
 06057539-n	slk:lemma	anatómia
 07288801-n	slk:lemma	zázrak
 02462580-v	slk:lemma	zvoliť
@@ -18217,7 +18217,7 @@
 00278403-n	slk:lemma	vlhčenie
 05059830-n	slk:lemma	účinnosť
 04007894-n	slk:lemma	produkcia
-01723091-s	slk:lemma	neobjektívny
+01723091-a	slk:lemma	neobjektívny
 05913538-n	slk:lemma	zásada
 08406486-n	slk:lemma	nadácia
 05454833-n	slk:lemma	kosákovitý erytrocyt
@@ -18241,7 +18241,7 @@
 06455497-n	slk:lemma	Synoptické evanjeliá
 00799383-v	slk:lemma	odstupovať
 01585759-v	slk:lemma	uvoľniť sa
-01080900-s	slk:lemma	štedrý
+01080900-a	slk:lemma	štedrý
 02451679-v	slk:lemma	potláčať
 01946996-v	slk:lemma	veslovať
 01195299-v	slk:lemma	ochutnať
@@ -18264,7 +18264,7 @@
 02764251-a	slk:lemma	vojenský
 05124792-n	slk:lemma	tepelná bariéra
 01534147-v	slk:lemma	zabrýzgať
-00520892-s	slk:lemma	absolútny
+00520892-a	slk:lemma	absolútny
 02669295-n	slk:lemma	podpera
 13555915-n	slk:lemma	zrážač
 00335182-r	slk:lemma	improvizovane
@@ -18297,10 +18297,10 @@
 01461328-v	slk:lemma	zlučovať
 01552519-v	slk:lemma	strihať
 01619231-v	slk:lemma	rušiť
-00398978-s	slk:lemma	pestrofarebný
+00398978-a	slk:lemma	pestrofarebný
 10371741-n	slk:lemma	lodný dôstojník
 09962966-n	slk:lemma	trestanec
-01441271-s	slk:lemma	dlhoročný
+01441271-a	slk:lemma	dlhoročný
 05275466-n	slk:lemma	os ischii
 10193967-n	slk:lemma	ženatý muž
 06710546-n	slk:lemma	kritika
@@ -18323,7 +18323,7 @@
 03079741-n	slk:lemma	kupé
 09849598-n	slk:lemma	najdrahší
 07527167-n	slk:lemma	potešenie
-01536641-s	slk:lemma	hypermoderný
+01536641-a	slk:lemma	hypermoderný
 00786195-n	slk:lemma	snaha
 02118933-v	slk:lemma	zapisovať si
 10536416-n	slk:lemma	rocková hviezda
@@ -18345,7 +18345,7 @@
 05602982-n	slk:lemma	lalok pod bradou
 08434259-n	slk:lemma	sústava
 10175090-n	slk:lemma	Výsosť
-00065064-s	slk:lemma	kladný
+00065064-a	slk:lemma	kladný
 02849154-n	slk:lemma	perina
 00899597-v	slk:lemma	pozdravovať sa
 09233284-n	slk:lemma	Kantábrijské vrchy
@@ -18388,25 +18388,25 @@
 00053913-n	slk:lemma	odchod
 00030358-n	slk:lemma	skutok
 06443922-n	slk:lemma	List Galaťanom
-02065665-s	slk:lemma	rôznorodý
+02065665-a	slk:lemma	rôznorodý
 00671335-v	slk:lemma	nedoceniť
 05124057-n	slk:lemma	okraj
 08710951-n	slk:lemma	Bermudský trojuholník
 03471473-n	slk:lemma	koryto
-01284212-s	slk:lemma	pôsobivý
+01284212-a	slk:lemma	pôsobivý
 00061917-n	slk:lemma	realizácia
 09879744-n	slk:lemma	babrák
 00010054-v	slk:lemma	pohnúť sa
 02724417-v	slk:lemma	súvisieť
 10751265-n	slk:lemma	podpredsedníčka
-01313004-s	slk:lemma	zanedbaný
+01313004-a	slk:lemma	zanedbaný
 02676054-v	slk:lemma	týkať sa
 00830448-n	slk:lemma	ovládanie
 02423762-v	slk:lemma	dusiť
 02061846-v	slk:lemma	dochádzať
 00456199-n	slk:lemma	zápas
 00813978-v	slk:lemma	prediskutovať
-00432453-s	slk:lemma	čistý
+00432453-a	slk:lemma	čistý
 06841365-n	slk:lemma	interpunkcia
 02064745-a	slk:lemma	rozdielny
 01805523-v	slk:lemma	chýbať
@@ -18438,14 +18438,14 @@
 15286249-n	slk:lemma	rýchlosť
 02761162-a	slk:lemma	medúzovitý
 01673503-n	slk:lemma	rad šupináče
-02398378-s	slk:lemma	pikantný
+02398378-a	slk:lemma	pikantný
 03656484-n	slk:lemma	objektív
 04562658-n	slk:lemma	vodný systém
 09021503-n	slk:lemma	Turkménska republika
 04262010-n	slk:lemma	otvor v ozvučnici
 08967868-n	slk:lemma	Monako
-01784401-s	slk:lemma	neverecký
-01264913-s	slk:lemma	smiešny
+01784401-a	slk:lemma	neverecký
+01264913-a	slk:lemma	smiešny
 00450335-n	slk:lemma	jazdectvo
 00058519-n	slk:lemma	odchádzanie
 00553362-n	slk:lemma	porucha
@@ -18477,7 +18477,7 @@
 00919542-a	slk:lemma	nadšený
 05910940-n	slk:lemma	rozvrh
 05089947-n	slk:lemma	vzdialenosť
-00340827-s	slk:lemma	osudový
+00340827-a	slk:lemma	osudový
 01582409-v	slk:lemma	pohlcovať
 07110615-n	slk:lemma	hlas
 03201638-n	slk:lemma	večerné šaty
@@ -18485,17 +18485,17 @@
 01272798-v	slk:lemma	dostávať perie
 13325847-n	slk:lemma	manipulačný poplatok za vedenie účtu
 00596644-v	slk:lemma	zažiť
-00491511-s	slk:lemma	osobitý
-01042491-s	slk:lemma	slávnostný
+00491511-a	slk:lemma	osobitý
+01042491-a	slk:lemma	slávnostný
 06543781-n	slk:lemma	stručné vyhlásenie o faktoch prípadu
 02835481-a	slk:lemma	revolučný
-01616157-s	slk:lemma	osobný
+01616157-a	slk:lemma	osobný
 05341920-n	slk:lemma	krčná tepna
 03682487-n	slk:lemma	zámok
 01782650-v	slk:lemma	vyplašiť
 01796346-v	slk:lemma	vzrušiť
 00890590-v	slk:lemma	poisťovať
-01167540-s	slk:lemma	spätný
+01167540-a	slk:lemma	spätný
 06783768-n	slk:lemma	hlavička
 00334790-r	slk:lemma	expresne
 12996225-n	slk:lemma	Basidiomycotina
@@ -18512,7 +18512,7 @@
 02341816-v	slk:lemma	vyčalúniť
 02231473-v	slk:lemma	nahrať
 00918872-v	slk:lemma	určovať
-01249137-s	slk:lemma	schopný vykurovania
+01249137-a	slk:lemma	schopný vykurovania
 10419047-n	slk:lemma	zvrhlík
 02966972-a	slk:lemma	argentínsky
 00328230-n	slk:lemma	návrat
@@ -18526,16 +18526,16 @@
 06193203-n	slk:lemma	atitúda
 00076193-r	slk:lemma	hore-dolu
 02213690-v	slk:lemma	odmietať
-01625492-s	slk:lemma	mátožný
+01625492-a	slk:lemma	mátožný
 09366017-n	slk:lemma	depresia
 09740954-n	slk:lemma	Aljašťanka
 00875806-v	slk:lemma	predsúvať (návrh, argument)
 00207127-r	slk:lemma	finančne
 08559155-n	slk:lemma	sídlo
 13354420-n	slk:lemma	finančné aktíva
-01076145-s	slk:lemma	intímny
+01076145-a	slk:lemma	intímny
 01963294-a	slk:lemma	nájomný
-01464700-s	slk:lemma	láskyplný
+01464700-a	slk:lemma	láskyplný
 00697188-a	slk:lemma	vymedzený
 13836136-n	slk:lemma	západ
 00046299-r	slk:lemma	nesmierne
@@ -18543,7 +18543,7 @@
 10001217-n	slk:lemma	distribútor
 05074774-n	slk:lemma	stanovisko
 00060185-v	slk:lemma	sedieť
-02421364-s	slk:lemma	hospodárny
+02421364-a	slk:lemma	hospodárny
 13393599-n	slk:lemma	nekryté peniaze
 01012561-v	slk:lemma	potvrdiť
 00471945-r	slk:lemma	výnimočne
@@ -18552,8 +18552,8 @@
 02564426-v	slk:lemma	dišpenzovať
 02765028-n	slk:lemma	náprava
 04263614-n	slk:lemma	prameň
-00803275-s	slk:lemma	intenzívny
-00721371-s	slk:lemma	otázny
+00803275-a	slk:lemma	intenzívny
+00721371-a	slk:lemma	otázny
 07627931-n	slk:lemma	krehké cesto
 07596684-n	slk:lemma	konfekcia
 09894909-n	slk:lemma	podvodník
@@ -18566,7 +18566,7 @@
 02009122-v	slk:lemma	vypadnúť
 00784342-v	slk:lemma	opýtať sa
 05491612-n	slk:lemma	pyramídový trakt
-00280463-s	slk:lemma	ligotavý
+00280463-a	slk:lemma	ligotavý
 01016002-v	slk:lemma	tvrdiť
 00518669-n	slk:lemma	spoločenská udalosť
 12663254-n	slk:lemma	káva Liberica
@@ -18596,17 +18596,17 @@
 13997253-n	slk:lemma	nevoľníctvo
 00203866-v	slk:lemma	zhoršovať
 08764107-n	slk:lemma	Nórske kráľovstvo
-01871565-s	slk:lemma	úsporný
+01871565-a	slk:lemma	úsporný
 02321391-v	slk:lemma	okradnúť
 08427453-n	slk:lemma	nástup chorých
 00039740-n	slk:lemma	očný kontakt
 00161243-n	slk:lemma	alternatíva
-01628531-s	slk:lemma	osočujúci
+01628531-a	slk:lemma	osočujúci
 04764741-n	slk:lemma	obyčajnosť
 09734294-n	slk:lemma	Siamčan
 09202810-n	slk:lemma	rieka Araguaya
 02687916-v	slk:lemma	rozpínať sa
-01443097-s	slk:lemma	krátkodobý
+01443097-a	slk:lemma	krátkodobý
 09467696-n	slk:lemma	močový kameň
 10179069-n	slk:lemma	nadšenec
 00509846-n	slk:lemma	mejdan
@@ -18634,13 +18634,13 @@
 01149480-n	slk:lemma	opísanie
 00651991-v	slk:lemma	líšiť sa
 06127683-n	slk:lemma	staviteľstvo
-00026168-s	slk:lemma	elementárny
+00026168-a	slk:lemma	elementárny
 08061905-n	slk:lemma	distribútor
 00277209-r	slk:lemma	priamo
 07523905-n	slk:lemma	nepokoj
 00943563-v	slk:lemma	porozprávať sa (o)
 00725274-v	slk:lemma	prekvapovať
-01226660-s	slk:lemma	ctihodný
+01226660-a	slk:lemma	ctihodný
 08743945-n	slk:lemma	Mazatlan
 07450842-n	slk:lemma	ceremoniál
 07442068-n	slk:lemma	nával
@@ -18650,7 +18650,7 @@
 08679972-n	slk:lemma	smer
 02488705-a	slk:lemma	prechodný
 13331778-n	slk:lemma	finančné prostriedky
-01536094-s	slk:lemma	moderný
+01536094-a	slk:lemma	moderný
 05750163-n	slk:lemma	štýl
 01429455-v	slk:lemma	chovať (zvieratá)
 08173030-n	slk:lemma	Severná Amerika
@@ -18661,10 +18661,10 @@
 04782878-n	slk:lemma	vierohodnosť
 14083790-n	slk:lemma	zmätok
 00451563-n	slk:lemma	cyklistika
-00363031-s	slk:lemma	usmievajúci sa
+00363031-a	slk:lemma	usmievajúci sa
 00040719-r	slk:lemma	nečakane
 04464615-n	slk:lemma	guličkový ovládač
-00417204-s	slk:lemma	hrubý
+00417204-a	slk:lemma	hrubý
 02633356-v	slk:lemma	skladať sa z
 00947077-v	slk:lemma	špecifikovať
 04678908-n	slk:lemma	prestrojenie
@@ -18674,7 +18674,7 @@
 02473981-v	slk:lemma	poveriť
 04184701-n	slk:lemma	kúsok
 00024649-v	slk:lemma	osviežiť
-00726317-s	slk:lemma	bezmocný
+00726317-a	slk:lemma	bezmocný
 00947719-n	slk:lemma	zneužívanie
 07802246-n	slk:lemma	seno
 06623316-n	slk:lemma	doporučená zásielka
@@ -18689,16 +18689,16 @@
 00296478-n	slk:lemma	putovanie
 01014609-v	slk:lemma	podčiarkovať
 05817743-n	slk:lemma	prípad
-02413390-s	slk:lemma	sklený
+02413390-a	slk:lemma	sklený
 10521662-n	slk:lemma	spravodajca
 03214253-n	slk:lemma	priekopa
 02133185-v	slk:lemma	pozorne sa pozrieť
 00784874-v	slk:lemma	montovať sa
 00514128-n	slk:lemma	huncútstvo
 02488834-v	slk:lemma	brať si
-01252151-s	slk:lemma	ľadovo studený
+01252151-a	slk:lemma	ľadovo studený
 04656996-n	slk:lemma	ľahostajnosť
-01950198-s	slk:lemma	neotesaný
+01950198-a	slk:lemma	neotesaný
 15063108-n	slk:lemma	konštrukčná oceľ
 00358021-r	slk:lemma	na slobode
 02344381-v	slk:lemma	odmeňovať
@@ -18708,7 +18708,7 @@
 13252293-n	slk:lemma	sídlo
 08173515-n	slk:lemma	Európska únia
 00229605-v	slk:lemma	zveľadiť
-02179968-s	slk:lemma	úprimný
+02179968-a	slk:lemma	úprimný
 00365012-n	slk:lemma	fluoridácia
 05107765-n	slk:lemma	suma
 04497570-n	slk:lemma	tunika
@@ -18720,14 +18720,14 @@
 10699099-n	slk:lemma	sčítač hlasov
 03405265-n	slk:lemma	zariadenie
 08196230-n	slk:lemma	USAF
-01644847-s	slk:lemma	starý
-01306645-s	slk:lemma	zabehnutý
+01644847-a	slk:lemma	starý
+01306645-a	slk:lemma	zabehnutý
 15277358-n	slk:lemma	radiačná dávka
 01055493-n	slk:lemma	návšteva
 09676746-n	slk:lemma	slovanská rasa
 02994872-a	slk:lemma	mramorový
-00729133-s	slk:lemma	nezávislý
-01539444-s	slk:lemma	jednoduchý
+00729133-a	slk:lemma	nezávislý
+01539444-a	slk:lemma	jednoduchý
 03257065-n	slk:lemma	dvojúrovňový byt
 01842888-v	slk:lemma	jazdiť
 06113170-n	slk:lemma	pneumatika
@@ -18763,7 +18763,7 @@
 09040839-n	slk:lemma	Adalia
 02510065-n	slk:lemma	Ailuropodidae
 00677544-v	slk:lemma	triediť
-01842468-s	slk:lemma	epizodický
+01842468-a	slk:lemma	epizodický
 01332730-v	slk:lemma	zakrývať
 12619306-n	slk:lemma	čeľaď Rosaceae
 05660268-n	slk:lemma	metóda
@@ -18775,7 +18775,7 @@
 00550777-a	slk:lemma	vyvrátiteľný
 00184284-r	slk:lemma	nepopierateľne
 01534147-v	slk:lemma	zašpiniť sa
-01517526-s	slk:lemma	vojnový
+01517526-a	slk:lemma	vojnový
 02373336-v	slk:lemma	hazardovať
 00060185-v	slk:lemma	vysedieť
 07162545-n	slk:lemma	hypotéza
@@ -18798,7 +18798,7 @@
 00834009-v	slk:lemma	zavádzať
 04928903-n	slk:lemma	móda
 05494130-n	slk:lemma	temenný mozgový lalok
-00486990-s	slk:lemma	častý
+00486990-a	slk:lemma	častý
 09477890-n	slk:lemma	mokrina
 12280487-n	slk:lemma	Betulaceae
 03091374-n	slk:lemma	spojka
@@ -18826,13 +18826,13 @@
 02118379-a	slk:lemma	seriózny
 14769160-n	slk:lemma	popol
 00041206-v	slk:lemma	zvýrazniť
-00848679-s	slk:lemma	vyžadovaný etiketou
-02586446-s	slk:lemma	ukážkový
+00848679-a	slk:lemma	vyžadovaný etiketou
+02586446-a	slk:lemma	ukážkový
 00296178-v	slk:lemma	opraviť
 01166351-v	slk:lemma	zjesť
 04418818-n	slk:lemma	divadelné javisko
-02257731-s	slk:lemma	klubový
-01443097-s	slk:lemma	zbežný
+02257731-a	slk:lemma	klubový
+01443097-a	slk:lemma	zbežný
 08630985-n	slk:lemma	región
 02289295-v	slk:lemma	zarábať
 12100538-n	slk:lemma	Graminaceae
@@ -18842,7 +18842,7 @@
 01044114-v	slk:lemma	šuškať
 08738715-n	slk:lemma	Santa Ana
 01193886-n	slk:lemma	zbavenie
-01439072-s	slk:lemma	trvajúci celý deň
+01439072-a	slk:lemma	trvajúci celý deň
 10121952-n	slk:lemma	hlasitá rana
 00618451-v	slk:lemma	označiť
 05736149-n	slk:lemma	oceňovanie
@@ -18855,7 +18855,7 @@
 01470813-a	slk:lemma	zmagnetizovateľný
 08232496-n	slk:lemma	futbalová liga
 08660934-n	slk:lemma	cieľ
-01982957-s	slk:lemma	ctený
+01982957-a	slk:lemma	ctený
 00095320-r	slk:lemma	dole
 00426005-r	slk:lemma	namáhavo
 06744396-n	slk:lemma	definícia
@@ -18865,7 +18865,7 @@
 03290771-n	slk:lemma	vchod
 09857200-n	slk:lemma	biskup
 07317764-n	slk:lemma	porucha
-02573987-s	slk:lemma	podobný džungli
+02573987-a	slk:lemma	podobný džungli
 00374135-v	slk:lemma	zmrznúť
 03137228-n	slk:lemma	priechod pre chodcov
 08834408-n	slk:lemma	Južná Austrália
@@ -18882,7 +18882,7 @@
 09174015-n	slk:lemma	Colima
 14755804-n	slk:lemma	živočíšna látka
 02957469-a	slk:lemma	nemecký
-00127137-s	slk:lemma	bývalý
+00127137-a	slk:lemma	bývalý
 00088120-v	slk:lemma	nachladnúť
 02669125-a	slk:lemma	ramenný
 04041408-n	slk:lemma	hadica chladiča
@@ -18891,13 +18891,13 @@
 00510364-v	slk:lemma	pokrývať škvrnami
 03272125-n	slk:lemma	elektrické kladivo
 02421199-v	slk:lemma	zodrať
-01664310-s	slk:lemma	naivný
-01754873-s	slk:lemma	nehynúci
+01664310-a	slk:lemma	naivný
+01754873-a	slk:lemma	nehynúci
 00102736-r	slk:lemma	najsamprv
 10316013-n	slk:lemma	militarista
 02393086-v	slk:lemma	preložiť
 01340439-v	slk:lemma	zaisťovať
-00953127-s	slk:lemma	vnútorný
+00953127-a	slk:lemma	vnútorný
 15133621-n	slk:lemma	trvanie
 14327266-n	slk:lemma	bolenie brucha
 02545272-v	slk:lemma	vystaviť riziku
@@ -18917,18 +18917,18 @@
 11573173-n	slk:lemma	rod hamamelid dicot
 07525555-n	slk:lemma	pochybnosť
 00258854-n	slk:lemma	korekcia
-00906099-s	slk:lemma	panegyrický
+00906099-a	slk:lemma	panegyrický
 05785508-n	slk:lemma	uvažovanie
 01999798-v	slk:lemma	privádzať
-01990653-s	slk:lemma	tuhý
+01990653-a	slk:lemma	tuhý
 07184735-n	slk:lemma	dohadovať sa
 00867644-v	slk:lemma	objasňovať
 04493381-n	slk:lemma	vaňa
-00853473-s	slk:lemma	neželaný
+00853473-a	slk:lemma	neželaný
 00721431-n	slk:lemma	služba
 00163047-n	slk:lemma	vôľa
 00259755-v	slk:lemma	poškodzovať
-02571277-s	slk:lemma	pochabý
+02571277-a	slk:lemma	pochabý
 09155306-n	slk:lemma	WV
 14447525-n	slk:lemma	spokojnosť
 01790943-n	slk:lemma	Gallus
@@ -18946,7 +18946,7 @@
 01752495-v	slk:lemma	plodiť
 10042845-n	slk:lemma	výstredný človek
 00152727-n	slk:lemma	stanovenie
-00933599-s	slk:lemma	nákladný
+00933599-a	slk:lemma	nákladný
 04298308-n	slk:lemma	schodište
 00145713-r	slk:lemma	dosť
 05979595-n	slk:lemma	uctievanie diabla
@@ -18958,7 +18958,7 @@
 02132580-n	slk:lemma	grizly
 04051439-n	slk:lemma	ubíjačka
 05089782-n	slk:lemma	relatívna hustota
-00846625-s	slk:lemma	menovaný
+00846625-a	slk:lemma	menovaný
 03471347-n	slk:lemma	styčníkový plech
 02072159-v	slk:lemma	pretiecť
 03405725-n	slk:lemma	nábytok
@@ -18973,8 +18973,8 @@
 05838765-n	slk:lemma	kategória
 02873244-n	slk:lemma	kufor
 11594676-n	slk:lemma	rad fungus
-01779558-s	slk:lemma	fyziologický
-01285136-s	slk:lemma	ušľachtilý
+01779558-a	slk:lemma	fyziologický
+01285136-a	slk:lemma	ušľachtilý
 00631737-v	slk:lemma	domnievať sa
 00947128-n	slk:lemma	zužitkovanie
 15202634-n	slk:lemma	rok
@@ -18992,15 +18992,15 @@
 09211266-n	slk:lemma	Austrália
 00385266-n	slk:lemma	odtrhnutie
 13599348-n	slk:lemma	kvóta
-00264178-s	slk:lemma	smelý
-01944088-s	slk:lemma	triezvy
+00264178-a	slk:lemma	smelý
+01944088-a	slk:lemma	triezvy
 00770141-v	slk:lemma	odplašiť
 01147451-n	slk:lemma	zastavenie
 00746718-v	slk:lemma	vydať zákaz
 02614181-v	slk:lemma	existovať
 11910835-n	slk:lemma	podtrieda astrovité
-00304949-s	slk:lemma	intenzívny
-01080900-s	slk:lemma	výdatný
+00304949-a	slk:lemma	intenzívny
+01080900-a	slk:lemma	výdatný
 03695957-n	slk:lemma	nosič batožín
 00794367-n	slk:lemma	pokus
 00491292-r	slk:lemma	užitočne
@@ -19015,7 +19015,7 @@
 02471327-v	slk:lemma	získavať (brancov)
 08308313-n	slk:lemma	mašinéria
 00064691-r	slk:lemma	poriadne
-01865967-s	slk:lemma	plodný
+01865967-a	slk:lemma	plodný
 01064863-n	slk:lemma	pokoj
 07954731-n	slk:lemma	zbierka
 03953416-n	slk:lemma	miesto bohoslužby
@@ -19029,16 +19029,16 @@
 01139000-n	slk:lemma	odobrenie
 07990956-n	slk:lemma	kŕdeľ
 01080297-a	slk:lemma	bohatý
-01281695-s	slk:lemma	neúspešný
-00012362-s	slk:lemma	koncepčný
+01281695-a	slk:lemma	neúspešný
+00012362-a	slk:lemma	koncepčný
 08428252-n	slk:lemma	pochod hladu
 09886403-n	slk:lemma	krabička s čajom
 06533484-n	slk:lemma	zákony o premlčacej lehote
-01413763-s	slk:lemma	pravdepodobný
+01413763-a	slk:lemma	pravdepodobný
 00927430-v	slk:lemma	dať tip
 05582305-n	slk:lemma	madzibunkový materiál
 08221348-n	slk:lemma	oddelenie
-00826215-s	slk:lemma	juhozápadný
+00826215-a	slk:lemma	juhozápadný
 00087988-v	slk:lemma	chytiť
 10242791-n	slk:lemma	pani
 08424222-n	slk:lemma	trustová spoločnosť
@@ -19058,7 +19058,7 @@
 06224136-n	slk:lemma	monoteistické náboženstvo
 03059966-a	slk:lemma	odborový
 05026312-n	slk:lemma	molekulárna hmotnosť
-02467559-s	slk:lemma	doluznačky
+02467559-a	slk:lemma	doluznačky
 06778102-n	slk:lemma	žart
 10742384-n	slk:lemma	úžerník
 10024937-n	slk:lemma	Dominičanka
@@ -19083,17 +19083,17 @@
 04905188-n	slk:lemma	prispôsobivosť
 05836468-n	slk:lemma	percepcia
 11877473-n	slk:lemma	repa
-01768466-s	slk:lemma	osobný
+01768466-a	slk:lemma	osobný
 10180923-n	slk:lemma	zlodej
-00978199-s	slk:lemma	svižný
+00978199-a	slk:lemma	svižný
 02749904-v	slk:lemma	byť
 02467662-v	slk:lemma	rozkúskovať
-02071973-s	slk:lemma	korešpondujúci
-00616532-s	slk:lemma	pečený
-00751099-s	slk:lemma	používateľsky príjemný
+02071973-a	slk:lemma	korešpondujúci
+00616532-a	slk:lemma	pečený
+00751099-a	slk:lemma	používateľsky príjemný
 05492259-n	slk:lemma	kožná riasa
 02116118-v	slk:lemma	vzbudiť
-00585202-s	slk:lemma	kreatívny
+00585202-a	slk:lemma	kreatívny
 14298815-n	slk:lemma	poranenie
 00908351-v	slk:lemma	starať sa
 00073897-r	slk:lemma	prevažne
@@ -19101,7 +19101,7 @@
 08800676-n	slk:lemma	Východorímska ríša
 00184362-n	slk:lemma	tajné hlasovanie
 00737188-n	slk:lemma	nepravideľnosť
-01282510-s	slk:lemma	perfektný
+01282510-a	slk:lemma	perfektný
 02758581-v	slk:lemma	pokryť ľadom
 02292125-v	slk:lemma	mať (niečo z niečoho)
 03975232-n	slk:lemma	indikátor
@@ -19110,9 +19110,9 @@
 05849040-n	slk:lemma	charakteristika
 13365698-n	slk:lemma	pomoc
 04086794-n	slk:lemma	posuvný odporník
-02023430-s	slk:lemma	úbohý
+02023430-a	slk:lemma	úbohý
 14830992-n	slk:lemma	exón
-00312234-s	slk:lemma	povrchný
+00312234-a	slk:lemma	povrchný
 02081578-v	slk:lemma	zanechať
 00064643-v	slk:lemma	poraniť
 00681429-v	slk:lemma	oceniť
@@ -19127,17 +19127,17 @@
 02285629-v	slk:lemma	nachádzať
 13996300-n	slk:lemma	podriadenosť
 09210604-n	slk:lemma	atmosféra
-02418692-s	slk:lemma	vysoko nepravdepodobný
+02418692-a	slk:lemma	vysoko nepravdepodobný
 02091689-v	slk:lemma	podísť
 01600333-a	slk:lemma	severný
 07161429-n	slk:lemma	návrh
 10420031-n	slk:lemma	prosebník
-01079052-s	slk:lemma	zovretý ľadom
+01079052-a	slk:lemma	zovretý ľadom
 05641720-n	slk:lemma	nekoordinovanosť
 07373602-n	slk:lemma	zjednotenie
 06353934-n	slk:lemma	kód
 15279596-n	slk:lemma	kilohertz
-00421875-s	slk:lemma	odporný
+00421875-a	slk:lemma	odporný
 00262792-a	slk:lemma	odvážny
 02810471-n	slk:lemma	batéria
 01925916-n	slk:lemma	larválne štádium motolíc
@@ -19156,7 +19156,7 @@
 08955626-n	slk:lemma	Kórejská republika
 04259771-n	slk:lemma	sonar
 13322113-n	slk:lemma	daň z licencie
-02111095-s	slk:lemma	oddelený
+02111095-a	slk:lemma	oddelený
 01645601-v	slk:lemma	zapríčiniť
 08646902-n	slk:lemma	krajina
 05003423-n	slk:lemma	elegancia
@@ -19177,7 +19177,7 @@
 03014288-a	slk:lemma	akčný
 02439281-v	slk:lemma	pristupovať (k niečomu)
 02740764-n	slk:lemma	pancierový plech
-00331167-s	slk:lemma	najvnútornejší
+00331167-a	slk:lemma	najvnútornejší
 02329401-n	slk:lemma	potkan
 02486932-v	slk:lemma	stretnúť sa
 00031798-r	slk:lemma	predsa už
@@ -19191,11 +19191,11 @@
 13356402-n	slk:lemma	bank
 00174412-n	slk:lemma	opatrenie
 07092592-n	slk:lemma	báseň
-02544048-s	slk:lemma	trpiaci závratmi
+02544048-a	slk:lemma	trpiaci závratmi
 13342692-n	slk:lemma	risk
 00705227-v	slk:lemma	plánovať si
 13367070-n	slk:lemma	fond
-00237788-s	slk:lemma	bilaterálny
+00237788-a	slk:lemma	bilaterálny
 00024720-n	slk:lemma	postavenie
 03491178-n	slk:lemma	tapiséria
 12581230-n	slk:lemma	rad Palmales
@@ -19208,19 +19208,19 @@
 08952190-n	slk:lemma	Maďarská republika
 09302804-n	slk:lemma	šíre more
 05222940-n	slk:lemma	septum
-02328012-s	slk:lemma	nepriaznivý
-01252714-s	slk:lemma	svieži
+02328012-a	slk:lemma	nepriaznivý
+01252714-a	slk:lemma	svieži
 04802403-n	slk:lemma	nesprávnosť
 00281237-r	slk:lemma	opatrne
 02201644-v	slk:lemma	distribuovať
 01660267-a	slk:lemma	operačný
-02557719-s	slk:lemma	nutričný
+02557719-a	slk:lemma	nutričný
 00658627-n	slk:lemma	hospitalizácia
 10120671-n	slk:lemma	záhradník
 00520059-n	slk:lemma	fašiangový utorok
 01471002-a	slk:lemma	hlavný
 10107303-n	slk:lemma	zakladateľ
-01784217-s	slk:lemma	ateistický
+01784217-a	slk:lemma	ateistický
 15046900-n	slk:lemma	pevná hmota
 10242791-n	slk:lemma	lady
 00611674-n	slk:lemma	žurnalistika
@@ -19234,10 +19234,10 @@
 01946996-v	slk:lemma	priveslovať
 05916306-n	slk:lemma	zdanie
 15273522-n	slk:lemma	medzivládie
-00657804-s	slk:lemma	kockovitý
+00657804-a	slk:lemma	kockovitý
 00622266-n	slk:lemma	bitka
 01534147-v	slk:lemma	zablatiť sa
-00012689-s	slk:lemma	ideový
+00012689-a	slk:lemma	ideový
 07307754-n	slk:lemma	výboj
 05511618-n	slk:lemma	kardiovaskulárna sústava
 02230772-v	slk:lemma	dať
@@ -19247,7 +19247,7 @@
 01210816-n	slk:lemma	ubytovanie
 08801678-n	slk:lemma	Itália
 10376523-n	slk:lemma	osoba skôr narodená
-02242798-s	slk:lemma	chrastovitý
+02242798-a	slk:lemma	chrastovitý
 02131942-n	slk:lemma	Ursus
 05477946-n	slk:lemma	čuchový nerv
 08191701-n	slk:lemma	vojnové loďstvo
@@ -19255,12 +19255,12 @@
 06755947-n	slk:lemma	podmienečné obmedzenie
 07332956-n	slk:lemma	úmrtnosť
 13098962-n	slk:lemma	lyko
-00687614-s	slk:lemma	tvrdený
+00687614-a	slk:lemma	tvrdený
 02453889-v	slk:lemma	schváliť
 03002948-n	slk:lemma	obradný kalich
 09725772-n	slk:lemma	Pakistanka
 05125377-n	slk:lemma	oblasť pôsobenia
-01179241-s	slk:lemma	ambróziový
+01179241-a	slk:lemma	ambróziový
 02157557-n	slk:lemma	chvost
 14451911-n	slk:lemma	sýtosť
 03167337-n	slk:lemma	smrteľná pasca
@@ -19276,7 +19276,7 @@
 00813044-v	slk:lemma	zvážiť
 15271008-n	slk:lemma	pauza
 00521562-n	slk:lemma	predvedenie
-00477661-s	slk:lemma	útulný
+00477661-a	slk:lemma	útulný
 00007015-r	slk:lemma	zhruba
 05079866-n	slk:lemma	postoj
 04673668-n	slk:lemma	odporúčanie
@@ -19298,23 +19298,23 @@
 02339171-v	slk:lemma	ponúkať
 03292736-n	slk:lemma	epicykloidný pohyb
 00407215-r	slk:lemma	krížom cez krajinu
-00516887-s	slk:lemma	alikvotný
+00516887-a	slk:lemma	alikvotný
 08309086-n	slk:lemma	zjazd
 05089947-n	slk:lemma	medzera
 04935239-n	slk:lemma	lepivosť
 04178897-n	slk:lemma	stoková sieť
 04344873-n	slk:lemma	gauč
 01117454-n	slk:lemma	predaj z druhej ruky
-00590163-s	slk:lemma	roztrpčený
+00590163-a	slk:lemma	roztrpčený
 01651896-a	slk:lemma	neplatný
-00658513-s	slk:lemma	ležiaci na tejto priamke
+00658513-a	slk:lemma	ležiaci na tejto priamke
 00658052-v	slk:lemma	posúdiť
 11552386-n	slk:lemma	semenné
 10200781-n	slk:lemma	vplyvná osoba
 06694540-n	slk:lemma	príhovor
 13360254-n	slk:lemma	fond pre politickú kampaň
-02465350-s	slk:lemma	spoľahlivý
-00493012-s	slk:lemma	komunálny
+02465350-a	slk:lemma	spoľahlivý
+00493012-a	slk:lemma	komunálny
 02035919-v	slk:lemma	prehýnať
 06559365-n	slk:lemma	obhajoba
 01088923-v	slk:lemma	priraďovať
@@ -19327,7 +19327,7 @@
 00528339-v	slk:lemma	stavať sa na nohy
 06438290-n	slk:lemma	Kniha proroka Jerenmiáša
 02717402-a	slk:lemma	redaktorský
-01046226-s	slk:lemma	lokálny
+01046226-a	slk:lemma	lokálny
 02488834-v	slk:lemma	brať sa
 02863724-a	slk:lemma	uhličitý
 15169421-n	slk:lemma	prítmie
@@ -19380,12 +19380,12 @@
 02586619-v	slk:lemma	ovládnuť
 00165793-n	slk:lemma	vkladanie rúk
 10594857-n	slk:lemma	gauner
-01223271-s	slk:lemma	pokrytecký
+01223271-a	slk:lemma	pokrytecký
 00254597-n	slk:lemma	epilácia
 00796586-n	slk:lemma	poverenie
 00205079-n	slk:lemma	popretie
 01183573-v	slk:lemma	splniť
-02378347-s	slk:lemma	trvajúci súčasne
+02378347-a	slk:lemma	trvajúci súčasne
 02291708-v	slk:lemma	dať zisk
 13354985-n	slk:lemma	účet
 00712225-n	slk:lemma	aplikácia
@@ -19405,12 +19405,12 @@
 00266806-n	slk:lemma	náprava
 08348815-n	slk:lemma	súdny orgán
 00067999-v	slk:lemma	vytiecť
-01690606-s	slk:lemma	vžitý
+01690606-a	slk:lemma	vžitý
 02123298-v	slk:lemma	pichať
 04018399-n	slk:lemma	krčma
 05651399-n	slk:lemma	zapamätanie si
 01814074-v	slk:lemma	udržať sa v dobrej nálade
-01155603-s	slk:lemma	vypočítavý
+01155603-a	slk:lemma	vypočítavý
 00699815-v	slk:lemma	determinovať
 08848568-n	slk:lemma	Manama
 04487996-n	slk:lemma	cena
@@ -19429,7 +19429,7 @@
 15047313-n	slk:lemma	rozpúšťadlo
 13292613-n	slk:lemma	odškodnenie
 08457543-n	slk:lemma	genetická informácia
-02074673-s	slk:lemma	šialený
+02074673-a	slk:lemma	šialený
 01116380-a	slk:lemma	predstieraný
 13866144-n	slk:lemma	polygón
 05565548-n	slk:lemma	ľavá ruka
@@ -19477,14 +19477,14 @@
 00605516-a	slk:lemma	tradičný
 00345761-v	slk:lemma	počať
 04217718-n	slk:lemma	signalizačný nástroj
-00724397-s	slk:lemma	zaručený
+00724397-a	slk:lemma	zaručený
 01926376-a	slk:lemma	nelogický
 10734394-n	slk:lemma	dvojča
 10437852-n	slk:lemma	žalobca
-00413861-s	slk:lemma	antický
+00413861-a	slk:lemma	antický
 02935387-n	slk:lemma	krabička
 00452034-n	slk:lemma	býčie zápasy
-01388062-s	slk:lemma	strhujúci
+01388062-a	slk:lemma	strhujúci
 08844279-n	slk:lemma	Nová Guinea
 08738014-n	slk:lemma	Tegucigalpa
 05553486-n	slk:lemma	hruď
@@ -19498,11 +19498,11 @@
 14440875-n	slk:lemma	degenerácia
 08462320-n	slk:lemma	dáta
 04406350-n	slk:lemma	televízna stanica
-01440641-s	slk:lemma	trvácny
+01440641-a	slk:lemma	trvácny
 01802494-v	slk:lemma	vyjadriť pocity
 07447261-n	slk:lemma	udalosť
 02339171-v	slk:lemma	prinášať
-02503305-s	slk:lemma	premárnený
+02503305-a	slk:lemma	premárnený
 00606370-n	slk:lemma	remeslo
 02756098-n	slk:lemma	šaty
 00318816-v	slk:lemma	natiahnuť
@@ -19521,7 +19521,7 @@
 06582403-n	slk:lemma	rutina
 07006119-n	slk:lemma	dramaturgia
 01955508-v	slk:lemma	odosielať
-02323072-s	slk:lemma	drvivý
+02323072-a	slk:lemma	drvivý
 10677713-n	slk:lemma	pomocník
 01295275-v	slk:lemma	pripájať k sebe
 09371360-n	slk:lemma	Níl, rieka Níl
@@ -19537,14 +19537,14 @@
 00396029-n	slk:lemma	drenáž
 02715513-n	slk:lemma	predsieň
 03996655-n	slk:lemma	elektráreň
-00071242-s	slk:lemma	zachvátený
+00071242-a	slk:lemma	zachvátený
 14607521-n	slk:lemma	kyselina
 10753546-n	slk:lemma	podliak
 06354774-n	slk:lemma	čiarový kód
 06887726-n	slk:lemma	výklad
 09370168-n	slk:lemma	New River
 10771809-n	slk:lemma	nositeľ
-01401413-s	slk:lemma	schválený
+01401413-a	slk:lemma	schválený
 02274482-v	slk:lemma	privlastniť si
 13624190-n	slk:lemma	kubický decimeter
 01776214-v	slk:lemma	zaujímať sa o niečo
@@ -19553,7 +19553,7 @@
 05338410-n	slk:lemma	bazilárna artéria
 00124702-r	slk:lemma	ručne
 00060833-v	slk:lemma	vykastrovať
-01062393-s	slk:lemma	nezávislý
+01062393-a	slk:lemma	nezávislý
 00593363-v	slk:lemma	odpísať
 01207951-v	slk:lemma	zakrývať
 01761706-v	slk:lemma	otriasť
@@ -19561,7 +19561,7 @@
 06729499-n	slk:lemma	dôrazné uistenie
 08633683-n	slk:lemma	nábrežie
 03604843-n	slk:lemma	spojovací kábel
-00343226-s	slk:lemma	osudný
+00343226-a	slk:lemma	osudný
 08892428-n	slk:lemma	hrad Balmoral
 01277974-v	slk:lemma	prekladať
 02110958-n	slk:lemma	mops
@@ -19582,7 +19582,7 @@
 01160729-n	slk:lemma	bitka
 00057306-n	slk:lemma	prerušenie
 02727462-v	slk:lemma	ostávať
-00827743-s	slk:lemma	juhovýchod
+00827743-a	slk:lemma	juhovýchod
 02319824-v	slk:lemma	zdražiť
 01202068-v	slk:lemma	hltať (tekutinu)
 06750804-n	slk:lemma	téza
@@ -19592,10 +19592,10 @@
 05619743-n	slk:lemma	geniálna myseľ
 04677716-n	slk:lemma	podoba
 13464204-n	slk:lemma	zhoršenie
-02382396-s	slk:lemma	opozičný
+02382396-a	slk:lemma	opozičný
 08395682-n	slk:lemma	AI
 00879759-n	slk:lemma	pozorovanie
-00850053-s	slk:lemma	prepychový
+00850053-a	slk:lemma	prepychový
 04137089-n	slk:lemma	delené okno
 02140033-v	slk:lemma	ukázať
 08793914-n	slk:lemma	Galilea
@@ -19615,10 +19615,10 @@
 00230331-r	slk:lemma	zvonku
 00753428-v	slk:lemma	požiadať
 00208210-v	slk:lemma	popudzovať
-02023430-s	slk:lemma	v núdzi
+02023430-a	slk:lemma	v núdzi
 09059274-n	slk:lemma	Arkansas
 10340312-n	slk:lemma	hráčka
-00796715-s	slk:lemma	divadelný
+00796715-a	slk:lemma	divadelný
 09167767-n	slk:lemma	Arabská púšť
 02662979-v	slk:lemma	zhodovať sa
 04959567-n	slk:lemma	odtieň
@@ -19626,17 +19626,17 @@
 04357314-n	slk:lemma	opaľovací krém
 03250952-n	slk:lemma	suchá batéria
 01504699-v	slk:lemma	biť sa
-00936297-s	slk:lemma	starý
+00936297-a	slk:lemma	starý
 05472205-n	slk:lemma	koronoidný výbežok sánky
 03127408-n	slk:lemma	kľukový hriadeľ
-01267632-s	slk:lemma	bláznivá komédia
+01267632-a	slk:lemma	bláznivá komédia
 01889610-v	slk:lemma	zatriasť sa
 04867871-n	slk:lemma	falošnosť
 05733583-n	slk:lemma	odhad
 00339463-n	slk:lemma	nové usporiadanie
 00512261-a	slk:lemma	nekompetentný
 04930478-n	slk:lemma	tvar
-01689442-s	slk:lemma	neoriginálny
+01689442-a	slk:lemma	neoriginálny
 12423565-n	slk:lemma	čeľaď Liliaceae
 00854904-v	slk:lemma	balamutiť (niekoho)
 02579447-v	slk:lemma	zvrátiť
@@ -19648,7 +19648,7 @@
 01813385-n	slk:lemma	divá hrdlička
 02237338-v	slk:lemma	odmietnuť
 05675601-n	slk:lemma	ego
-01208738-s	slk:lemma	vyspelý
+01208738-a	slk:lemma	vyspelý
 00503164-v	slk:lemma	podráždiť
 02027612-v	slk:lemma	hrnúť sa
 02387034-v	slk:lemma	pripraviť
@@ -19659,7 +19659,7 @@
 03397762-n	slk:lemma	krajka
 08184217-n	slk:lemma	nával ľudí
 03843316-n	slk:lemma	olejnička
-00455310-s	slk:lemma	oblečený do sutany
+00455310-a	slk:lemma	oblečený do sutany
 01873294-v	slk:lemma	odtlačiť
 11877646-n	slk:lemma	biela repa
 05982915-n	slk:lemma	zámer
@@ -19670,7 +19670,7 @@
 01785971-v	slk:lemma	dožrať
 10164492-n	slk:lemma	vrchná sestra
 01171183-v	slk:lemma	upíjať si
-01993408-s	slk:lemma	mravný
+01993408-a	slk:lemma	mravný
 06726158-n	slk:lemma	oznámenie
 05490983-n	slk:lemma	adrenálny kortex
 04072960-n	slk:lemma	elektrické relé
@@ -19678,21 +19678,21 @@
 01944692-v	slk:lemma	priplaviť sa na lodi
 09930772-n	slk:lemma	obchodník s galantériou
 08149781-n	slk:lemma	náboženská sekta
-00373493-s	slk:lemma	farby medi
+00373493-a	slk:lemma	farby medi
 08764561-n	slk:lemma	Svalbard
 03156405-n	slk:lemma	valec motora
-00445169-s	slk:lemma	blízko ležiaci
+00445169-a	slk:lemma	blízko ležiaci
 02579447-v	slk:lemma	morálne degenerovať
 05827684-n	slk:lemma	impulz
 02862797-a	slk:lemma	jadrový
 02632353-v	slk:lemma	nemať
-00782216-s	slk:lemma	nejasný
+00782216-a	slk:lemma	nejasný
 01480149-v	slk:lemma	ukoristiť
 00699815-v	slk:lemma	stanoviť sa
 00279523-r	slk:lemma	úprimne
 04232800-n	slk:lemma	strešné okno
 03769881-n	slk:lemma	malý autobus
-01655538-s	slk:lemma	stiahnutý
+01655538-a	slk:lemma	stiahnutý
 06825863-n	slk:lemma	dvojkomorový skript
 05691241-n	slk:lemma	zádrheľ
 14257377-n	slk:lemma	chronické ochorenie postihujúce spojivky
@@ -19701,7 +19701,7 @@
 06263762-n	slk:lemma	médium
 14407536-n	slk:lemma	očarenie
 04095342-n	slk:lemma	nit
-01796977-s	slk:lemma	rozožraný od červov
+01796977-a	slk:lemma	rozožraný od červov
 15230076-n	slk:lemma	piata kanonická hodina
 10806222-n	slk:lemma	zoológ
 10535881-n	slk:lemma	rocker
@@ -19714,9 +19714,9 @@
 08697827-n	slk:lemma	škandinávsky národ
 00490678-r	slk:lemma	najprv
 00509607-v	slk:lemma	vybodkovávať
-00494409-s	slk:lemma	patričný
+00494409-a	slk:lemma	patričný
 00048225-n	slk:lemma	výsledok
-01707733-s	slk:lemma	skrytý
+01707733-a	slk:lemma	skrytý
 14097432-n	slk:lemma	afakia
 15113229-n	slk:lemma	doba
 02746897-a	slk:lemma	cisársky
@@ -19735,16 +19735,16 @@
 06865345-n	slk:lemma	tón
 00213052-n	slk:lemma	odstúpenie
 10080869-n	slk:lemma	otec
-01971846-s	slk:lemma	príbuzný
+01971846-a	slk:lemma	príbuzný
 00946105-v	slk:lemma	uviesť
 08053905-n	slk:lemma	medicínske zariadenie
 00463234-v	slk:lemma	premáhať
 04060904-n	slk:lemma	zásobník
 01126360-v	slk:lemma	zabrať územie
-01059711-s	slk:lemma	nehybný
-00659259-s	slk:lemma	plochý
+01059711-a	slk:lemma	nehybný
+00659259-a	slk:lemma	plochý
 03828465-n	slk:lemma	nesteroidný protizápalový liek
-00890351-s	slk:lemma	rovný
+00890351-a	slk:lemma	rovný
 13311830-n	slk:lemma	zisk, kapitálový
 01326015-n	slk:lemma	chochol
 00710260-a	slk:lemma	náročný
@@ -19754,7 +19754,7 @@
 02283324-v	slk:lemma	ponechať si
 00363260-n	slk:lemma	zvýšenie
 05686086-n	slk:lemma	dilema
-02449952-s	slk:lemma	smrteľný
+02449952-a	slk:lemma	smrteľný
 06446711-n	slk:lemma	Jakubov list
 05749619-n	slk:lemma	perceptívnosť
 10164747-n	slk:lemma	predstaviteľ štátu
@@ -19764,7 +19764,7 @@
 09762509-n	slk:lemma	kanón
 05715864-n	slk:lemma	chuť
 01022824-n	slk:lemma	zbavenie práv a slobôd
-00709215-s	slk:lemma	krehký
+00709215-a	slk:lemma	krehký
 06513366-n	slk:lemma	prosba
 03792048-n	slk:lemma	kopec
 00439849-v	slk:lemma	zrýchliť
@@ -19772,11 +19772,11 @@
 05207130-n	slk:lemma	neschopnosť
 13576101-n	slk:lemma	určité množstvo
 05044673-n	slk:lemma	časové usporiadanie
-00418364-s	slk:lemma	bez poškvrny
+00418364-a	slk:lemma	bez poškvrny
 03160309-n	slk:lemma	hrádza
 01876028-v	slk:lemma	hojdať
 01254253-n	slk:lemma	oddeľovanie
-00357556-s	slk:lemma	typický
+00357556-a	slk:lemma	typický
 02687916-v	slk:lemma	pokračovať
 05274247-n	slk:lemma	kostrčová kosť
 10171219-n	slk:lemma	posol
@@ -19802,13 +19802,13 @@
 01022824-n	slk:lemma	zbavenie výsad
 00721431-n	slk:lemma	miesto
 00066025-v	slk:lemma	poplakať
-01515692-s	slk:lemma	zúčastnený
+01515692-a	slk:lemma	zúčastnený
 00389763-n	slk:lemma	vzájomná pomoc
 03031152-n	slk:lemma	cigaršpic
 10671613-n	slk:lemma	dedič
 06609909-n	slk:lemma	blbosť
 06833890-n	slk:lemma	Z
-02418093-s	slk:lemma	možný
+02418093-a	slk:lemma	možný
 00299580-v	slk:lemma	prispôsobiť si
 00224941-r	slk:lemma	nekonečne
 00617748-v	slk:lemma	zmýliť sa
@@ -19819,7 +19819,7 @@
 10378412-n	slk:lemma	ovládač
 06168552-n	slk:lemma	výpočtová lingvistika
 00057388-r	slk:lemma	poriadne
-00522885-s	slk:lemma	celý
+00522885-a	slk:lemma	celý
 06642138-n	slk:lemma	zvesť
 01156834-v	slk:lemma	skonzumovať
 01664172-v	slk:lemma	prichystať si (jedlo)
@@ -19830,23 +19830,23 @@
 06760722-n	slk:lemma	podvod
 01130169-v	slk:lemma	strážiť
 00512522-n	slk:lemma	koketovanie
-02515214-s	slk:lemma	skazený
-01127147-s	slk:lemma	strašný
+02515214-a	slk:lemma	skazený
+01127147-a	slk:lemma	strašný
 00689809-v	slk:lemma	myslieť si
-01769378-s	slk:lemma	osobný
+01769378-a	slk:lemma	osobný
 00066025-v	slk:lemma	plakať
 00505226-r	slk:lemma	v tesnej blízkosti
 11902200-n	slk:lemma	Papaver rhoeas
 00008055-v	slk:lemma	mrkať
 01587062-v	slk:lemma	obkľúčiť
 13792579-n	slk:lemma	spoj
-00970610-s	slk:lemma	zvyčajný
+00970610-a	slk:lemma	zvyčajný
 02439728-n	slk:lemma	predná laba
 01433294-v	slk:lemma	prinášať
 01686956-v	slk:lemma	vyjadriť
 01962178-v	slk:lemma	plávať prsia
 14042165-n	slk:lemma	neprítomnosť CO2 v krvi
-02586446-s	slk:lemma	príkladný
+02586446-a	slk:lemma	príkladný
 14983326-n	slk:lemma	kyselina pikrová
 00986938-n	slk:lemma	streľba
 06177450-n	slk:lemma	náuka o hláskach
@@ -19855,7 +19855,7 @@
 00645365-n	slk:lemma	časová štúdia
 00552815-v	slk:lemma	rozpadnúť sa
 03009794-n	slk:lemma	márnica
-01239410-s	slk:lemma	ležiaci tvárou k zemi
+01239410-a	slk:lemma	ležiaci tvárou k zemi
 00035758-v	slk:lemma	umyť
 00619869-v	slk:lemma	nerozumieť
 08710113-n	slk:lemma	Barbuda
@@ -19865,15 +19865,15 @@
 02061495-v	slk:lemma	hnať sa
 03717447-n	slk:lemma	prielez
 02490004-v	slk:lemma	brať si
-01969707-s	slk:lemma	mesačný
+01969707-a	slk:lemma	mesačný
 06833436-n	slk:lemma	v
 13455487-n	slk:lemma	spracovanie dát
 10621514-n	slk:lemma	sodomista
 07652401-n	slk:lemma	husacia pečeň
 03383099-n	slk:lemma	predná plachta
-00733297-s	slk:lemma	žiadaný
+00733297-a	slk:lemma	žiadaný
 08708742-n	slk:lemma	Anguilla
-00018850-s	slk:lemma	neprijateľný
+00018850-a	slk:lemma	neprijateľný
 09851465-n	slk:lemma	družba
 00926472-v	slk:lemma	odhadovať
 00356412-r	slk:lemma	potom
@@ -19885,7 +19885,7 @@
 02444662-v	slk:lemma	dať formálne povolenie
 00664483-v	slk:lemma	uisťovať sa
 01580467-v	slk:lemma	zahaliť
-00507292-s	slk:lemma	ukrutný
+00507292-a	slk:lemma	ukrutný
 01509527-a	slk:lemma	silný
 02684971-a	slk:lemma	nebeský
 09306257-n	slk:lemma	Žltá rieka
@@ -19902,7 +19902,7 @@
 02099774-a	slk:lemma	seniorský
 01761871-a	slk:lemma	dovolený
 07628870-n	slk:lemma	koláč
-00930765-s	slk:lemma	neočakávaný
+00930765-a	slk:lemma	neočakávaný
 00604576-v	slk:lemma	učiť sa naspamäť
 07500159-n	slk:lemma	schválenie
 02681795-v	slk:lemma	udržiavať sa
@@ -19917,18 +19917,18 @@
 00122661-n	slk:lemma	strieľanie
 13108841-n	slk:lemma	ihličnatý strom
 00332154-v	slk:lemma	rozdrviť
-00160768-s	slk:lemma	samostatne stojaci
-01001945-s	slk:lemma	schopný počatia
+00160768-a	slk:lemma	samostatne stojaci
+01001945-a	slk:lemma	schopný počatia
 01349948-n	slk:lemma	bacil
-01592857-s	slk:lemma	pokorný
+01592857-a	slk:lemma	pokorný
 01378556-v	slk:lemma	rozšíriť
-00906655-s	slk:lemma	úražlivý
+00906655-a	slk:lemma	úražlivý
 10182913-n	slk:lemma	homosexuál
 07479144-n	slk:lemma	zničenie hlavy
 05413465-n	slk:lemma	hormón štítnej žľazy
 13625063-n	slk:lemma	kilometer kubický
 01183573-v	slk:lemma	uspokojiť
-02577734-s	slk:lemma	hmotný
+02577734-a	slk:lemma	hmotný
 15093298-n	slk:lemma	kyselina askorbová
 01884539-a	slk:lemma	retrospektívny
 04570532-n	slk:lemma	smútočné šaty
@@ -19947,7 +19947,7 @@
 00258175-r	slk:lemma	bez platenia
 00025203-v	slk:lemma	znervózňovať
 00713594-n	slk:lemma	narábanie
-01789481-s	slk:lemma	jarabatý
+01789481-a	slk:lemma	jarabatý
 01876028-v	slk:lemma	kolísať
 13542474-n	slk:lemma	profáza
 00466053-v	slk:lemma	usporiadať sa
@@ -19982,9 +19982,9 @@
 03918480-n	slk:lemma	PC
 15147504-n	slk:lemma	chlapčenský vek
 03862676-n	slk:lemma	piecka
-02062133-s	slk:lemma	predajný
+02062133-a	slk:lemma	predajný
 06544142-n	slk:lemma	testament
-00304949-s	slk:lemma	úporný
+00304949-a	slk:lemma	úporný
 00388494-r	slk:lemma	lento
 01031256-v	slk:lemma	posielať
 10521662-n	slk:lemma	novinár
@@ -19997,7 +19997,7 @@
 02022659-v	slk:lemma	zmeškať
 08083599-n	slk:lemma	rímsko-katolíci
 02604477-v	slk:lemma	súčasne existovať
-00084795-s	slk:lemma	bojovný
+00084795-a	slk:lemma	bojovný
 10079893-n	slk:lemma	fašista
 04827652-n	slk:lemma	nespravodlivosť
 01842888-v	slk:lemma	pohnúť sa
@@ -20020,11 +20020,11 @@
 02795670-n	slk:lemma	putika
 07464725-n	slk:lemma	turnaj
 04644512-n	slk:lemma	ochota
-00547317-s	slk:lemma	úsečný
+00547317-a	slk:lemma	úsečný
 04043411-n	slk:lemma	rádio-gramofón
 14436029-n	slk:lemma	obskurita
 01167548-n	slk:lemma	pokora
-00477284-s	slk:lemma	útulný
+00477284-a	slk:lemma	útulný
 04289576-n	slk:lemma	spritová plachta
 07238102-n	slk:lemma	domnienka
 07515560-n	slk:lemma	tichosť
@@ -20038,7 +20038,7 @@
 04024396-n	slk:lemma	dierka
 00955601-v	slk:lemma	rozvíjať
 08416652-n	slk:lemma	pravica
-02526611-s	slk:lemma	chránený
+02526611-a	slk:lemma	chránený
 01567275-v	slk:lemma	zasadiť
 01782050-n	slk:lemma	čeľaď Tetranychidae
 11664929-n	slk:lemma	Anthophyta
@@ -20046,7 +20046,7 @@
 01229976-v	slk:lemma	pichať
 03597469-n	slk:lemma	šperky
 00798717-v	slk:lemma	odvolať
-01501821-s	slk:lemma	medový
+01501821-a	slk:lemma	medový
 03080492-a	slk:lemma	latinský
 01188725-v	slk:lemma	vyžiadať
 00895304-v	slk:lemma	prehovoriť na obranu
@@ -20066,12 +20066,12 @@
 02251743-v	slk:lemma	vyplatiť
 12212361-n	slk:lemma	zelenina
 02159271-n	slk:lemma	Insecta
-02227946-s	slk:lemma	odborný
+02227946-a	slk:lemma	odborný
 05594037-n	slk:lemma	nožná kosť
 02935387-n	slk:lemma	krabička s čajom
 03104594-n	slk:lemma	kópia
 06782019-n	slk:lemma	domnienka
-02282651-s	slk:lemma	samovoľný
+02282651-a	slk:lemma	samovoľný
 00279523-r	slk:lemma	hrubo
 02018372-v	slk:lemma	chytať
 08119397-n	slk:lemma	zásobovacie oddelenie
@@ -20080,7 +20080,7 @@
 04208936-n	slk:lemma	sprcha
 08742205-n	slk:lemma	Acapulco
 09963914-n	slk:lemma	koordinátor
-01680559-s	slk:lemma	nerastný
+01680559-a	slk:lemma	nerastný
 00128168-r	slk:lemma	typicky
 04286128-n	slk:lemma	lokál
 01088757-n	slk:lemma	poistenie pre prípad nespôsobilosti
@@ -20091,9 +20091,9 @@
 14539268-n	slk:lemma	istota
 00644583-v	slk:lemma	rozobrať
 15170504-n	slk:lemma	víkend
-02316992-s	slk:lemma	kľukatý
+02316992-a	slk:lemma	kľukatý
 15239174-n	slk:lemma	suché ročné obdobie
-01086915-s	slk:lemma	holý
+01086915-a	slk:lemma	holý
 02037272-a	slk:lemma	nespravodlivý
 09849012-n	slk:lemma	krásavica
 04140631-n	slk:lemma	koza na rezanie dreva
@@ -20103,7 +20103,7 @@
 02199712-n	slk:lemma	Nematocera
 07997703-n	slk:lemma	trieda
 01926376-a	slk:lemma	iracionálny
-00792202-s	slk:lemma	silnejší
+00792202-a	slk:lemma	silnejší
 01169744-n	slk:lemma	konfrontácia
 00072012-v	slk:lemma	počúrať sa
 00799798-v	slk:lemma	vziať späť
@@ -20121,18 +20121,18 @@
 04947186-n	slk:lemma	uhladenosť
 02479990-v	slk:lemma	rozmiestniť
 04493381-n	slk:lemma	kaďa
-00922840-s	slk:lemma	jednotvárny
-00021110-s	slk:lemma	ochotný
+00922840-a	slk:lemma	jednotvárny
+00021110-a	slk:lemma	ochotný
 01100145-v	slk:lemma	vyhrať
 00755447-v	slk:lemma	apelovať
-01254165-s	slk:lemma	ľadový
+01254165-a	slk:lemma	ľadový
 01814815-v	slk:lemma	čičíkať
 03257343-n	slk:lemma	verná kópia
 01686439-a	slk:lemma	svojrázny
-00511739-s	slk:lemma	nevýkonný
+00511739-a	slk:lemma	nevýkonný
 06358159-n	slk:lemma	strojový kód
 03612814-n	slk:lemma	kotol
-01368464-s	slk:lemma	smútočný
+01368464-a	slk:lemma	smútočný
 00346296-n	slk:lemma	zmena smeru
 13374597-n	slk:lemma	banková pôžička
 02238770-v	slk:lemma	získavať
@@ -20147,7 +20147,7 @@
 00720565-n	slk:lemma	post
 07593549-n	slk:lemma	zmrazená potravina
 02952485-n	slk:lemma	jedáleň
-01856419-s	slk:lemma	zásadný
+01856419-a	slk:lemma	zásadný
 04247175-n	slk:lemma	továrenský komín
 00157950-v	slk:lemma	zintenzívňovať sa
 00630380-v	slk:lemma	rozvažovať
@@ -20155,7 +20155,7 @@
 04959567-n	slk:lemma	nádych
 00088154-n	slk:lemma	jednorazová subvencia
 05124928-n	slk:lemma	vrchol
-00682521-s	slk:lemma	hluchý ako peň
+00682521-a	slk:lemma	hluchý ako peň
 02023107-v	slk:lemma	stretnúť sa
 00033308-r	slk:lemma	teraz
 14420464-n	slk:lemma	koherencia
@@ -20164,7 +20164,7 @@
 06455138-n	slk:lemma	evanjelium
 00992518-v	slk:lemma	triasť rukou
 00800242-v	slk:lemma	nechávať napospas
-02573987-s	slk:lemma	džungľovitý
+02573987-a	slk:lemma	džungľovitý
 04645943-n	slk:lemma	zdráhanie sa
 04157320-n	slk:lemma	plastika
 10036929-n	slk:lemma	bubeník
@@ -20177,7 +20177,7 @@
 08663860-n	slk:lemma	vrchol
 01557774-v	slk:lemma	odpojiť sa
 03208556-n	slk:lemma	kotúč
-02325984-s	slk:lemma	bledý
+02325984-a	slk:lemma	bledý
 11808468-n	slk:lemma	Dianthus caryophyllus
 04548503-n	slk:lemma	stenový panel
 07965085-n	slk:lemma	spolok
@@ -20204,13 +20204,13 @@
 04151581-n	slk:lemma	ochrana
 00648224-v	slk:lemma	realizovať výskum
 02261888-v	slk:lemma	vyznamenať
-01871473-s	slk:lemma	platený
+01871473-a	slk:lemma	platený
 05633385-n	slk:lemma	myšlienka
 01864707-n	slk:lemma	rod cicavcov
 10638385-n	slk:lemma	predstaviteľ
 13300922-n	slk:lemma	odňatie
 05318831-n	slk:lemma	ušný bubienok
-00609564-s	slk:lemma	podivný
+00609564-a	slk:lemma	podivný
 07094508-n	slk:lemma	metrický rozbor
 02261888-v	slk:lemma	vyznamenávať
 05827684-n	slk:lemma	dráždenie
@@ -20225,7 +20225,7 @@
 09759311-n	slk:lemma	akademik
 00097108-r	slk:lemma	proti prúdu
 00045250-n	slk:lemma	pohon
-00280463-s	slk:lemma	lesklý
+00280463-a	slk:lemma	lesklý
 08398773-n	slk:lemma	zbierka
 02753044-n	slk:lemma	nukleárna bomba
 05466005-n	slk:lemma	Gogliho bunka
@@ -20236,7 +20236,7 @@
 00220461-v	slk:lemma	zosilnieť
 13868944-n	slk:lemma	zvlnenie
 08714132-n	slk:lemma	Bulharská republika
-00215087-s	slk:lemma	vlasatý
+00215087-a	slk:lemma	vlasatý
 02405252-v	slk:lemma	odstraňovať
 07205308-n	slk:lemma	dvojitý negatív
 08551177-n	slk:lemma	oblasť ohrozenia
@@ -20267,25 +20267,25 @@
 12485653-n	slk:lemma	budleja dávidova
 10293590-n	slk:lemma	markíza
 03102859-n	slk:lemma	chladenie
-00345494-s	slk:lemma	premenlivý
-00167829-s	slk:lemma	pôvabný
+00345494-a	slk:lemma	premenlivý
+00167829-a	slk:lemma	pôvabný
 02225739-v	slk:lemma	šetriť
 05534333-n	slk:lemma	črevo
 06546633-n	slk:lemma	postúpenie
 04359589-n	slk:lemma	podpora
-01462882-s	slk:lemma	obľúbený
+01462882-a	slk:lemma	obľúbený
 00050195-n	slk:lemma	objavenie (sa)
 14492373-n	slk:lemma	opulencia
 03258730-n	slk:lemma	pracovný plášť
 11424704-n	slk:lemma	prúdová intenzita
 03686130-n	slk:lemma	manzarda
-02569558-s	slk:lemma	prezieravý
+02569558-a	slk:lemma	prezieravý
 02109190-v	slk:lemma	znášať
 10613996-n	slk:lemma	fešanda
 00175135-r	slk:lemma	prudko
 02023107-v	slk:lemma	stretnúť
 04965661-n	slk:lemma	žltá farba
-01871565-s	slk:lemma	ekonomický
+01871565-a	slk:lemma	ekonomický
 04713118-n	slk:lemma	súlad
 01153486-v	slk:lemma	odplatiť sa
 09974648-n	slk:lemma	pracovník
@@ -20298,9 +20298,9 @@
 07575510-n	slk:lemma	pobedný čaj
 15183802-n	slk:lemma	náboženský sviatok
 04182514-n	slk:lemma	šachta
-02340458-s	slk:lemma	nízky
+02340458-a	slk:lemma	nízky
 05757536-n	slk:lemma	školské vyučovanie
-00850648-s	slk:lemma	vkusný
+00850648-a	slk:lemma	vkusný
 01107932-n	slk:lemma	prevod
 01032326-v	slk:lemma	podať (list)
 00994449-n	slk:lemma	delostrelecká paľba
@@ -20325,21 +20325,21 @@
 03110332-n	slk:lemma	nárožný kameň
 08829775-n	slk:lemma	provincia Saskačevan
 00193130-v	slk:lemma	povzbudiť
-02051616-s	slk:lemma	sedliacky
+02051616-a	slk:lemma	sedliacky
 09297920-n	slk:lemma	Carpentaria
 00110853-a	slk:lemma	analytický
-02285407-s	slk:lemma	písaný rukou
+02285407-a	slk:lemma	písaný rukou
 13586122-n	slk:lemma	index
 01329830-a	slk:lemma	kombinovaný
 02348405-n	slk:lemma	čeľaď Heteromyidae
 08077292-n	slk:lemma	administratívna jednotka
-00488998-s	slk:lemma	neobvyklý
+00488998-a	slk:lemma	neobvyklý
 01220152-n	slk:lemma	odmietanie
-01035559-s	slk:lemma	narodený v cudzine
+01035559-a	slk:lemma	narodený v cudzine
 01953810-v	slk:lemma	prepraviť
 01993549-v	slk:lemma	preháňať sa
 01148491-n	slk:lemma	obmedzovanie obchodu
-00138782-s	slk:lemma	nepríhodný
+00138782-a	slk:lemma	nepríhodný
 13454130-n	slk:lemma	crossing-over
 09623038-n	slk:lemma	líder
 06833436-n	slk:lemma	véčko
@@ -20356,7 +20356,7 @@
 00433802-n	slk:lemma	gymnastika
 07928696-n	slk:lemma	Coca Cola
 05341920-n	slk:lemma	krčná artéria
-00541614-s	slk:lemma	rozsiahly
+00541614-a	slk:lemma	rozsiahly
 02066304-v	slk:lemma	odbiehať
 02566528-v	slk:lemma	prekročiť
 12900987-n	slk:lemma	červená paprika
@@ -20373,13 +20373,13 @@
 02078399-a	slk:lemma	neprekonateľný
 12996841-n	slk:lemma	Basidiomycetes
 01564144-v	slk:lemma	kaziť
-00461609-s	slk:lemma	nejasný
-00179315-s	slk:lemma	kráľovský
+00461609-a	slk:lemma	nejasný
+00179315-a	slk:lemma	kráľovský
 00385791-n	slk:lemma	delenie
 02109190-v	slk:lemma	trpieť
 05230603-n	slk:lemma	kraniometrický bod
 03425956-n	slk:lemma	plynárenské zariadenie
-00136884-s	slk:lemma	vystavený (komu)
+00136884-a	slk:lemma	vystavený (komu)
 01883898-a	slk:lemma	prezieravý
 14476290-n	slk:lemma	pohroma
 05546383-n	slk:lemma	lícny výbežok
@@ -20390,11 +20390,11 @@
 01069809-v	slk:lemma	pýtať sa
 02304982-v	slk:lemma	zbierať
 01762283-v	slk:lemma	povzbudiť
-01752953-s	slk:lemma	poškodený
+01752953-a	slk:lemma	poškodený
 02687916-v	slk:lemma	rozkladať sa
 13855828-n	slk:lemma	rub
 10076033-n	slk:lemma	prihriaty
-00107017-s	slk:lemma	nepatrný
+00107017-a	slk:lemma	nepatrný
 02150948-v	slk:lemma	sledovať
 06429590-n	slk:lemma	náboženský text
 03472232-n	slk:lemma	telocvičné náradie
@@ -20407,7 +20407,7 @@
 01846320-v	slk:lemma	riadiť loď
 01335075-v	slk:lemma	pokryť fóliou
 02108377-v	slk:lemma	podstupovať (niečo)
-01689223-s	slk:lemma	triviálny
+01689223-a	slk:lemma	triviálny
 00205046-v	slk:lemma	vylepšiť
 01202415-n	slk:lemma	integrácia
 00057486-n	slk:lemma	vzďaľovanie sa
@@ -20431,19 +20431,19 @@
 03823111-n	slk:lemma	hrot
 02955767-n	slk:lemma	pelerína
 06782383-n	slk:lemma	negatívny posudok
-02500179-s	slk:lemma	nesprávny
+02500179-a	slk:lemma	nesprávny
 05231769-n	slk:lemma	kríženie vencového a šípového švu
 15282696-n	slk:lemma	rýchlosť
 04474843-n	slk:lemma	brička
 05762149-n	slk:lemma	pamäť
-01126841-s	slk:lemma	biedny
+01126841-a	slk:lemma	biedny
 08141092-n	slk:lemma	CID
-01625893-s	slk:lemma	odporný
+01625893-a	slk:lemma	odporný
 09044862-n	slk:lemma	Štáty americké
 02296153-v	slk:lemma	odovzdať
 00475647-v	slk:lemma	zbavovať (niečoho)
 02697120-v	slk:lemma	predstavovať hrozbu
-01865967-s	slk:lemma	úrodný
+01865967-a	slk:lemma	úrodný
 03093076-a	slk:lemma	olympijský
 01916229-a	slk:lemma	sporný
 06461077-n	slk:lemma	Poučné knihy Starého zákona
@@ -20462,14 +20462,14 @@
 03702248-n	slk:lemma	obrábací stroj
 00813978-v	slk:lemma	prebrať (niečo)
 03132438-n	slk:lemma	priechodka
-00974159-s	slk:lemma	zastaraný
-01729566-s	slk:lemma	predchádzajúci
+00974159-a	slk:lemma	zastaraný
+01729566-a	slk:lemma	predchádzajúci
 03436417-n	slk:lemma	obchod s darčekovými predmetmi
 04799133-n	slk:lemma	národnosť
 15094053-n	slk:lemma	papier na vyhodenie
 01155090-v	slk:lemma	doháňať
-02214736-s	slk:lemma	osamelý
-00482673-s	slk:lemma	pomerný
+02214736-a	slk:lemma	osamelý
+00482673-a	slk:lemma	pomerný
 00356954-v	slk:lemma	zdeformovať
 00875394-v	slk:lemma	navrhovať
 05568767-n	slk:lemma	nerv v lakti
@@ -20499,13 +20499,13 @@
 01400562-a	slk:lemma	právny
 00939857-v	slk:lemma	vysvetliť
 03725968-n	slk:lemma	MIT
-01166413-s	slk:lemma	užitočný
+01166413-a	slk:lemma	užitočný
 01411085-v	slk:lemma	potrestať palicou
 14491271-n	slk:lemma	blahobyt
 05595083-n	slk:lemma	kĺb
 01636008-v	slk:lemma	zviditeľniť
 00490035-a	slk:lemma	zriedkavý
-01689442-s	slk:lemma	otrepaný
+01689442-a	slk:lemma	otrepaný
 01615602-v	slk:lemma	pokovovať
 02066939-v	slk:lemma	pretekať
 09746637-n	slk:lemma	obyvateľ Wyomingu
@@ -20543,21 +20543,21 @@
 13729428-n	slk:lemma	komplexné číslo
 07635827-n	slk:lemma	maslový koláčik
 02994872-a	slk:lemma	z mramoru
-01945350-s	slk:lemma	nedovolený
-01774483-s	slk:lemma	odolný voči tukom
+01945350-a	slk:lemma	nedovolený
+01774483-a	slk:lemma	odolný voči tukom
 01020005-v	slk:lemma	všímať si
 01925469-n	slk:lemma	trieda Trematoda
 08683177-n	slk:lemma	Divoký Západ
 08003935-n	slk:lemma	sesterská firma
 00299580-v	slk:lemma	prispôsobovať si
 00211110-n	slk:lemma	dokončenie
-02436025-s	slk:lemma	neznesiteľný
+02436025-a	slk:lemma	neznesiteľný
 02496816-v	slk:lemma	krotiť
 01380122-v	slk:lemma	rozširovať sa
 15191661-n	slk:lemma	Kvetná nedeľa
 04530176-n	slk:lemma	povrch
 10386312-n	slk:lemma	vyvrheľ
-00798103-s	slk:lemma	ožratý do nemoty
+00798103-a	slk:lemma	ožratý do nemoty
 02160878-a	slk:lemma	podpísaný
 07399917-n	slk:lemma	šum
 01322854-v	slk:lemma	pobíjať
@@ -20580,17 +20580,17 @@
 08857682-n	slk:lemma	Britská ríša
 04677952-n	slk:lemma	podoba
 01523520-v	slk:lemma	odmotať
-00837415-s	slk:lemma	ťažkopádny
+00837415-a	slk:lemma	ťažkopádny
 10700201-n	slk:lemma	prenajímateľ
 00023868-v	slk:lemma	omdlieť
-01637371-s	slk:lemma	neskúsený
+01637371-a	slk:lemma	neskúsený
 01615991-v	slk:lemma	dávať nabok
 07930554-n	slk:lemma	punč
 09196103-n	slk:lemma	Amur
 04897428-n	slk:lemma	neusporiadanosť
 06803636-n	slk:lemma	volanie o pomoc
 00402539-v	slk:lemma	skomplikovať
-02321809-s	slk:lemma	húževnatý
+02321809-a	slk:lemma	húževnatý
 12587803-n	slk:lemma	kokosová palma
 00813044-v	slk:lemma	uvažovať
 13622914-n	slk:lemma	kilderkin
@@ -20636,11 +20636,11 @@
 00059171-r	slk:lemma	veľmi
 02452464-n	slk:lemma	rypák
 06551339-n	slk:lemma	povolenie k sobášu
-00975487-s	slk:lemma	módny
+00975487-a	slk:lemma	módny
 14030820-n	slk:lemma	hroziace nebezpečie
 02062212-v	slk:lemma	trepať
 04676540-n	slk:lemma	fáza
-01287486-s	slk:lemma	evidentný
+01287486-a	slk:lemma	evidentný
 02897237-n	slk:lemma	pivovar
 01051331-n	slk:lemma	umiestnenie
 00030358-n	slk:lemma	aktivita
@@ -20670,9 +20670,9 @@
 10403162-n	slk:lemma	líder politickej strany
 00212414-v	slk:lemma	uchovať
 13910019-n	slk:lemma	kvapka
-01153141-s	slk:lemma	hebký
+01153141-a	slk:lemma	hebký
 04286128-n	slk:lemma	miesto
-01265308-s	slk:lemma	humorný
+01265308-a	slk:lemma	humorný
 05585383-n	slk:lemma	skelet
 00709379-v	slk:lemma	zamýšľať
 00159620-n	slk:lemma	pokúšanie
@@ -20686,7 +20686,7 @@
 00418394-n	slk:lemma	obťažovanie
 00263044-v	slk:lemma	porušiť
 07201562-n	slk:lemma	charakteristika
-00990855-s	slk:lemma	malý
+00990855-a	slk:lemma	malý
 07368256-n	slk:lemma	prerušenie
 10599354-n	slk:lemma	hlupák
 07183151-n	slk:lemma	polemika
@@ -20705,7 +20705,7 @@
 00075021-v	slk:lemma	umoriť sa
 06515662-n	slk:lemma	letopisy
 00156222-r	slk:lemma	mimochodom
-01496311-s	slk:lemma	hraničný
+01496311-a	slk:lemma	hraničný
 00020926-v	slk:lemma	uviesť do tranzu
 02920503-n	slk:lemma	nora
 01641914-v	slk:lemma	uvádzať
@@ -20715,7 +20715,7 @@
 04161981-n	slk:lemma	miesto na sedenie
 00280853-n	slk:lemma	blíženie sa
 11444117-n	slk:lemma	úmrtie
-02241988-s	slk:lemma	kamenistý
+02241988-a	slk:lemma	kamenistý
 04880273-n	slk:lemma	svetskosť
 00318816-v	slk:lemma	predĺžiť
 01813053-v	slk:lemma	skľučovať
@@ -20723,7 +20723,7 @@
 01301410-v	slk:lemma	zatvárať
 04646548-n	slk:lemma	serióznosť
 02621395-v	slk:lemma	vytvárať
-01046784-s	slk:lemma	slangový
+01046784-a	slk:lemma	slangový
 03209666-n	slk:lemma	disková jednotka
 00257228-n	slk:lemma	strihanie
 09815455-n	slk:lemma	postupník
@@ -20750,7 +20750,7 @@
 09225943-n	slk:lemma	močarina
 14498843-n	slk:lemma	zafúľanosť
 00664788-v	slk:lemma	dokázať
-01569166-s	slk:lemma	nadnárodný
+01569166-a	slk:lemma	nadnárodný
 01904930-v	slk:lemma	chodiť
 09632518-n	slk:lemma	pracovníčka
 02857407-a	slk:lemma	politický
@@ -20765,7 +20765,7 @@
 06000400-n	slk:lemma	prírodné vedy
 03753077-n	slk:lemma	meracie zariadenie
 06755568-n	slk:lemma	výhrada
-02123007-s	slk:lemma	hravý
+02123007-a	slk:lemma	hravý
 02921753-a	slk:lemma	pápeženský
 03746330-n	slk:lemma	oblečenie pre mužov
 10140314-n	slk:lemma	guvernér
@@ -20793,20 +20793,20 @@
 02619612-v	slk:lemma	rozumieť niečomu
 09482330-n	slk:lemma	Jenisej
 00273601-n	slk:lemma	úpadok
-01427333-s	slk:lemma	morový
-00562909-s	slk:lemma	neslušný
+01427333-a	slk:lemma	morový
+00562909-a	slk:lemma	neslušný
 09088396-n	slk:lemma	Kansas City
 00074324-n	slk:lemma	postavenie mimo hry
 03483086-n	slk:lemma	ručný vozík
 02589245-v	slk:lemma	združovať sa
 08497294-n	slk:lemma	oblasť
-01492596-s	slk:lemma	mladícky (nerozvážnosť)
+01492596-a	slk:lemma	mladícky (nerozvážnosť)
 01649999-v	slk:lemma	stimulovať
 00704690-v	slk:lemma	nachystať sa
 01445407-v	slk:lemma	bodať
 11986091-n	slk:lemma	Lactuca
 01810447-v	slk:lemma	šokovať
-01649271-s	slk:lemma	nedospelý
+01649271-a	slk:lemma	nedospelý
 08212347-n	slk:lemma	muži
 03320046-n	slk:lemma	ventilátor
 00085219-n	slk:lemma	zabavenie
@@ -20817,12 +20817,12 @@
 08176077-n	slk:lemma	OAS
 02248808-v	slk:lemma	vyberať (z pamäti)
 00065639-v	slk:lemma	utrpieť (poranenie)
-01019000-s	slk:lemma	hrbatý
+01019000-a	slk:lemma	hrbatý
 04468005-n	slk:lemma	vlaková doprava
 00770270-n	slk:lemma	prečin
 02796623-n	slk:lemma	hrádza
 00439849-v	slk:lemma	zrýchľovať
-00182961-s	slk:lemma	ručný
+00182961-a	slk:lemma	ručný
 10085869-n	slk:lemma	snúbenec
 10751265-n	slk:lemma	viceprezident
 10280945-n	slk:lemma	zmierovací sudca
@@ -20845,7 +20845,7 @@
 02687423-n	slk:lemma	lietadlový motor
 00192613-n	slk:lemma	úspora
 09027460-n	slk:lemma	Aragon
-00250739-s	slk:lemma	nerozumný
+00250739-a	slk:lemma	nerozumný
 06445214-n	slk:lemma	Druhý list Solúnčanom
 08145871-n	slk:lemma	všeobecne uznávané účtovné zásady
 03302938-n	slk:lemma	výfukový systém
@@ -20862,7 +20862,7 @@
 09299397-n	slk:lemma	záliv svätého Vavrinca
 02341816-v	slk:lemma	potiahnuť
 05994935-n	slk:lemma	teória ekonomiky
-00179815-s	slk:lemma	nedovolený
+00179815-a	slk:lemma	nedovolený
 13709700-n	slk:lemma	jen
 02154508-v	slk:lemma	spozorovať
 00754731-v	slk:lemma	podať petíciu
@@ -20871,10 +20871,10 @@
 00251820-r	slk:lemma	de iure
 01232635-a	slk:lemma	rovný
 08337324-n	slk:lemma	vládny úrad
-01467534-s	slk:lemma	drobný
+01467534-a	slk:lemma	drobný
 09356320-n	slk:lemma	rieka Missouri
 06546408-n	slk:lemma	zmluva o poručníctve
-00260100-s	slk:lemma	robotnícky
+00260100-a	slk:lemma	robotnícky
 15022617-n	slk:lemma	myozín
 00407215-r	slk:lemma	po celej krajine
 03265479-n	slk:lemma	okraj
@@ -20885,7 +20885,7 @@
 01535246-v	slk:lemma	opierať
 00745499-v	slk:lemma	objednávať
 01170962-n	slk:lemma	bitka
-02251212-s	slk:lemma	osamelý
+02251212-a	slk:lemma	osamelý
 01438304-v	slk:lemma	dodávať
 13747606-n	slk:lemma	šestnástka
 02460619-v	slk:lemma	najať
@@ -20895,7 +20895,7 @@
 13385216-n	slk:lemma	prachy
 01774136-v	slk:lemma	nemať rád
 04310018-n	slk:lemma	parná lokomotíva
-01175158-s	slk:lemma	ulcerózny
+01175158-a	slk:lemma	ulcerózny
 09034550-n	slk:lemma	Tanzánia
 01631072-v	slk:lemma	obnovovať
 07890750-n	slk:lemma	medovina
@@ -20908,11 +20908,11 @@
 10016103-n	slk:lemma	učeník
 05939432-n	slk:lemma	zjav
 06473837-n	slk:lemma	formulár prihlášky
-00018850-s	slk:lemma	neprípustný
+00018850-a	slk:lemma	neprípustný
 09936215-n	slk:lemma	spolupracovníčka
 00770437-v	slk:lemma	ovplyvňovať
 01888295-v	slk:lemma	kĺzať sa
-00074594-s	slk:lemma	prirodzený
+00074594-a	slk:lemma	prirodzený
 02473981-v	slk:lemma	splnomocňovať
 08715390-n	slk:lemma	Barma
 00003380-r	slk:lemma	protivne
@@ -20949,12 +20949,12 @@
 13744722-n	slk:lemma	číslo šesť
 03968293-n	slk:lemma	zástrčka
 03208556-n	slk:lemma	disk
-00937616-s	slk:lemma	nevyužitý
+00937616-a	slk:lemma	nevyužitý
 04910848-n	slk:lemma	frajerina
 02766390-v	slk:lemma	zažiariť
 09777012-n	slk:lemma	broker
 01523654-v	slk:lemma	odmotávať
-01982957-s	slk:lemma	vážený
+01982957-a	slk:lemma	vážený
 01822248-v	slk:lemma	súcitiť s
 07248320-n	slk:lemma	obal
 06286395-n	slk:lemma	slovo
@@ -20969,7 +20969,7 @@
 09832538-n	slk:lemma	nosič
 03113835-n	slk:lemma	kroj
 01205696-v	slk:lemma	prichádzať do styku
-01167269-s	slk:lemma	ochranný
+01167269-a	slk:lemma	ochranný
 15139130-n	slk:lemma	dočasné uvoľnenie z povinnosti
 00467913-a	slk:lemma	rozdeľovací
 01888295-v	slk:lemma	vkrádať sa
@@ -20985,7 +20985,7 @@
 07027180-n	slk:lemma	harmónia
 08245172-n	slk:lemma	organizovaný zločin
 14984973-n	slk:lemma	náter
-01007258-s	slk:lemma	obmedzený
+01007258-a	slk:lemma	obmedzený
 04884627-n	slk:lemma	slabosť
 00191142-n	slk:lemma	vystriedanie
 05479314-n	slk:lemma	lícny nerv
@@ -21002,7 +21002,7 @@
 01267098-v	slk:lemma	pokryť (cestu, chodník)
 06753800-n	slk:lemma	premisia
 05525252-n	slk:lemma	mužská reprodukčná žľaza
-01392249-s	slk:lemma	maličký
+01392249-a	slk:lemma	maličký
 10171755-n	slk:lemma	kacír
 02230772-v	slk:lemma	podávať
 14483620-n	slk:lemma	dúfanie
@@ -21021,7 +21021,7 @@
 02976870-a	slk:lemma	kvalitatívny
 02549211-v	slk:lemma	podporovať
 09287124-n	slk:lemma	rieka Garonne
-01991586-s	slk:lemma	oddaný
+01991586-a	slk:lemma	oddaný
 02392762-v	slk:lemma	ponechať
 02482820-n	slk:lemma	čeľaď Hylobatidae
 02843276-n	slk:lemma	klietka pre vtáky
@@ -21030,13 +21030,13 @@
 00528667-n	slk:lemma	balet
 01524199-v	slk:lemma	odvinúť
 08736517-n	slk:lemma	Republika Pobrežia Slonoviny
-01154030-s	slk:lemma	jemný ako páperie
+01154030-a	slk:lemma	jemný ako páperie
 10272913-n	slk:lemma	porazený
 04096733-n	slk:lemma	vozovka
 05984182-n	slk:lemma	vec
 03839795-n	slk:lemma	zábrana
 00210935-r	slk:lemma	bežne
-00813589-s	slk:lemma	praveký
+00813589-a	slk:lemma	praveký
 05702275-n	slk:lemma	zaujatie
 00466651-v	slk:lemma	včleniť
 00083975-n	slk:lemma	apropriácia
@@ -21062,7 +21062,7 @@
 09357580-n	slk:lemma	rieka Monongahela
 00415743-v	slk:lemma	nadísť
 14699752-n	slk:lemma	drahokam
-01792573-s	slk:lemma	holý
+01792573-a	slk:lemma	holý
 07097346-n	slk:lemma	asonancia
 09376198-n	slk:lemma	oceán
 09930772-n	slk:lemma	obchodník s látkami
@@ -21081,10 +21081,10 @@
 13268146-n	slk:lemma	odmena
 01038666-v	slk:lemma	porozprávať
 07136711-n	slk:lemma	prázdne reči
-01901186-s	slk:lemma	oneskorený
+01901186-a	slk:lemma	oneskorený
 02401523-v	slk:lemma	navrhnúť
 00126264-v	slk:lemma	zmeniť
-00937616-s	slk:lemma	nepoužitý
+00937616-a	slk:lemma	nepoužitý
 09135993-n	slk:lemma	Chester
 03684823-n	slk:lemma	lokomotíva
 00802629-n	slk:lemma	risk
@@ -21092,11 +21092,11 @@
 01640855-v	slk:lemma	uskutočniť
 01150559-v	slk:lemma	namieriť
 13837439-n	slk:lemma	profesionálny vzťah
-01535270-s	slk:lemma	radikálny
-01230616-s	slk:lemma	bezmocný
+01535270-a	slk:lemma	radikálny
+01230616-a	slk:lemma	bezmocný
 09028477-n	slk:lemma	Valencia
 13360390-n	slk:lemma	čierny fond
-01388062-s	slk:lemma	kolosálny
+01388062-a	slk:lemma	kolosálny
 04270147-n	slk:lemma	špachtľa
 08820121-n	slk:lemma	Kanada
 02075049-v	slk:lemma	vypariť sa
@@ -21115,12 +21115,12 @@
 00528059-n	slk:lemma	tanec na špičkách
 01346804-v	slk:lemma	otvoriť sa
 01437254-v	slk:lemma	rozosielať
-01144102-s	slk:lemma	náhly
+01144102-a	slk:lemma	náhly
 02281093-v	slk:lemma	naplniť zásobami
-01619475-s	slk:lemma	vyložený
+01619475-a	slk:lemma	vyložený
 13440935-n	slk:lemma	dyadická operácia
 05036237-n	slk:lemma	úsilie
-01951197-s	slk:lemma	neotesaný
+01951197-a	slk:lemma	neotesaný
 01767661-n	slk:lemma	článkonožec
 10355449-n	slk:lemma	mladé ucho
 09343422-n	slk:lemma	prieliv Long Island
@@ -21146,8 +21146,8 @@
 11664929-n	slk:lemma	oddelenie Magnoliophyta
 01138204-v	slk:lemma	dočkať si
 00103834-n	slk:lemma	náraz
-00696996-s	slk:lemma	pokojný
-01742715-s	slk:lemma	militantný
+00696996-a	slk:lemma	pokojný
+01742715-a	slk:lemma	militantný
 00214951-v	slk:lemma	mokriť
 09883174-n	slk:lemma	pouličný spevák
 06598915-n	slk:lemma	predmet
@@ -21175,23 +21175,23 @@
 03539754-n	slk:lemma	bič na kone
 01072949-v	slk:lemma	zahrať si
 08674739-n	slk:lemma	zem
-01199083-s	slk:lemma	rôznorodý
+01199083-a	slk:lemma	rôznorodý
 00073177-n	slk:lemma	chyba zaokrúhlenia
-00798491-s	slk:lemma	spitý
-00491320-s	slk:lemma	čudný
+00798491-a	slk:lemma	spitý
+00491320-a	slk:lemma	čudný
 07360647-n	slk:lemma	infikovanie
 01802309-n	slk:lemma	bažantovité
 01826723-v	slk:lemma	dúfať
 02499629-v	slk:lemma	trestať
 08565506-n	slk:lemma	raj
-00865007-s	slk:lemma	nezamestnaný
+00865007-a	slk:lemma	nezamestnaný
 05035353-n	slk:lemma	pevnosť
 01595596-a	slk:lemma	neobvyklý
 14972359-n	slk:lemma	kyslíkatá kyselina
 10665698-n	slk:lemma	žiačka
 01911053-a	slk:lemma	odborný
 04844024-n	slk:lemma	necitlivosť
-00122844-s	slk:lemma	výsledný
+00122844-a	slk:lemma	výsledný
 04797295-n	slk:lemma	nezvyčajnosť, neobyčajnosť
 02018372-v	slk:lemma	stihnúť
 13317002-n	slk:lemma	colný poplatok
@@ -21228,11 +21228,11 @@
 14781631-n	slk:lemma	odroda chalcedónu
 03119396-n	slk:lemma	dvojsedadlové auto
 00376063-n	slk:lemma	zmena
-00412171-s	slk:lemma	pokročilý
+00412171-a	slk:lemma	pokročilý
 02387034-v	slk:lemma	školiť
 14446161-n	slk:lemma	potešenie
 00581401-a	slk:lemma	nenápadný
-00507292-s	slk:lemma	tvrdý
+00507292-a	slk:lemma	tvrdý
 02272090-v	slk:lemma	špekulovať
 09955015-n	slk:lemma	klamár
 14110674-n	slk:lemma	srdcová arytmia
@@ -21243,11 +21243,11 @@
 10583387-n	slk:lemma	usadlík
 11986511-n	slk:lemma	Lactuca sativa
 09972157-n	slk:lemma	návrhár
-00505410-s	slk:lemma	neporovnateľný
+00505410-a	slk:lemma	neporovnateľný
 00528990-v	slk:lemma	prudko vytekať
 02604477-v	slk:lemma	koexistovať
 09184834-n	slk:lemma	mentálna energia
-00852197-s	slk:lemma	hodný
+00852197-a	slk:lemma	hodný
 05760202-n	slk:lemma	spomínanie
 06263762-n	slk:lemma	nosič informácií
 09945319-n	slk:lemma	komunista
@@ -21265,13 +21265,13 @@
 06795168-n	slk:lemma	somárske uši
 00622384-v	slk:lemma	zaraziť
 01601234-v	slk:lemma	nosiť
-01392249-s	slk:lemma	miniatúrny
+01392249-a	slk:lemma	miniatúrny
 04975122-n	slk:lemma	odtieň
 00475647-v	slk:lemma	očistiť
 02590340-v	slk:lemma	kolonizovať
-02550333-s	slk:lemma	upršaný
+02550333-a	slk:lemma	upršaný
 05559908-n	slk:lemma	úd
-02500179-s	slk:lemma	mylný
+02500179-a	slk:lemma	mylný
 00843468-v	slk:lemma	dávať vinu
 02407338-v	slk:lemma	boriť sa s
 02386388-v	slk:lemma	delegovať
@@ -21279,7 +21279,7 @@
 13397932-n	slk:lemma	dlhový strop
 01523520-v	slk:lemma	odviť
 05807147-n	slk:lemma	poučenie z minulosti
-01044557-s	slk:lemma	dennodenný
+01044557-a	slk:lemma	dennodenný
 00980453-v	slk:lemma	vyjadriť
 05733583-n	slk:lemma	výmer
 10069869-n	slk:lemma	štátny zamestnanec
@@ -21293,7 +21293,7 @@
 06333653-n	slk:lemma	názov
 01463963-v	slk:lemma	aranžovať
 07083732-n	slk:lemma	inflexia
-01628531-s	slk:lemma	hrubý
+01628531-a	slk:lemma	hrubý
 15195059-n	slk:lemma	1. november
 02387486-v	slk:lemma	vychovať si
 00773432-v	slk:lemma	namietať
@@ -21303,7 +21303,7 @@
 02703911-a	slk:lemma	bezšnúrový
 09356080-n	slk:lemma	Mississippi
 00439826-n	slk:lemma	ľahká atletika
-02329864-s	slk:lemma	poddaný
+02329864-a	slk:lemma	poddaný
 02907656-a	slk:lemma	atletický
 14613643-n	slk:lemma	kyselina kyanovodíková
 02946921-n	slk:lemma	plechovka
@@ -21317,12 +21317,12 @@
 10564400-n	slk:lemma	autor scenára
 14509712-n	slk:lemma	otrava
 02165304-v	slk:lemma	nazrieť
-00930765-s	slk:lemma	nečakaný
-02515001-s	slk:lemma	ošklivý
+00930765-a	slk:lemma	nečakaný
+02515001-a	slk:lemma	ošklivý
 00020259-v	slk:lemma	zostávať hore
 00622384-v	slk:lemma	trápiť
 02637938-v	slk:lemma	čakať
-02112108-s	slk:lemma	spoločný
+02112108-a	slk:lemma	spoločný
 08249960-n	slk:lemma	tanečná kapela
 06354774-n	slk:lemma	univerzálny kód výrobku
 00103194-r	slk:lemma	zo začiatku
@@ -21397,7 +21397,7 @@
 01146576-n	slk:lemma	uväznenie
 11552386-n	slk:lemma	Embryophyta siphogama
 14406303-n	slk:lemma	záchvat
-02418412-s	slk:lemma	zdanlivý
+02418412-a	slk:lemma	zdanlivý
 10741590-n	slk:lemma	používateľ
 00450998-n	slk:lemma	exhibičné skoky na koni
 01177327-n	slk:lemma	odpor
@@ -21406,15 +21406,15 @@
 05204982-n	slk:lemma	slabosť
 08512736-n	slk:lemma	colná hranica
 00633864-n	slk:lemma	bádanie
-00510644-s	slk:lemma	spôsobilý
-00669853-s	slk:lemma	zlorečený
+00510644-a	slk:lemma	spôsobilý
+00669853-a	slk:lemma	zlorečený
 01182709-v	slk:lemma	poskytnúť
 02469835-v	slk:lemma	spojiť
 02650552-v	slk:lemma	bývať (niekde)
 05600637-n	slk:lemma	tvár
 05706629-n	slk:lemma	zanedbanie
 00086809-n	slk:lemma	okupovanie
-02250430-s	slk:lemma	sám
+02250430-a	slk:lemma	sám
 03124590-n	slk:lemma	ohrada pre dobytok
 00212414-v	slk:lemma	uchovávať si
 06634239-n	slk:lemma	ospravedlnenie sa
@@ -21427,7 +21427,7 @@
 00153961-n	slk:lemma	otestovanie
 03672521-n	slk:lemma	plátno
 02731123-n	slk:lemma	odbavovacia plocha
-00486990-s	slk:lemma	bežný
+00486990-a	slk:lemma	bežný
 01024392-n	slk:lemma	lekárska metóda
 02549392-v	slk:lemma	preukazovať pozornosť
 14791988-n	slk:lemma	kyselina kapronová
@@ -21437,7 +21437,7 @@
 00258857-v	slk:lemma	poškodzovať
 00029343-a	slk:lemma	hrabivý
 08439022-n	slk:lemma	prales
-02562705-s	slk:lemma	úzky
+02562705-a	slk:lemma	úzky
 01719921-v	slk:lemma	interpretovať
 00740577-v	slk:lemma	komunikovať
 03862676-n	slk:lemma	rúra
@@ -21482,7 +21482,7 @@
 01982866-v	slk:lemma	stavať
 07928367-n	slk:lemma	zázvorové pivo
 03541696-n	slk:lemma	hostel
-01059711-s	slk:lemma	pevný
+01059711-a	slk:lemma	pevný
 02028366-v	slk:lemma	rinúť sa
 02613275-v	slk:lemma	vykonať bohoslužbu
 15067025-n	slk:lemma	tanín
@@ -21501,7 +21501,7 @@
 09283193-n	slk:lemma	nositeľ
 00044861-r	slk:lemma	tvárou v tvár
 01812720-v	slk:lemma	oduševniť
-01017439-s	slk:lemma	telesne zdatný
+01017439-a	slk:lemma	telesne zdatný
 04256520-n	slk:lemma	pohovka
 08794366-n	slk:lemma	Gaza
 02238770-v	slk:lemma	zháňať
@@ -21525,7 +21525,7 @@
 02540670-v	slk:lemma	posluhovať niekomu
 00925735-v	slk:lemma	diviť sa
 10727256-n	slk:lemma	osoba zodpovedná za finančné transakcie
-02574481-s	slk:lemma	lesnatý
+02574481-a	slk:lemma	lesnatý
 00145218-n	slk:lemma	spojenie
 02955065-n	slk:lemma	klobúčik
 02298160-v	slk:lemma	obchodovať
@@ -21556,7 +21556,7 @@
 00310666-n	slk:lemma	okruh
 00820721-a	slk:lemma	neskorý
 09375085-n	slk:lemma	jadro
-01618376-s	slk:lemma	jasný
+01618376-a	slk:lemma	jasný
 00102463-r	slk:lemma	dokonale
 06634376-n	slk:lemma	správa
 06437824-n	slk:lemma	Pieseň piesní
@@ -21571,7 +21571,7 @@
 00916464-n	slk:lemma	hospodárstvo
 07092592-n	slk:lemma	poézia
 08398773-n	slk:lemma	zmes
-00876204-s	slk:lemma	apatický
+00876204-a	slk:lemma	apatický
 05512835-n	slk:lemma	ureter
 07373803-n	slk:lemma	zlučovanie
 04021503-n	slk:lemma	generátor impulzov
@@ -21588,11 +21588,11 @@
 02549211-v	slk:lemma	napomáhať
 00048268-r	slk:lemma	aktuálne
 13767239-n	slk:lemma	pohár
-00830051-s	slk:lemma	vzdelaný
+00830051-a	slk:lemma	vzdelaný
 04978216-n	slk:lemma	nahnedlosť
 09749011-n	slk:lemma	obyvateľ Gibraltaru
 05033906-n	slk:lemma	imúnnosť
-00071242-s	slk:lemma	uchvátený
+00071242-a	slk:lemma	uchvátený
 02213690-v	slk:lemma	odmietnuť
 03096960-n	slk:lemma	ovládanie
 03610270-n	slk:lemma	pamiatka
@@ -21603,7 +21603,7 @@
 04891333-n	slk:lemma	nerozumnosť
 01235258-n	slk:lemma	revanš
 08763387-n	slk:lemma	Roseau
-01276150-s	slk:lemma	najpodstatnejší
+01276150-a	slk:lemma	najpodstatnejší
 00155621-r	slk:lemma	väčšinou
 05510907-n	slk:lemma	cesty
 06267145-n	slk:lemma	časopis
@@ -21636,25 +21636,25 @@
 09252273-n	slk:lemma	rieka Connecticut
 00097504-n	slk:lemma	uskutočnenie
 00831074-v	slk:lemma	poúčať
-00421875-s	slk:lemma	hnusný
-01935935-s	slk:lemma	vyfabrikovaný
+00421875-a	slk:lemma	hnusný
+01935935-a	slk:lemma	vyfabrikovaný
 06691083-n	slk:lemma	povolenie
 09542339-n	slk:lemma	diabol
 05817396-n	slk:lemma	pravda
-00661640-s	slk:lemma	nakrájaný
+00661640-a	slk:lemma	nakrájaný
 00343249-n	slk:lemma	točenie
 03434285-n	slk:lemma	generátor
 01125429-a	slk:lemma	nedobrý
-00403072-s	slk:lemma	menlivý
+00403072-a	slk:lemma	menlivý
 00948103-a	slk:lemma	vonkajší
 08223263-n	slk:lemma	stúpenci
 03900979-n	slk:lemma	pavilón
-01484651-s	slk:lemma	dievčenský
-00833018-s	slk:lemma	pracovný
+01484651-a	slk:lemma	dievčenský
+00833018-a	slk:lemma	pracovný
 00213223-v	slk:lemma	nakladať
 06753299-n	slk:lemma	postulát
 05551617-n	slk:lemma	mužská hruď
-02074929-s	slk:lemma	strelený
+02074929-a	slk:lemma	strelený
 00059171-r	slk:lemma	mnoho
 07152463-n	slk:lemma	fráza
 02477755-v	slk:lemma	rušiť
@@ -21676,18 +21676,18 @@
 02176268-v	slk:lemma	znieť
 02294436-v	slk:lemma	rozdeliť
 05637558-n	slk:lemma	znalosť
-01115635-s	slk:lemma	vierohodný
+01115635-a	slk:lemma	vierohodný
 00179112-r	slk:lemma	výhradne
 02642814-v	slk:lemma	presunúť
 02222318-v	slk:lemma	odhadzovať
 03596787-n	slk:lemma	šperk
 05159854-n	slk:lemma	všeobecné blaho
-00709446-s	slk:lemma	krehký
+00709446-a	slk:lemma	krehký
 00258282-r	slk:lemma	vnútri v listine
 00345761-v	slk:lemma	započať sa
 01397210-v	slk:lemma	mlátiť
 10071332-n	slk:lemma	emigrant
-00150505-s	slk:lemma	výstižný
+00150505-a	slk:lemma	výstižný
 04083309-n	slk:lemma	kabelka typu reticule
 03512147-n	slk:lemma	vrtuľník
 00980453-v	slk:lemma	formulovať
@@ -21697,8 +21697,8 @@
 00730052-v	slk:lemma	mať na mysli
 01787955-v	slk:lemma	rozčuľovať
 15298852-n	slk:lemma	skutočný čas
-02440617-s	slk:lemma	horný
-02051616-s	slk:lemma	vidiecky
+02440617-a	slk:lemma	horný
+02051616-a	slk:lemma	vidiecky
 02755352-n	slk:lemma	zväzok
 09483738-n	slk:lemma	fiktívna postava
 02421199-v	slk:lemma	drieť sa
@@ -21710,17 +21710,17 @@
 04257790-n	slk:lemma	slnečný kolektor
 08578174-n	slk:lemma	prašná krajina
 00947128-n	slk:lemma	použitie
-02126430-s	slk:lemma	položený
+02126430-a	slk:lemma	položený
 00996969-n	slk:lemma	vymeriavanie
 02121511-v	slk:lemma	mať bolesti
 05843042-n	slk:lemma	normanská architektúra
 00799076-v	slk:lemma	odvolávať
-01044730-s	slk:lemma	neformálny
+01044730-a	slk:lemma	neformálny
 13954253-n	slk:lemma	existencia
-00477284-s	slk:lemma	pohodlný
+00477284-a	slk:lemma	pohodlný
 02843717-a	slk:lemma	srdcový
 06376154-n	slk:lemma	dráma
-02275412-s	slk:lemma	silný
+02275412-a	slk:lemma	silný
 00641252-v	slk:lemma	odpočítavať
 00636061-v	slk:lemma	hádať
 13982357-n	slk:lemma	nesúhlas
@@ -21741,7 +21741,7 @@
 00250259-n	slk:lemma	vývoj
 15076180-n	slk:lemma	nástrojová oceľ
 01204191-v	slk:lemma	platiť výživné
-01525320-s	slk:lemma	nehybný
+01525320-a	slk:lemma	nehybný
 11463746-n	slk:lemma	šťastie
 09820263-n	slk:lemma	športovec
 00061528-r	slk:lemma	neočakávane
@@ -21761,14 +21761,14 @@
 02051694-v	slk:lemma	prejsť okolo
 09483340-n	slk:lemma	Pearl
 02764614-n	slk:lemma	os otáčania
-01040752-s	slk:lemma	nezabudnuteľný
+01040752-a	slk:lemma	nezabudnuteľný
 13945919-n	slk:lemma	pozícia
 02713769-n	slk:lemma	krúžok
 07538674-n	slk:lemma	nátlak
 00796976-v	slk:lemma	opovrhnúť
 12581230-n	slk:lemma	Palmales
-00615191-s	slk:lemma	dôveryhodný
-01742715-s	slk:lemma	útočný
+00615191-a	slk:lemma	dôveryhodný
+01742715-a	slk:lemma	útočný
 09874618-n	slk:lemma	nevesta
 05154517-n	slk:lemma	prínos
 03402080-n	slk:lemma	otočný bod
@@ -21788,7 +21788,7 @@
 01985923-v	slk:lemma	klesať
 10179291-n	slk:lemma	hokejista
 08648917-n	slk:lemma	pozoruhodnosť
-02177584-s	slk:lemma	komplikovaný
+02177584-a	slk:lemma	komplikovaný
 13998014-n	slk:lemma	nútená práca
 03400231-n	slk:lemma	rajnica
 02963987-n	slk:lemma	herňa
@@ -21803,13 +21803,13 @@
 00250259-n	slk:lemma	rozvoj
 02560164-v	slk:lemma	presadiť
 07654667-n	slk:lemma	kus
-00826215-s	slk:lemma	juhozápad
+00826215-a	slk:lemma	juhozápad
 00966152-v	slk:lemma	ohlásiť príchod
 00755447-v	slk:lemma	vzývať
 14802262-n	slk:lemma	tvárne železo
 00088154-n	slk:lemma	štátna investícia do sociálneho programu
-00341655-s	slk:lemma	nepredvídateľný
-00182225-s	slk:lemma	samočinný
+00341655-a	slk:lemma	nepredvídateľný
+00182225-a	slk:lemma	samočinný
 10490699-n	slk:lemma	novinár
 00635850-n	slk:lemma	výskum
 06637350-n	slk:lemma	inicializácia
@@ -21841,7 +21841,7 @@
 02563327-v	slk:lemma	realizovať
 01522376-a	slk:lemma	pohyblivý
 03537866-n	slk:lemma	hrôza
-01645678-s	slk:lemma	šedivý
+01645678-a	slk:lemma	šedivý
 04014297-n	slk:lemma	ochranný kryt
 05196375-n	slk:lemma	ovládanie
 10165448-n	slk:lemma	poslucháč
@@ -21852,7 +21852,7 @@
 02384686-v	slk:lemma	pozývať
 14585519-n	slk:lemma	kúsok
 00830761-v	slk:lemma	prednášať
-01592262-s	slk:lemma	kráľovský
+01592262-a	slk:lemma	kráľovský
 08619795-n	slk:lemma	námestie
 00139508-r	slk:lemma	primerane
 01028748-v	slk:lemma	nazvať
@@ -21862,7 +21862,7 @@
 00361795-n	slk:lemma	opotrebovanie
 01113806-v	slk:lemma	prehrať
 00851100-v	slk:lemma	vystreliť si (z niekoho)
-00934966-s	slk:lemma	úsporný
+00934966-a	slk:lemma	úsporný
 02290461-v	slk:lemma	získavať
 01504130-v	slk:lemma	rozmiestňovať
 09906538-n	slk:lemma	hrdina
@@ -21881,7 +21881,7 @@
 02920503-n	slk:lemma	úkryt
 02484570-v	slk:lemma	odstreliť
 10027476-n	slk:lemma	dvojitý agent
-01019713-s	slk:lemma	slabý
+01019713-a	slk:lemma	slabý
 02460199-v	slk:lemma	prenajať
 02759614-v	slk:lemma	zapáliť
 01107206-a	slk:lemma	federálny
@@ -21895,18 +21895,18 @@
 00920062-n	slk:lemma	dobytkárčenie
 06611147-n	slk:lemma	hlúposti
 06359877-n	slk:lemma	písmo
-00990855-s	slk:lemma	drobný
+00990855-a	slk:lemma	drobný
 01467986-n	slk:lemma	plášťovce
 04531098-n	slk:lemma	nádoba
-02456157-s	slk:lemma	znepokojený
+02456157-a	slk:lemma	znepokojený
 10787470-n	slk:lemma	žena
 00140751-v	slk:lemma	prepínať
 02497062-v	slk:lemma	oslobodiť
 01705494-v	slk:lemma	písať
 00513401-n	slk:lemma	šaškovanie
 01233993-v	slk:lemma	zastrešiť
-01632066-s	slk:lemma	defenzívny
-01952643-s	slk:lemma	prírodný
+01632066-a	slk:lemma	defenzívny
+01952643-a	slk:lemma	prírodný
 06043075-n	slk:lemma	medicína
 02540347-v	slk:lemma	vyrastať
 01578254-v	slk:lemma	potápať
@@ -21919,7 +21919,7 @@
 06793817-n	slk:lemma	reklamný plagát
 05732756-n	slk:lemma	klasifikácia
 01280488-v	slk:lemma	zohnúť
-01971846-s	slk:lemma	blízky
+01971846-a	slk:lemma	blízky
 01428580-n	slk:lemma	mäkkoplutvá ryba
 02395694-n	slk:lemma	prasa
 14364432-n	slk:lemma	stvrdnutie kože
@@ -21931,7 +21931,7 @@
 00022099-v	slk:lemma	privádzať k sebe
 01651444-v	slk:lemma	spískať
 02154508-v	slk:lemma	zistiť
-00861216-s	slk:lemma	hypotetický
+00861216-a	slk:lemma	hypotetický
 06264398-n	slk:lemma	pošta
 02875930-a	slk:lemma	kožný
 08583095-n	slk:lemma	zemská pologuľa
@@ -21940,10 +21940,10 @@
 09469152-n	slk:lemma	premenná hviezda
 05846355-n	slk:lemma	vymedzenie
 05174653-n	slk:lemma	nárok
-00935359-s	slk:lemma	za pár grošov
+00935359-a	slk:lemma	za pár grošov
 07219923-n	slk:lemma	správa o postupe
 00132060-r	slk:lemma	osobne
-01804422-s	slk:lemma	odpudivý
+01804422-a	slk:lemma	odpudivý
 00262881-v	slk:lemma	oslabiť
 00208210-v	slk:lemma	kaziť
 02076676-v	slk:lemma	vyprázdniť
@@ -21952,7 +21952,7 @@
 00318706-v	slk:lemma	predlžovať
 00161243-n	slk:lemma	voľba
 03025070-n	slk:lemma	diera
-01395028-s	slk:lemma	maličký
+01395028-a	slk:lemma	maličký
 04255034-n	slk:lemma	zásuvka
 00315986-n	slk:lemma	transport
 06732350-n	slk:lemma	priznanie
@@ -21979,7 +21979,7 @@
 03135656-n	slk:lemma	priečka
 06479665-n	slk:lemma	právny dokument
 00928630-v	slk:lemma	oznámiť
-00152629-s	slk:lemma	neschopný slova
+00152629-a	slk:lemma	neschopný slova
 15164463-n	slk:lemma	piatok
 02783085-a	slk:lemma	pragmatický
 08547938-n	slk:lemma	križovanie (sa)
@@ -21991,36 +21991,36 @@
 03100315-a	slk:lemma	rybársky
 02945161-n	slk:lemma	kemp
 00863823-a	slk:lemma	pracujúci na voľnej nohe
-00448314-s	slk:lemma	hroziaci
+00448314-a	slk:lemma	hroziaci
 01088923-v	slk:lemma	zaradiť
 02026086-v	slk:lemma	odprevadiť
 00952963-n	slk:lemma	vojenská akcia
 08072287-n	slk:lemma	realitný investičný fond
-00082766-s	slk:lemma	bojovný
+00082766-a	slk:lemma	bojovný
 03379204-n	slk:lemma	futbalový štadión
 06502192-n	slk:lemma	pozemková kniha
 05638063-n	slk:lemma	schopnosť
 00962129-n	slk:lemma	revolta
-01114973-s	slk:lemma	ochotný
+01114973-a	slk:lemma	ochotný
 00609506-v	slk:lemma	mať na pamäti
-00989647-s	slk:lemma	štíhly a dlhý
+00989647-a	slk:lemma	štíhly a dlhý
 07181546-n	slk:lemma	disonancia
 02641571-a	slk:lemma	arzénový
-00561896-s	slk:lemma	identický
+00561896-a	slk:lemma	identický
 06424869-n	slk:lemma	kľúč
 04690196-n	slk:lemma	ošklivosť
 10529965-n	slk:lemma	jazdec
-01710946-s	slk:lemma	nehonorovaný
+01710946-a	slk:lemma	nehonorovaný
 07306032-n	slk:lemma	kalvária
 02521284-v	slk:lemma	obviňovať
 00746587-n	slk:lemma	zneuctenie
 02402425-n	slk:lemma	voly
-00590163-s	slk:lemma	najedovaný
+00590163-a	slk:lemma	najedovaný
 13724474-n	slk:lemma	hektogram
 00251408-r	slk:lemma	poobede
 06423619-n	slk:lemma	adresár
 01278427-v	slk:lemma	pokrčiť
-00082034-s	slk:lemma	neústupný
+00082034-a	slk:lemma	neústupný
 01523105-v	slk:lemma	navinúť sa
 03717131-n	slk:lemma	koryto
 05495172-n	slk:lemma	miecha
@@ -22029,7 +22029,7 @@
 02620213-v	slk:lemma	padať
 02935658-n	slk:lemma	kaviareň
 09749260-n	slk:lemma	Grenadčan
-01676026-s	slk:lemma	krajný
+01676026-a	slk:lemma	krajný
 08473623-n	slk:lemma	reformné hnutie
 09782397-n	slk:lemma	poslanec komunálneho zastupiteľstva
 00437449-v	slk:lemma	špecializovať sa na
@@ -22052,7 +22052,7 @@
 00807078-n	slk:lemma	načasovanie
 09040998-n	slk:lemma	Antakiya
 15195928-n	slk:lemma	pesach
-01285136-s	slk:lemma	majestátny
+01285136-a	slk:lemma	majestátny
 10020890-n	slk:lemma	doktor
 00164444-v	slk:lemma	posilniť
 08063650-n	slk:lemma	predajca automobilov
@@ -22070,7 +22070,7 @@
 13007417-n	slk:lemma	hliva ustricová
 02167435-v	slk:lemma	dozerať na
 01124794-n	slk:lemma	ovládanie
-00072281-s	slk:lemma	odolný
+00072281-a	slk:lemma	odolný
 09956387-n	slk:lemma	znalec
 08600274-n	slk:lemma	minimum
 03079230-n	slk:lemma	kompaktný disk
@@ -22078,8 +22078,8 @@
 05872742-n	slk:lemma	abeceda
 01164394-n	slk:lemma	kameňovanie
 04477091-n	slk:lemma	dezén pneumatiky
-01941814-s	slk:lemma	skutočný
-01874331-s	slk:lemma	podradný
+01941814-a	slk:lemma	skutočný
+01874331-a	slk:lemma	podradný
 09936215-n	slk:lemma	kolegyňa
 04618781-n	slk:lemma	osobnosť
 03872495-n	slk:lemma	čistiaci tampón
@@ -22111,7 +22111,7 @@
 05119223-n	slk:lemma	luxus
 09639919-n	slk:lemma	Semita
 05267345-n	slk:lemma	tkanivo
-01855086-s	slk:lemma	rezervný
+01855086-a	slk:lemma	rezervný
 00894552-n	slk:lemma	tréning
 01984902-v	slk:lemma	sadnúť si
 05712076-n	slk:lemma	zmyslový vnem
@@ -22142,16 +22142,16 @@
 06284225-n	slk:lemma	lingvistická jednotka
 00916909-v	slk:lemma	odhadnúť
 07306252-n	slk:lemma	aféra
-02502994-s	slk:lemma	malicherný
+02502994-a	slk:lemma	malicherný
 06789411-n	slk:lemma	náboženská doktrína
 01468238-n	slk:lemma	plášťovce
 10409752-n	slk:lemma	platiteľ
 04634161-n	slk:lemma	energia
 08233056-n	slk:lemma	odborový zväz
-01674134-s	slk:lemma	definitívny
+01674134-a	slk:lemma	definitívny
 00022099-v	slk:lemma	preberať (z bezvedomia)
 09155306-n	slk:lemma	Západná Virgínia
-02406370-s	slk:lemma	podráždený
+02406370-a	slk:lemma	podráždený
 03504723-n	slk:lemma	ústredný úrad
 12299988-n	slk:lemma	čeľaď Oleaceae
 01266895-v	slk:lemma	galvanizovať
@@ -22161,7 +22161,7 @@
 13903387-n	slk:lemma	lem
 02685082-n	slk:lemma	ozdoba hlavy
 00744443-n	slk:lemma	poškodenie
-01728614-s	slk:lemma	staroveký
+01728614-a	slk:lemma	staroveký
 00283127-n	slk:lemma	chod
 09731571-n	slk:lemma	juhoameričan
 00916909-v	slk:lemma	hádať
@@ -22185,7 +22185,7 @@
 10163723-n	slk:lemma	hviezda programu
 00917772-v	slk:lemma	predpokladať
 08396760-n	slk:lemma	CCRC
-01267632-s	slk:lemma	komický fór
+01267632-a	slk:lemma	komický fór
 02904075-a	slk:lemma	organizačný
 10164997-n	slk:lemma	kat
 00151689-v	slk:lemma	strácať sa
@@ -22193,7 +22193,7 @@
 01873784-v	slk:lemma	presadiť
 09917593-n	slk:lemma	mláďa
 00856824-v	slk:lemma	pochvaľovať
-00178811-s	slk:lemma	poverený
+00178811-a	slk:lemma	poverený
 14439745-n	slk:lemma	hanba
 05545047-n	slk:lemma	šípový šev
 08737041-n	slk:lemma	Guatemalská republika
@@ -22202,10 +22202,10 @@
 04878861-n	slk:lemma	nevera
 00445351-n	slk:lemma	veslovanie
 03307037-n	slk:lemma	predlžovačka
-01918771-s	slk:lemma	matematický
+01918771-a	slk:lemma	matematický
 02760099-n	slk:lemma	automat na kávu
-02499301-s	slk:lemma	odôvodnený
-01999085-s	slk:lemma	nezodpovedajúci sa (nikomu)
+02499301-a	slk:lemma	odôvodnený
+01999085-a	slk:lemma	nezodpovedajúci sa (nikomu)
 00066025-v	slk:lemma	mravčať
 00066781-r	slk:lemma	vpredu
 01738347-v	slk:lemma	prehrať
@@ -22218,7 +22218,7 @@
 00635012-n	slk:lemma	policajná práca
 01252730-v	slk:lemma	zamazávať bahnom
 10523519-n	slk:lemma	obyvateľ
-01796977-s	slk:lemma	červovitý
+01796977-a	slk:lemma	červovitý
 01531998-v	slk:lemma	zašpiniť
 04158457-n	slk:lemma	plávajúca kotva
 03871371-n	slk:lemma	obchod s liehovinami
@@ -22243,15 +22243,15 @@
 05235607-n	slk:lemma	symphysion
 07884567-n	slk:lemma	alkoholický nápoj
 07140978-n	slk:lemma	argumentácia
-00521811-s	slk:lemma	kompletný
+00521811-a	slk:lemma	kompletný
 01614343-n	slk:lemma	Aquila chrysaetos
 00262881-v	slk:lemma	poškodiť
 07523905-n	slk:lemma	starosť
 01133825-v	slk:lemma	vymršťovať
-00651039-s	slk:lemma	nebezpečný
+00651039-a	slk:lemma	nebezpečný
 01752884-v	slk:lemma	vytvoriť
 00274941-n	slk:lemma	farbenie
-01987646-s	slk:lemma	chladný
+01987646-a	slk:lemma	chladný
 00215314-n	slk:lemma	rozlúčenie
 01501960-v	slk:lemma	stavať vedľa seba
 10468962-n	slk:lemma	prezident
@@ -22262,7 +22262,7 @@
 15122231-n	slk:lemma	čas
 00081486-r	slk:lemma	na dennom poriadku
 02153387-v	slk:lemma	prehliadnuť
-01950711-s	slk:lemma	hrubý
+01950711-a	slk:lemma	hrubý
 02296153-v	slk:lemma	preniesť
 01790020-v	slk:lemma	rozrušovať
 00517728-n	slk:lemma	slávnosť
@@ -22270,15 +22270,15 @@
 04714156-n	slk:lemma	zhodnosť
 03224893-n	slk:lemma	internát
 00043765-a	slk:lemma	reálny
-00712877-s	slk:lemma	neodkladný
+00712877-a	slk:lemma	neodkladný
 09812338-n	slk:lemma	umelec
 01625747-n	slk:lemma	trieda obojživelníky
-00533452-s	slk:lemma	zrozumiteľný
+00533452-a	slk:lemma	zrozumiteľný
 00262249-n	slk:lemma	ozdobovanie
-00710097-s	slk:lemma	netrieštivý
+00710097-a	slk:lemma	netrieštivý
 00431005-n	slk:lemma	vtip
 05996646-n	slk:lemma	odbor štúdia
-01711465-s	slk:lemma	bolestivý
+01711465-a	slk:lemma	bolestivý
 01762283-v	slk:lemma	vzrušovať
 08892766-n	slk:lemma	Lothská oblasť
 00673766-v	slk:lemma	podceňovať
@@ -22287,7 +22287,7 @@
 01998432-v	slk:lemma	držať sa (koho/čoho)
 02459173-v	slk:lemma	ubytovávať
 00742320-v	slk:lemma	postupovať (informáciu)
-01920697-s	slk:lemma	bzučiaci
+01920697-a	slk:lemma	bzučiaci
 01022178-n	slk:lemma	pozostatok
 01126360-v	slk:lemma	napadnúť
 03601840-n	slk:lemma	stropný nosník
@@ -22308,7 +22308,7 @@
 03106110-n	slk:lemma	šnúrka
 06803636-n	slk:lemma	núdzový signál
 08555102-n	slk:lemma	predmestie
-02369179-s	slk:lemma	kyslý
+02369179-a	slk:lemma	kyslý
 01775535-v	slk:lemma	milovať
 00844298-v	slk:lemma	posťažovať si
 05396366-n	slk:lemma	lymfatická sústava
@@ -22320,7 +22320,7 @@
 04710390-n	slk:lemma	tvrdosť
 05779371-n	slk:lemma	teoretizácia
 10602985-n	slk:lemma	sestra
-02074929-s	slk:lemma	švihnutý
+02074929-a	slk:lemma	švihnutý
 08616311-n	slk:lemma	cesta
 02822746-a	slk:lemma	hypochondrický
 00270186-n	slk:lemma	prestavba
@@ -22330,7 +22330,7 @@
 02374914-a	slk:lemma	súcitiaci
 02967407-n	slk:lemma	prachar
 04685396-n	slk:lemma	krása
-01679744-s	slk:lemma	integrovaný
+01679744-a	slk:lemma	integrovaný
 14698884-n	slk:lemma	štrk
 05849789-n	slk:lemma	charakteristická vlastnosť
 05933054-n	slk:lemma	zrak
@@ -22350,8 +22350,8 @@
 02395406-n	slk:lemma	sviňa domáca
 10402086-n	slk:lemma	prívrženec niečoho
 00974173-v	slk:lemma	hlásať
-02587556-s	slk:lemma	drahocenný
-00312234-s	slk:lemma	zbežný
+02587556-a	slk:lemma	drahocenný
+00312234-a	slk:lemma	zbežný
 02439281-v	slk:lemma	chystať sa (na niečo)
 13489037-n	slk:lemma	rast
 00384620-v	slk:lemma	opravovať
@@ -22360,7 +22360,7 @@
 01240210-n	slk:lemma	intervencia
 02823848-n	slk:lemma	pivnica
 09141526-n	slk:lemma	TX
-00090219-s	slk:lemma	hrubý
+00090219-a	slk:lemma	hrubý
 00104868-v	slk:lemma	vyprázdňovať
 06663018-n	slk:lemma	obchodná politika
 07270179-n	slk:lemma	značka
@@ -22378,14 +22378,14 @@
 03231912-n	slk:lemma	výtokové potrubie
 02381089-a	slk:lemma	syndetický
 05018103-n	slk:lemma	svetlosť
-01888765-s	slk:lemma	ochranný
+01888765-a	slk:lemma	ochranný
 00611256-v	slk:lemma	pamätať si
 14685881-n	slk:lemma	naftové palivo
 02564146-v	slk:lemma	zbavovať (niečoho)
 04760771-n	slk:lemma	hmotná existencia
 08198398-n	slk:lemma	vojenský oddiel
 12900148-n	slk:lemma	rod Capsicum
-01765132-s	slk:lemma	preventívny
+01765132-a	slk:lemma	preventívny
 00042311-n	slk:lemma	zapríčinenie
 04361641-n	slk:lemma	tlmivka
 09008454-n	slk:lemma	Sankt Peterburg
@@ -22411,10 +22411,10 @@
 00030358-n	slk:lemma	počin
 00431826-v	slk:lemma	ubúdať
 04151940-n	slk:lemma	ochrana
-02024928-s	slk:lemma	vznešený
+02024928-a	slk:lemma	vznešený
 10453265-n	slk:lemma	úbožiak
 10476086-n	slk:lemma	zajatec
-02340458-s	slk:lemma	skromný
+02340458-a	slk:lemma	skromný
 14492373-n	slk:lemma	luxus
 06410776-n	slk:lemma	recenzia
 03560567-n	slk:lemma	zapaľovanie motora
@@ -22424,7 +22424,7 @@
 00475996-a	slk:lemma	pohodlný
 04306592-n	slk:lemma	stator
 02439501-v	slk:lemma	riadiť
-00440292-s	slk:lemma	sprostý
+00440292-a	slk:lemma	sprostý
 00180756-r	slk:lemma	bokom
 04657876-n	slk:lemma	nepriateľskosť
 05139094-n	slk:lemma	nedostatok
@@ -22441,17 +22441,17 @@
 00496127-r	slk:lemma	úmyselne
 01342224-v	slk:lemma	otvoriť
 00528990-v	slk:lemma	vytrysknúť
-00583842-s	slk:lemma	stály
+00583842-a	slk:lemma	stály
 00365709-n	slk:lemma	roztiahnutie
 03959350-n	slk:lemma	katastrálna mapa
-01631386-s	slk:lemma	porušujúci
+01631386-a	slk:lemma	porušujúci
 05177285-n	slk:lemma	nárok
 00392848-n	slk:lemma	odstránenie
-01592857-s	slk:lemma	nízkeho pôvodu
+01592857-a	slk:lemma	nízkeho pôvodu
 04631700-n	slk:lemma	aktívnosť
 03287178-n	slk:lemma	konečný výrobok
 03592773-n	slk:lemma	bok otvoru
-00032497-s	slk:lemma	akčný
+00032497-a	slk:lemma	akčný
 07993279-n	slk:lemma	živočíšstvo
 00899049-n	slk:lemma	simulácia
 00236982-r	slk:lemma	tragicky
@@ -22460,10 +22460,10 @@
 01636008-v	slk:lemma	predstaviť si
 06421301-n	slk:lemma	vade mecum
 05112215-n	slk:lemma	strata
-00545746-s	slk:lemma	nevšímavý
+00545746-a	slk:lemma	nevšímavý
 00608808-v	slk:lemma	myslieť
 09790278-n	slk:lemma	psychoanalytik
-00387392-s	slk:lemma	strieborný
+00387392-a	slk:lemma	strieborný
 05943300-n	slk:lemma	doktrína
 02062212-v	slk:lemma	šmárať
 00911562-v	slk:lemma	smútiť
@@ -22474,12 +22474,12 @@
 01101734-v	slk:lemma	prevládať
 02512305-v	slk:lemma	diskriminovať
 09882716-n	slk:lemma	podnikateľ
-02379157-s	slk:lemma	paralelný
+02379157-a	slk:lemma	paralelný
 09575548-n	slk:lemma	Atlas
 01306853-v	slk:lemma	pohrabať
 03173929-n	slk:lemma	vozidlo na rozvoz tovaru
 01171183-v	slk:lemma	preplachovať si (hrdlo, ústa, gágor)
-01917594-s	slk:lemma	čudný
+01917594-a	slk:lemma	čudný
 02228698-v	slk:lemma	priraďovať
 02827160-a	slk:lemma	galvanický
 01791625-n	slk:lemma	Gallus gallus
@@ -22505,7 +22505,7 @@
 07303335-n	slk:lemma	oheň
 04633197-n	slk:lemma	vitalita
 03775199-n	slk:lemma	mixér
-02552315-s	slk:lemma	sušený vzduchom
+02552315-a	slk:lemma	sušený vzduchom
 02935658-n	slk:lemma	malá reštaurácia
 00998399-v	slk:lemma	nahrávať
 05036715-n	slk:lemma	tažkost
@@ -22523,8 +22523,8 @@
 12100382-n	slk:lemma	rad Graminales
 06312966-n	slk:lemma	gramatický komponent
 01617192-v	slk:lemma	vytvárať
-00557108-s	slk:lemma	oprávnený
-00066146-s	slk:lemma	smelý
+00557108-a	slk:lemma	oprávnený
+00066146-a	slk:lemma	smelý
 04952120-n	slk:lemma	vysvietenie
 04211356-n	slk:lemma	roleta
 13489037-n	slk:lemma	vývoj
@@ -22556,20 +22556,20 @@
 01955508-v	slk:lemma	zasielať
 07823591-n	slk:lemma	mätová omáčka
 02899808-n	slk:lemma	mostíkový obvod
-00068180-s	slk:lemma	uvážený
+00068180-a	slk:lemma	uvážený
 10477585-n	slk:lemma	podmienečne prepustená osoba
 00795785-a	slk:lemma	hrateľný
 02123298-v	slk:lemma	pichnúť
 04850589-n	slk:lemma	nemorálnosť
 12288598-n	slk:lemma	rod Corylus
 01635432-v	slk:lemma	vidieť predstavu
-00866987-s	slk:lemma	podporný
+00866987-a	slk:lemma	podporný
 10417551-n	slk:lemma	osobný splnomocnenec
 02550698-v	slk:lemma	ošetriť
 07415730-n	slk:lemma	zmena
-00107017-s	slk:lemma	malý
+00107017-a	slk:lemma	malý
 05817396-n	slk:lemma	okolnosť
-00505853-s	slk:lemma	osobitý
+00505853-a	slk:lemma	osobitý
 04413419-n	slk:lemma	terminál
 13979173-n	slk:lemma	rozkol
 01193886-n	slk:lemma	uvoľnenie
@@ -22591,23 +22591,23 @@
 01974062-v	slk:lemma	zdvíhať
 05483677-n	slk:lemma	biela hmota
 09797606-n	slk:lemma	antikvár
-00421590-s	slk:lemma	špinavý
+00421590-a	slk:lemma	špinavý
 00713952-n	slk:lemma	nakládka
 02016523-v	slk:lemma	ísť (do)
 09844898-n	slk:lemma	orodovník
 08665504-n	slk:lemma	mesto
 00826509-v	slk:lemma	skritizovať
 09270508-n	slk:lemma	voda
-00972642-s	slk:lemma	moderný
+00972642-a	slk:lemma	moderný
 07339098-n	slk:lemma	otras
 02493260-v	slk:lemma	neviazane hodovať
 15147850-n	slk:lemma	adolescencia
 00237636-r	slk:lemma	naschvál
 09408977-n	slk:lemma	rieka Rhone
 13850304-n	slk:lemma	rozsah
-02030562-s	slk:lemma	reakcionársky
+02030562-a	slk:lemma	reakcionársky
 02205896-n	slk:lemma	blanokrídlovce
-01166413-s	slk:lemma	priaznivý
+01166413-a	slk:lemma	priaznivý
 05278922-n	slk:lemma	miesto
 07303839-n	slk:lemma	lesný požiar
 04269270-n	slk:lemma	sviečka
@@ -22629,7 +22629,7 @@
 05615869-n	slk:lemma	pozornosť
 01976957-n	slk:lemma	krab
 01714208-v	slk:lemma	podávať výkon
-00972642-s	slk:lemma	aktuálny
+00972642-a	slk:lemma	aktuálny
 08457976-n	slk:lemma	rad
 02597762-v	slk:lemma	dostaviť sa
 00863417-n	slk:lemma	oneskorená reakcia
@@ -22669,8 +22669,8 @@
 08281682-n	slk:lemma	obchodná akadémia
 05616786-n	slk:lemma	know-how
 02090435-v	slk:lemma	pokrútiť sa
-00358534-s	slk:lemma	záporný
-01916979-s	slk:lemma	neistý
+00358534-a	slk:lemma	záporný
+01916979-a	slk:lemma	neistý
 00705778-v	slk:lemma	presahovať
 08744105-n	slk:lemma	Mexicali
 05587288-n	slk:lemma	axiálna kostra
@@ -22725,7 +22725,7 @@
 00770437-v	slk:lemma	podnecovať
 07423560-n	slk:lemma	vývoj
 00256507-v	slk:lemma	opuchnúť
-01680559-s	slk:lemma	minerálový
+01680559-a	slk:lemma	minerálový
 07737081-n	slk:lemma	jedlý orech
 00630380-v	slk:lemma	zamýšľať sa
 00649362-v	slk:lemma	pátrať
@@ -22735,7 +22735,7 @@
 01042578-n	slk:lemma	tichá omša
 07600506-n	slk:lemma	kandizované ovocie
 02451679-v	slk:lemma	inhibovať
-00978754-s	slk:lemma	bezprostredný
+00978754-a	slk:lemma	bezprostredný
 00014742-v	slk:lemma	spávať
 08199025-n	slk:lemma	ozbrojené sily
 06650070-n	slk:lemma	potvrdenie
@@ -22743,7 +22743,7 @@
 00669243-v	slk:lemma	podržať v ťažkostiach
 01272798-v	slk:lemma	dostať perie
 14327125-n	slk:lemma	zlatá žila
-00028471-s	slk:lemma	domnelý
+00028471-a	slk:lemma	domnelý
 02116118-v	slk:lemma	dráždiť
 09031653-n	slk:lemma	Švajčiarska konfederácia
 02563327-v	slk:lemma	uskutočňovať
@@ -22752,21 +22752,21 @@
 02026442-a	slk:lemma	neschopný platiť
 00018813-v	slk:lemma	preberať (zo spánku)
 00382635-v	slk:lemma	premieňať
-00032497-s	slk:lemma	atletický
+00032497-a	slk:lemma	atletický
 13319726-n	slk:lemma	základný kurz
-00491511-s	slk:lemma	špecifický
-01313004-s	slk:lemma	opustený
+00491511-a	slk:lemma	špecifický
+01313004-a	slk:lemma	opustený
 10258602-n	slk:lemma	úradník udeľujúci licencie
 10499355-n	slk:lemma	kráľovná
-02104890-s	slk:lemma	citlivý na žiarenie
+02104890-a	slk:lemma	citlivý na žiarenie
 02873244-n	slk:lemma	batožinový priestor
-01930004-s	slk:lemma	inertný
+01930004-a	slk:lemma	inertný
 01619929-v	slk:lemma	zničiť
-00144510-s	slk:lemma	v brnení
-01993693-s	slk:lemma	solídny
+00144510-a	slk:lemma	v brnení
+01993693-a	slk:lemma	solídny
 00541479-n	slk:lemma	ceremoniálny tanec
 01974399-n	slk:lemma	Crustacea
-01111418-s	slk:lemma	veľkorysý
+01111418-a	slk:lemma	veľkorysý
 05509452-n	slk:lemma	urogenitálny systém
 02431971-v	slk:lemma	riadiť
 01805982-v	slk:lemma	oceniť
@@ -22783,11 +22783,11 @@
 05196582-n	slk:lemma	oprávnenie
 08616050-n	slk:lemma	pasienok
 02699941-v	slk:lemma	slušať
-02372434-s	slk:lemma	skrížený
+02372434-a	slk:lemma	skrížený
 06314423-n	slk:lemma	hlavná veta
 03102859-n	slk:lemma	chladiaci systém
 01312371-v	slk:lemma	vyberať
-01214430-s	slk:lemma	ostrý
+01214430-a	slk:lemma	ostrý
 01236173-n	slk:lemma	krvná pomsta
 05112215-n	slk:lemma	úbytok
 02475922-v	slk:lemma	dosadiť
@@ -22813,14 +22813,14 @@
 09014979-n	slk:lemma	Ukrajina
 00575365-n	slk:lemma	brnkačka
 00746718-v	slk:lemma	zakázať
-00974159-s	slk:lemma	prežitý
+00974159-a	slk:lemma	prežitý
 00071178-v	slk:lemma	trápiť
 09187743-n	slk:lemma	Adige
 00896141-v	slk:lemma	odôvodniť
 01853310-v	slk:lemma	vyčerpať
 08325686-n	slk:lemma	komisia
 07408171-n	slk:lemma	explózia
-00411353-s	slk:lemma	nasledujúci Krista
+00411353-a	slk:lemma	nasledujúci Krista
 00882948-v	slk:lemma	odporúčať
 04137444-n	slk:lemma	umelý satelit
 06733476-n	slk:lemma	vyhrážanie
@@ -22829,9 +22829,9 @@
 02488834-v	slk:lemma	sobášiť sa
 03404449-n	slk:lemma	pec
 00879540-v	slk:lemma	nominovať
-00758800-s	slk:lemma	uhladený
+00758800-a	slk:lemma	uhladený
 07844042-n	slk:lemma	mlieko
-02336904-s	slk:lemma	biedny
+02336904-a	slk:lemma	biedny
 13916721-n	slk:lemma	kocka
 01563579-n	slk:lemma	rod králik
 00649362-v	slk:lemma	sliediť
@@ -22841,14 +22841,14 @@
 02759963-n	slk:lemma	samonabíjacia zbraň
 05159725-n	slk:lemma	dobro
 09410026-n	slk:lemma	prasklina
-00135455-s	slk:lemma	pravý
+00135455-a	slk:lemma	pravý
 04458843-n	slk:lemma	dotyková obrazovka
 01077350-n	slk:lemma	predchádzanie
 10110421-n	slk:lemma	nezávislý pracovník
 07109196-n	slk:lemma	reč
 00220869-v	slk:lemma	posilniť
 11500816-n	slk:lemma	mikrovlnné spektrum
-00453308-s	slk:lemma	úzky
+00453308-a	slk:lemma	úzky
 02524171-v	slk:lemma	podariť sa
 00032299-r	slk:lemma	hrozne
 00016756-a	slk:lemma	obmedzený
@@ -22862,7 +22862,7 @@
 15002233-n	slk:lemma	rádioaktívny materiál
 07271942-n	slk:lemma	škvrna
 09369844-n	slk:lemma	Neva
-00968010-s	slk:lemma	zvláštny
+00968010-a	slk:lemma	zvláštny
 05516848-n	slk:lemma	vak
 04543158-n	slk:lemma	vozík
 07893642-n	slk:lemma	šampanské
@@ -22876,7 +22876,7 @@
 07068844-n	slk:lemma	prostriedok
 01461328-v	slk:lemma	spájať sa
 13909190-n	slk:lemma	sínusoida
-00127948-s	slk:lemma	ďalší
+00127948-a	slk:lemma	ďalší
 00033852-v	slk:lemma	zamračiť sa
 00368515-n	slk:lemma	recirkulácia
 10076033-n	slk:lemma	homoš
@@ -22884,7 +22884,7 @@
 10179649-n	slk:lemma	sviňa
 01014066-n	slk:lemma	zhromažďovanie
 02590340-v	slk:lemma	obsadzovať
-01294583-s	slk:lemma	smerujúci domov
+01294583-a	slk:lemma	smerujúci domov
 10632576-n	slk:lemma	lekár špecialista
 14500047-n	slk:lemma	chaos
 05161614-n	slk:lemma	nevýhoda
@@ -22892,7 +22892,7 @@
 00993014-v	slk:lemma	písať
 04756887-n	slk:lemma	pochybnosť
 00330457-n	slk:lemma	zrýchlenie
-01442597-s	slk:lemma	skrátený
+01442597-a	slk:lemma	skrátený
 03820318-n	slk:lemma	bránka
 08292756-n	slk:lemma	flotila
 01883898-a	slk:lemma	perspektívny
@@ -22905,7 +22905,7 @@
 12916935-n	slk:lemma	Euphorbiaceae
 02690081-n	slk:lemma	letecká spoločnosť
 00827010-n	slk:lemma	izolovanie
-02186338-s	slk:lemma	jeden
+02186338-a	slk:lemma	jeden
 07037384-n	slk:lemma	ďakovná bohoslužba
 00063630-r	slk:lemma	celkove
 00003316-v	slk:lemma	vdýchnuť
@@ -22921,7 +22921,7 @@
 02958392-a	slk:lemma	francúzsky
 06023969-n	slk:lemma	priemerná hodnota
 11450869-n	slk:lemma	elektromagnetické žiarenie
-01038332-s	slk:lemma	vnútorný
+01038332-a	slk:lemma	vnútorný
 00303849-n	slk:lemma	parašutizmus
 03426134-n	slk:lemma	nádrž na benzín
 00763399-v	slk:lemma	dojednávať
@@ -22936,12 +22936,12 @@
 06290637-n	slk:lemma	tvar slova
 06532330-n	slk:lemma	právo
 14972807-n	slk:lemma	ozón
-00815000-s	slk:lemma	predčasný
+00815000-a	slk:lemma	predčasný
 08798382-n	slk:lemma	Kanaán
 14403107-n	slk:lemma	vzrušenie
 10550252-n	slk:lemma	nosič reklám
 00047392-r	slk:lemma	nadmerne
-02325984-s	slk:lemma	mdlý
+02325984-a	slk:lemma	mdlý
 02745172-v	slk:lemma	pridať
 03694098-n	slk:lemma	dolná paluba
 02757462-n	slk:lemma	audiosystém
@@ -22949,7 +22949,7 @@
 05502556-n	slk:lemma	dutina
 04836268-n	slk:lemma	ambícia
 02541509-v	slk:lemma	reprezentovať
-00874226-s	slk:lemma	svieži
+00874226-a	slk:lemma	svieži
 02373601-n	slk:lemma	Equidae
 02704928-v	slk:lemma	trvať
 00998886-v	slk:lemma	ukladať
@@ -22965,15 +22965,15 @@
 03795580-n	slk:lemma	závora
 00715541-v	slk:lemma	uvádzať
 08556491-n	slk:lemma	panstvo
-00595299-s	slk:lemma	neprestajný
+00595299-a	slk:lemma	neprestajný
 13779374-n	slk:lemma	objem
 14494893-n	slk:lemma	čistota
 03302938-n	slk:lemma	výfuk
-00515380-s	slk:lemma	stopercentný
+00515380-a	slk:lemma	stopercentný
 10548419-n	slk:lemma	mladá predavačka
 00087736-v	slk:lemma	onemocnieť (na čo)
 00097504-n	slk:lemma	výkon
-01723648-s	slk:lemma	objektívny
+01723648-a	slk:lemma	objektívny
 09040998-n	slk:lemma	Antioch
 04007894-n	slk:lemma	výrobok
 13275288-n	slk:lemma	náklady
@@ -22986,7 +22986,7 @@
 05068461-n	slk:lemma	stúpanie
 02034511-v	slk:lemma	odvrátiť
 01469263-v	slk:lemma	pridávať
-02332604-s	slk:lemma	produktívny
+02332604-a	slk:lemma	produktívny
 04652635-n	slk:lemma	spoločenskosť
 00064018-n	slk:lemma	víťazstvo
 02539101-v	slk:lemma	zamiešať sa
@@ -22995,7 +22995,7 @@
 07082025-n	slk:lemma	paralingvistická komunikácia
 01020005-v	slk:lemma	poznamenávať
 09358358-n	slk:lemma	mesiac
-01634736-s	slk:lemma	oficiálny
+01634736-a	slk:lemma	oficiálny
 02188065-n	slk:lemma	rad Diptera
 04847482-n	slk:lemma	kladná mravná vlastnosť
 02709906-v	slk:lemma	odchyľovať sa od
@@ -23013,7 +23013,7 @@
 01984902-v	slk:lemma	usadiť sa
 04555700-n	slk:lemma	kôš na odpadky
 05157574-n	slk:lemma	prospech
-00440489-s	slk:lemma	hlúpy
+00440489-a	slk:lemma	hlúpy
 06507041-n	slk:lemma	register
 00334996-v	slk:lemma	kaziť
 07628870-n	slk:lemma	múčnik
@@ -23037,11 +23037,11 @@
 02629390-v	slk:lemma	vylučovať
 14746048-n	slk:lemma	progesterón
 10477585-n	slk:lemma	podmienečne prepustený
-00907400-s	slk:lemma	namyslený
+00907400-a	slk:lemma	namyslený
 00978173-n	slk:lemma	obranná akcia
 05599769-n	slk:lemma	dvojitá brada
 14930476-n	slk:lemma	kyselina dodekanová
-01625063-s	slk:lemma	odpudivý
+01625063-a	slk:lemma	odpudivý
 01166093-v	slk:lemma	používať
 08065093-n	slk:lemma	obchodný podnik
 13927383-n	slk:lemma	stav
@@ -23051,11 +23051,11 @@
 00790347-n	slk:lemma	verejná ponuka kúpy
 06196284-n	slk:lemma	stanovište
 10042690-n	slk:lemma	poslucháč
-01610261-s	slk:lemma	nevidený
+01610261-a	slk:lemma	nevidený
 07562495-n	slk:lemma	výživový doplnok
-00027599-s	slk:lemma	prípustný
+00027599-a	slk:lemma	prípustný
 02874876-a	slk:lemma	komunistický
-01631386-s	slk:lemma	nedodržiavajúci
+01631386-a	slk:lemma	nedodržiavajúci
 13875571-n	slk:lemma	slučka
 10100761-n	slk:lemma	ťulpas
 11439690-n	slk:lemma	mrak
@@ -23080,7 +23080,7 @@
 03127531-n	slk:lemma	nárazová bariéra
 09430771-n	slk:lemma	rieka Severn
 01617192-v	slk:lemma	stvoriť
-00974519-s	slk:lemma	nevkusný
+00974519-a	slk:lemma	nevkusný
 08118991-n	slk:lemma	personálne oddelenie
 02158354-n	slk:lemma	uropygium
 01061017-v	slk:lemma	nosiť v sebe
@@ -23093,15 +23093,15 @@
 08191987-n	slk:lemma	americké vojenské námorníctvo
 01023259-v	slk:lemma	citovať
 00262881-v	slk:lemma	narúšať
-01969348-s	slk:lemma	semestrálny
+01969348-a	slk:lemma	semestrálny
 00019448-v	slk:lemma	postihovať
 04620558-n	slk:lemma	vnútro
-02067491-s	slk:lemma	rôzny
+02067491-a	slk:lemma	rôzny
 00782527-v	slk:lemma	zlákať
 00061677-r	slk:lemma	odrazu
 04978216-n	slk:lemma	tmavosť
 05124057-n	slk:lemma	krajný bod
-01031602-s	slk:lemma	rýchly
+01031602-a	slk:lemma	rýchly
 02200198-n	slk:lemma	moskyt
 15057744-n	slk:lemma	steroid
 01419473-v	slk:lemma	narušiť
@@ -23109,7 +23109,7 @@
 01886728-v	slk:lemma	prijazdiť na voľnobeh
 00964911-v	slk:lemma	načínať (tému)
 00768778-v	slk:lemma	nahovárať
-00916199-s	slk:lemma	voľný
+00916199-a	slk:lemma	voľný
 02389346-v	slk:lemma	kontaktovať
 05284617-n	slk:lemma	intervertebrálna platnička
 00353611-n	slk:lemma	znižovanie
@@ -23119,16 +23119,16 @@
 07518261-n	slk:lemma	rozčuľovanie
 08897065-n	slk:lemma	Arabská republika Egypt
 05761918-n	slk:lemma	spomínanie
-02523092-s	slk:lemma	rastový
+02523092-a	slk:lemma	rastový
 01069980-n	slk:lemma	pôst
 01380638-v	slk:lemma	pozbierať
 09437241-n	slk:lemma	plátok
 00086077-v	slk:lemma	otvoriť žilu
 04625129-n	slk:lemma	morálka armády
 02294179-v	slk:lemma	požiť s niekým
-00341655-s	slk:lemma	premenlivý
+00341655-a	slk:lemma	premenlivý
 10763383-n	slk:lemma	čašník
-01263445-s	slk:lemma	hrubý
+01263445-a	slk:lemma	hrubý
 02416410-n	slk:lemma	Capra
 03497100-n	slk:lemma	lacná jedáleň
 14418822-n	slk:lemma	aliancia
@@ -23137,15 +23137,15 @@
 13862780-n	slk:lemma	geometrický tvar
 00387657-n	slk:lemma	rezanie
 14570939-n	slk:lemma	väčší počet chromozómov
-00696996-s	slk:lemma	nežný
-01042703-s	slk:lemma	formálny
+00696996-a	slk:lemma	nežný
+01042703-a	slk:lemma	formálny
 06559365-n	slk:lemma	proces
 00947077-v	slk:lemma	stanoviť
 02285205-v	slk:lemma	uhrádzať
 00419908-n	slk:lemma	zlé zaobchádzanie
 00145854-r	slk:lemma	chabo
 00887081-n	slk:lemma	náuka
-02322512-s	slk:lemma	tvrdý
+02322512-a	slk:lemma	tvrdý
 00659112-v	slk:lemma	znovu usporiadať
 00564857-v	slk:lemma	zožmoliť
 02532508-a	slk:lemma	teplokrvný
@@ -23153,7 +23153,7 @@
 02255268-v	slk:lemma	povoľovať
 09955015-n	slk:lemma	podvodník
 07420991-n	slk:lemma	pulzovanie
-00032497-s	slk:lemma	akrobatický
+00032497-a	slk:lemma	akrobatický
 11566682-n	slk:lemma	čeľaď rosid dicot
 01054545-n	slk:lemma	bývanie
 03047071-a	slk:lemma	krstný
@@ -23161,7 +23161,7 @@
 00314835-r	slk:lemma	priamo
 09482715-n	slk:lemma	Yosemite
 02123424-v	slk:lemma	pichať
-01208738-s	slk:lemma	sofistikovaný
+01208738-a	slk:lemma	sofistikovaný
 00057042-r	slk:lemma	ani náhodou nie
 01552519-v	slk:lemma	odseknúť
 04858785-n	slk:lemma	smelosť
@@ -23172,7 +23172,7 @@
 00510364-v	slk:lemma	pokryť machuľami
 05431585-n	slk:lemma	protoplast
 08419774-n	slk:lemma	transferový zástupca
-01019713-s	slk:lemma	ochablý
+01019713-a	slk:lemma	ochablý
 07497473-n	slk:lemma	sympatia
 15248564-n	slk:lemma	vek
 06619428-n	slk:lemma	program
@@ -23191,7 +23191,7 @@
 00028651-n	slk:lemma	priestor
 10383816-n	slk:lemma	pôvodca
 02761696-n	slk:lemma	automobilová továreň
-00072281-s	slk:lemma	imúnny
+00072281-a	slk:lemma	imúnny
 02154508-v	slk:lemma	všímať si
 12423565-n	slk:lemma	čeľaď ľaliové
 07008680-n	slk:lemma	úryvok
@@ -23216,12 +23216,12 @@
 02599689-a	slk:lemma	unikajúci
 03054978-a	slk:lemma	citrónový
 14188804-n	slk:lemma	dnová artritída
-00959244-s	slk:lemma	istý
+00959244-a	slk:lemma	istý
 04710127-n	slk:lemma	ponurosť
 03833564-n	slk:lemma	dýza
 02881567-a	slk:lemma	genitálny
 00767122-v	slk:lemma	presvedčiť k zmene názoru
-02075321-s	slk:lemma	duševne nevyrovnaný
+02075321-a	slk:lemma	duševne nevyrovnaný
 09830194-n	slk:lemma	obranca
 07247071-n	slk:lemma	promočný materiál
 03230785-n	slk:lemma	predbežný nárys
@@ -23236,8 +23236,8 @@
 07587206-n	slk:lemma	korytnačia polievka
 13085864-n	slk:lemma	zber
 09227219-n	slk:lemma	Bospor
-01625893-s	slk:lemma	vzbudzujúci odpor
-00218305-s	slk:lemma	krásny
+01625893-a	slk:lemma	vzbudzujúci odpor
+00218305-a	slk:lemma	krásny
 07495327-n	slk:lemma	bolesť
 03098803-a	slk:lemma	farmaceutický
 01057200-n	slk:lemma	poskytovanie
@@ -23245,9 +23245,9 @@
 05979909-n	slk:lemma	absencia viery
 06667317-n	slk:lemma	zákon
 01741446-v	slk:lemma	obrobiť
-01166656-s	slk:lemma	hojivý
+01166656-a	slk:lemma	hojivý
 14616181-n	slk:lemma	kyselina suberová
-01276482-s	slk:lemma	dominantný
+01276482-a	slk:lemma	dominantný
 10363913-n	slk:lemma	nováčik
 00520214-a	slk:lemma	kompletný
 03923918-n	slk:lemma	fonografická ihla
@@ -23260,8 +23260,8 @@
 01691057-v	slk:lemma	napísať
 00694068-v	slk:lemma	ctiť si
 00157624-r	slk:lemma	plne
-01375831-s	slk:lemma	slávny
-00422168-s	slk:lemma	zamastený
+01375831-a	slk:lemma	slávny
+00422168-a	slk:lemma	zamastený
 04618921-n	slk:lemma	osobnosť
 02031158-v	slk:lemma	oddeliť
 07050042-n	slk:lemma	pieseň
@@ -23270,7 +23270,7 @@
 01848465-v	slk:lemma	urobiť miesto
 04399382-n	slk:lemma	medvedík
 05172596-n	slk:lemma	nezávažnosť
-01975671-s	slk:lemma	relevantný
+01975671-a	slk:lemma	relevantný
 07009946-n	slk:lemma	text divadelnej hry
 00501990-r	slk:lemma	dnu
 10051975-n	slk:lemma	vysťahovalec
@@ -23278,13 +23278,13 @@
 07532440-n	slk:lemma	nešťastnosť
 05538494-n	slk:lemma	perineum
 14864961-n	slk:lemma	živec
-02199177-s	slk:lemma	miliónový
+02199177-a	slk:lemma	miliónový
 09316066-n	slk:lemma	Irtyš
 00112828-n	slk:lemma	stlačenie myši
 02210855-v	slk:lemma	obdržať
 14832193-n	slk:lemma	RNA
 08663156-n	slk:lemma	konček
-01025212-s	slk:lemma	nekompromisný
+01025212-a	slk:lemma	nekompromisný
 00634906-v	slk:lemma	pochopiť
 07938773-n	slk:lemma	zostavenie
 13149506-n	slk:lemma	čierne korenie
@@ -23295,18 +23295,18 @@
 02299437-a	slk:lemma	plný hviezd
 02014553-v	slk:lemma	štartovať
 00608162-n	slk:lemma	šitie šiat
-01764351-s	slk:lemma	prekážajúci
+01764351-a	slk:lemma	prekážajúci
 09969718-n	slk:lemma	predavač
 00226618-a	slk:lemma	láskavý
 02143756-v	slk:lemma	kopať
 07238455-n	slk:lemma	ohováranie
 00018526-v	slk:lemma	prebrať sa (zo spánku)
 00941166-v	slk:lemma	dávať podnet
-01405523-s	slk:lemma	nečitateľný
+01405523-a	slk:lemma	nečitateľný
 08986691-n	slk:lemma	Katar
 02653996-v	slk:lemma	stavať stan
 00858781-v	slk:lemma	povzbudiť
-00799401-s	slk:lemma	zhulený
+00799401-a	slk:lemma	zhulený
 08681222-n	slk:lemma	orientácia
 00235208-n	slk:lemma	úpadok
 02982790-n	slk:lemma	narážka
@@ -23336,7 +23336,7 @@
 09755788-n	slk:lemma	začiatočník
 01068773-n	slk:lemma	odopieranie si
 03391301-n	slk:lemma	rám okuliarov
-02526124-s	slk:lemma	nedobytný
+02526124-a	slk:lemma	nedobytný
 06684383-n	slk:lemma	prísľub
 03690473-n	slk:lemma	kamión
 09244831-n	slk:lemma	Čukotské more
@@ -23365,9 +23365,9 @@
 00289082-a	slk:lemma	rozbitý
 11465688-n	slk:lemma	búrka s krúpami
 00118764-v	slk:lemma	držať krok (s dobou)
-00835292-s	slk:lemma	pôsobivý
+00835292-a	slk:lemma	pôsobivý
 05647156-n	slk:lemma	pochabosť
-02032850-s	slk:lemma	pravý
+02032850-a	slk:lemma	pravý
 11445395-n	slk:lemma	sedimentácia
 05286536-n	slk:lemma	väzivo
 10407954-n	slk:lemma	stúpenec
@@ -23376,11 +23376,11 @@
 00898804-n	slk:lemma	zobrazovanie
 08061042-n	slk:lemma	obchod
 10665698-n	slk:lemma	študentka
-00510644-s	slk:lemma	efektívny
+00510644-a	slk:lemma	efektívny
 08189659-n	slk:lemma	jednotka
 03292736-n	slk:lemma	planétové súkolesie
 05867413-n	slk:lemma	časť
-00298293-s	slk:lemma	družstevný
+00298293-a	slk:lemma	družstevný
 00812526-n	slk:lemma	zovretie
 06146053-n	slk:lemma	náuka o nápisoch
 02374924-v	slk:lemma	odvažovať sa
@@ -23400,7 +23400,7 @@
 00152684-r	slk:lemma	nasledovne
 01995549-v	slk:lemma	prechádzať
 08440630-n	slk:lemma	cézarizmus
-01762257-s	slk:lemma	prípustný
+01762257-a	slk:lemma	prípustný
 02402825-v	slk:lemma	dať výpoveď
 00391086-n	slk:lemma	trhanie
 05996646-n	slk:lemma	disciplína
@@ -23409,29 +23409,29 @@
 02346724-v	slk:lemma	osvojiť si
 00402217-r	slk:lemma	uprostred týždňa
 06436939-n	slk:lemma	Kniha Jób
-00668053-s	slk:lemma	aktuálny
+00668053-a	slk:lemma	aktuálny
 01099592-v	slk:lemma	nevyhrať
 01534147-v	slk:lemma	mazať sa
-00282675-s	slk:lemma	lesklý
+00282675-a	slk:lemma	lesklý
 05888929-n	slk:lemma	predpoklad
 05274590-n	slk:lemma	čuchová kosť
 12708654-n	slk:lemma	sevillský pomaranč
 01761706-v	slk:lemma	vzbudiť
-01439784-s	slk:lemma	večný
-01711465-s	slk:lemma	ubolený
+01439784-a	slk:lemma	večný
+01711465-a	slk:lemma	ubolený
 04531873-n	slk:lemma	vesta
 00725775-n	slk:lemma	zadák
 09330604-n	slk:lemma	Champlain
 00208210-v	slk:lemma	pokaziť
 01000214-v	slk:lemma	zaregistrovať
-00051571-s	slk:lemma	postačujúci
+00051571-a	slk:lemma	postačujúci
 03790512-n	slk:lemma	motocykel
 00067999-v	slk:lemma	presakovať (do okolia)
 07094093-n	slk:lemma	rytmus
-00682521-s	slk:lemma	totálne hluchý
+00682521-a	slk:lemma	totálne hluchý
 02367363-v	slk:lemma	dojednať
 01642924-v	slk:lemma	pripravovať
-02100968-s	slk:lemma	podriadený
+02100968-a	slk:lemma	podriadený
 10694163-n	slk:lemma	daňovník
 03058726-n	slk:lemma	rodový erb
 04921011-n	slk:lemma	dedičstvo
@@ -23442,14 +23442,14 @@
 00018813-v	slk:lemma	budiť
 01100877-n	slk:lemma	družstvo
 09146681-n	slk:lemma	Victoria
-01384212-s	slk:lemma	rozľahlý
+01384212-a	slk:lemma	rozľahlý
 01864230-v	slk:lemma	začať
 00719494-n	slk:lemma	záväzok
 01741446-v	slk:lemma	obrábať
 08348091-n	slk:lemma	NSA
 00239064-r	slk:lemma	pešo
 03466947-n	slk:lemma	gilošovaná ozdoba
-02257856-s	slk:lemma	družný
+02257856-a	slk:lemma	družný
 05999266-n	slk:lemma	oblasť poznania
 00223395-r	slk:lemma	poctivo
 00539936-v	slk:lemma	sprístupňovať
@@ -23519,14 +23519,14 @@
 03773504-n	slk:lemma	strela
 00812526-n	slk:lemma	stisnutie
 02231328-v	slk:lemma	podstrčiť
-01674242-s	slk:lemma	všedný
+01674242-a	slk:lemma	všedný
 10298482-n	slk:lemma	odborník
 00285387-n	slk:lemma	hovor počas spania
 02608902-a	slk:lemma	agronomický
-01990653-s	slk:lemma	neochvejný
+01990653-a	slk:lemma	neochvejný
 02066304-v	slk:lemma	schádzať (z cesty)
 00759501-v	slk:lemma	dôrazne prosiť
-00848466-s	slk:lemma	záväzný
+00848466-a	slk:lemma	záväzný
 10409752-n	slk:lemma	platca
 00118764-v	slk:lemma	byť v obraze
 02620587-v	slk:lemma	byť
@@ -23547,7 +23547,7 @@
 07927931-n	slk:lemma	kola
 02589245-v	slk:lemma	zhodovať sa
 03250588-n	slk:lemma	pieskovač
-01440574-s	slk:lemma	podlhovastý
+01440574-a	slk:lemma	podlhovastý
 02478701-v	slk:lemma	ratifikovať
 02620466-v	slk:lemma	rezignovať
 00196848-n	slk:lemma	novácia
@@ -23558,7 +23558,7 @@
 03301066-n	slk:lemma	etónsky golier
 01494310-v	slk:lemma	klásť
 02935387-n	slk:lemma	debna
-02243255-s	slk:lemma	bradavičnatý
+02243255-a	slk:lemma	bradavičnatý
 15119536-n	slk:lemma	dnešná doba
 08109624-n	slk:lemma	podrod
 07060844-n	slk:lemma	ragtime
@@ -23577,7 +23577,7 @@
 09911465-n	slk:lemma	milostivá
 10657969-n	slk:lemma	majiteľ akcií
 06664473-n	slk:lemma	najvyššia dovolená rýchlosť
-01625492-s	slk:lemma	pohrebný
+01625492-a	slk:lemma	pohrebný
 07301336-n	slk:lemma	nehoda
 00823436-v	slk:lemma	vyvrácať
 00151040-r	slk:lemma	tak, ako je treba
@@ -23601,7 +23601,7 @@
 02676054-v	slk:lemma	vzťahovať sa
 02904223-a	slk:lemma	vedúci
 02157731-v	slk:lemma	zakaliť
-01676517-s	slk:lemma	úžasný
+01676517-a	slk:lemma	úžasný
 08153437-n	slk:lemma	kráľovský dom
 01673891-v	slk:lemma	utkať
 03759243-n	slk:lemma	mikrofiš
@@ -23610,7 +23610,7 @@
 09223725-n	slk:lemma	perina (snehová)
 06757891-n	slk:lemma	fikcia
 00399393-n	slk:lemma	revízia
-01263971-s	slk:lemma	krutý
+01263971-a	slk:lemma	krutý
 02026442-a	slk:lemma	insolventný dlžník
 11880032-n	slk:lemma	repkový olej
 00239230-n	slk:lemma	prvý ťah
@@ -23636,7 +23636,7 @@
 02405252-v	slk:lemma	odstrániť
 00720808-v	slk:lemma	predvidieť (budúcnosť)
 00422090-v	slk:lemma	zjavovať sa
-00377702-s	slk:lemma	gaštanovo hnedý
+00377702-a	slk:lemma	gaštanovo hnedý
 01494429-a	slk:lemma	trvajúci celý rok
 02422663-v	slk:lemma	zdržiavať
 02193194-v	slk:lemma	spoznať
@@ -23659,7 +23659,7 @@
 05496990-n	slk:lemma	medzimozog
 10615334-n	slk:lemma	pašerák
 07035870-n	slk:lemma	hymna
-02405805-s	slk:lemma	napínavý
+02405805-a	slk:lemma	napínavý
 01111028-v	slk:lemma	triumfovať
 04954534-n	slk:lemma	lesk
 00799076-v	slk:lemma	vziať späť
@@ -23686,7 +23686,7 @@
 01033527-v	slk:lemma	obsiahnuť
 00231765-r	slk:lemma	sám od seba
 10243137-n	slk:lemma	dáma
-01463414-s	slk:lemma	ohrdnutý
+01463414-a	slk:lemma	ohrdnutý
 01454431-v	slk:lemma	vliecť
 13740168-n	slk:lemma	ničota
 00601043-v	slk:lemma	ponárať sa (do niečoho)
@@ -23700,19 +23700,19 @@
 14929350-n	slk:lemma	laktogén
 10024937-n	slk:lemma	Dominičan
 05322103-n	slk:lemma	endolymfa
-01894196-s	slk:lemma	osvedčený
-01124192-s	slk:lemma	dosť dobrý
+01894196-a	slk:lemma	osvedčený
+01124192-a	slk:lemma	dosť dobrý
 02060141-v	slk:lemma	rozptýliť sa
 00528397-n	slk:lemma	pódiový tanec
 04771890-n	slk:lemma	nerovnosť
 00265119-n	slk:lemma	prestavba
 07616748-n	slk:lemma	banana split
-00136589-s	slk:lemma	vypovedateľný
+00136589-a	slk:lemma	vypovedateľný
 03620052-n	slk:lemma	kuchynské zariadenie
 07939382-n	slk:lemma	zoskupenie
 01603303-v	slk:lemma	pokoviť
 07636534-n	slk:lemma	mandľové pečivo
-02378496-s	slk:lemma	zhodný
+02378496-a	slk:lemma	zhodný
 03391770-n	slk:lemma	prostredie
 00958896-n	slk:lemma	konflikt
 03412058-n	slk:lemma	obrazáreň
@@ -23720,7 +23720,7 @@
 10013399-n	slk:lemma	blbec
 05068461-n	slk:lemma	svah
 01032040-n	slk:lemma	bohoslužba
-02384077-s	slk:lemma	plný slov
+02384077-a	slk:lemma	plný slov
 14992613-n	slk:lemma	sadra
 09020440-n	slk:lemma	Kirgizská republika
 02081578-v	slk:lemma	zanechávať
@@ -23732,9 +23732,9 @@
 02066939-v	slk:lemma	stiecť
 00328502-n	slk:lemma	kĺzanie
 01469161-a	slk:lemma	dramatický
-02347086-s	slk:lemma	biedny
+02347086-a	slk:lemma	biedny
 00356954-v	slk:lemma	vyduť sa
-00119006-s	slk:lemma	živý
+00119006-a	slk:lemma	živý
 05413241-n	slk:lemma	hormón štítnej žľazy
 01058574-v	slk:lemma	spozorovať
 01639714-v	slk:lemma	rozvrhnúť
@@ -23744,12 +23744,12 @@
 00779248-n	slk:lemma	oklamať za účelom získania zisku
 14496710-n	slk:lemma	poriadok
 00475845-r	slk:lemma	nežne
-01710809-s	slk:lemma	nepodliehajúci povinnosti platiť nájomné
+01710809-a	slk:lemma	nepodliehajúci povinnosti platiť nájomné
 07990158-n	slk:lemma	zmiešané manželstvo
 04184701-n	slk:lemma	črep
 02504562-v	slk:lemma	donútiť
 13968547-n	slk:lemma	poriadok
-00354934-s	slk:lemma	pretvorený
+00354934-a	slk:lemma	pretvorený
 00199130-n	slk:lemma	prechod
 00462092-v	slk:lemma	porážať
 03540595-n	slk:lemma	nemocnica
@@ -23763,7 +23763,7 @@
 01116585-v	slk:lemma	vydržať
 12694707-n	slk:lemma	čeľaď Meliaceae
 05017757-n	slk:lemma	dohľad
-02569558-s	slk:lemma	dôvtipný
+02569558-a	slk:lemma	dôvtipný
 10478293-n	slk:lemma	prokonzul
 10459212-n	slk:lemma	rýchly posol
 01032892-n	slk:lemma	spoločná modlitba
@@ -23797,11 +23797,11 @@
 07860988-n	slk:lemma	cesto
 11778391-n	slk:lemma	rad Arales
 05119837-n	slk:lemma	nadmiera
-02552646-s	slk:lemma	vyprahnutý
+02552646-a	slk:lemma	vyprahnutý
 10792856-n	slk:lemma	odpratávač trosiek
 10421470-n	slk:lemma	lekárnik
 02879638-a	slk:lemma	pápežský
-00876204-s	slk:lemma	mdlý
+00876204-a	slk:lemma	mdlý
 01066163-n	slk:lemma	zdržanie
 00137562-r	slk:lemma	na striedačku
 06999802-n	slk:lemma	graf
@@ -23809,7 +23809,7 @@
 01021128-v	slk:lemma	vysvetľovať
 00720565-n	slk:lemma	funkcia
 02062212-v	slk:lemma	sotiť
-01263013-s	slk:lemma	nemilosrdný
+01263013-a	slk:lemma	nemilosrdný
 12651465-n	slk:lemma	rod hruška (Pyrus)
 01058574-v	slk:lemma	postrehnúť
 00384933-n	slk:lemma	odchod
@@ -23827,7 +23827,7 @@
 13255883-n	slk:lemma	ľahký zárobok
 00380881-n	slk:lemma	nával
 01031256-v	slk:lemma	poslať
-01756292-s	slk:lemma	krátkodobý
+01756292-a	slk:lemma	krátkodobý
 04335435-n	slk:lemma	električka
 12202712-n	slk:lemma	rod Tilia
 01272798-v	slk:lemma	operiť sa
@@ -23835,7 +23835,7 @@
 00770270-n	slk:lemma	porušenie
 03246454-n	slk:lemma	kulisy
 05770926-n	slk:lemma	zamyslenie
-02343110-s	slk:lemma	excelentný
+02343110-a	slk:lemma	excelentný
 01041061-v	slk:lemma	nehovoriť
 04664413-n	slk:lemma	ostražitosť
 10636598-n	slk:lemma	duša
@@ -23848,8 +23848,8 @@
 02518161-v	slk:lemma	počínať si
 00220409-n	slk:lemma	zabitie
 05933246-n	slk:lemma	výhľad
-01042491-s	slk:lemma	obradný
-00592880-s	slk:lemma	opakujúci sa
+01042491-a	slk:lemma	obradný
+00592880-a	slk:lemma	opakujúci sa
 07963087-n	slk:lemma	stoh
 13886133-n	slk:lemma	klenba
 04409712-n	slk:lemma	kurt
@@ -23864,7 +23864,7 @@
 02294056-v	slk:lemma	tratiť
 09268236-n	slk:lemma	rieka Dneper
 14778436-n	slk:lemma	agens
-00683531-s	slk:lemma	hrubý
+00683531-a	slk:lemma	hrubý
 00916464-n	slk:lemma	poľnohospodárstvo
 00634862-a	slk:lemma	schopný nápravy
 02552449-v	slk:lemma	opravovať
@@ -23889,16 +23889,16 @@
 06021499-n	slk:lemma	štatistika
 08178741-n	slk:lemma	populácia
 09617867-n	slk:lemma	znalec
-00672382-s	slk:lemma	zákazkový
+00672382-a	slk:lemma	zákazkový
 05913538-n	slk:lemma	princíp
 09857852-n	slk:lemma	podvodník
 07993279-n	slk:lemma	zvieratstvo
 07548978-n	slk:lemma	nevraživosť
-01322323-s	slk:lemma	kriminálny
+01322323-a	slk:lemma	kriminálny
 06300632-n	slk:lemma	položka slovníka
 08309086-n	slk:lemma	stretnutie
 02373601-n	slk:lemma	čeľaď koňovité
-00782216-s	slk:lemma	neurčitý
+00782216-a	slk:lemma	neurčitý
 01573515-v	slk:lemma	roztrhnúť
 00505114-r	slk:lemma	len ak
 06115701-n	slk:lemma	geológia
@@ -23920,7 +23920,7 @@
 10657969-n	slk:lemma	majiteľ cenných papierov
 00112601-r	slk:lemma	práve
 02688974-a	slk:lemma	cerebrálny
-01625893-s	slk:lemma	odpudzujúci
+01625893-a	slk:lemma	odpudzujúci
 05615373-n	slk:lemma	rozumnosť
 00124880-n	slk:lemma	styk
 02549211-v	slk:lemma	ponúknuť
@@ -23928,7 +23928,7 @@
 00927049-v	slk:lemma	uvažovať
 04664778-n	slk:lemma	pozornosť
 14579827-n	slk:lemma	pozícia
-00529657-s	slk:lemma	tichý
+00529657-a	slk:lemma	tichý
 08152787-n	slk:lemma	duchovenstvo
 07517550-n	slk:lemma	pocit urážky
 10142391-n	slk:lemma	dedo
@@ -23939,7 +23939,7 @@
 01571744-v	slk:lemma	prepadávať a škrtiť
 13556893-n	slk:lemma	dym
 09820263-n	slk:lemma	atlét
-01765132-s	slk:lemma	znemožňujúci
+01765132-a	slk:lemma	znemožňujúci
 09356639-n	slk:lemma	rieka Mobile
 05124928-n	slk:lemma	maximum
 04191595-n	slk:lemma	úkryt
@@ -23949,19 +23949,19 @@
 09191875-n	slk:lemma	rieka Alabama
 00396344-n	slk:lemma	masová snaha o výber bankových vkladov
 14633206-n	slk:lemma	uhlík
-00065667-s	slk:lemma	negatívny
+00065667-a	slk:lemma	negatívny
 00804476-v	slk:lemma	ustúpiť
 04975122-n	slk:lemma	chromatickosť
 01631830-a	slk:lemma	ospravedlňujúci
 09302804-n	slk:lemma	medzinárodné vody
 05035961-n	slk:lemma	sila
-01336837-s	slk:lemma	hlúpy
-02342608-s	slk:lemma	úžasný
+01336837-a	slk:lemma	hlúpy
+02342608-a	slk:lemma	úžasný
 10369528-n	slk:lemma	komentátor
 04682462-n	slk:lemma	miesto
 01528069-v	slk:lemma	upevniť
 03616763-n	slk:lemma	nožný spúšťač
-01010271-s	slk:lemma	konečný
+01010271-a	slk:lemma	konečný
 00273601-n	slk:lemma	strata prestíže
 04878861-n	slk:lemma	cudzoložstvo
 02051694-v	slk:lemma	prechádzať
@@ -23990,7 +23990,7 @@
 00075021-v	slk:lemma	unavovať
 00388959-n	slk:lemma	vetvenie
 01812720-v	slk:lemma	povzniesť
-02342899-s	slk:lemma	akostný
+02342899-a	slk:lemma	akostný
 02083863-n	slk:lemma	rod Canis
 02707659-a	slk:lemma	kuchársky
 00621734-v	slk:lemma	mýliť
@@ -23999,15 +23999,15 @@
 00836705-v	slk:lemma	vytvárať klamnú predstavu
 01208708-v	slk:lemma	pokrývať
 02413480-v	slk:lemma	odrobiť
-00379804-s	slk:lemma	lososovo ružový
+00379804-a	slk:lemma	lososovo ružový
 00888786-v	slk:lemma	zaväzovať
 02976350-n	slk:lemma	okenné krídlo
 13927383-n	slk:lemma	okolnosti
-00090219-s	slk:lemma	drsný
-01660444-s	slk:lemma	v bojovej pohotovosti
-00876204-s	slk:lemma	bezduchý
+00090219-a	slk:lemma	drsný
+01660444-a	slk:lemma	v bojovej pohotovosti
+00876204-a	slk:lemma	bezduchý
 00665476-v	slk:lemma	nastoliť
-00209916-s	slk:lemma	trávovitý
+00209916-a	slk:lemma	trávovitý
 00453803-v	slk:lemma	dopĺňať
 01811736-v	slk:lemma	pozdvihovať
 02614387-v	slk:lemma	žiť
@@ -24021,7 +24021,7 @@
 07949463-n	slk:lemma	národnosť
 01205696-v	slk:lemma	kontaktovať
 13911872-n	slk:lemma	bod
-00750296-s	slk:lemma	elementárny
+00750296-a	slk:lemma	elementárny
 15251600-n	slk:lemma	dvojstoročné výročie
 10002760-n	slk:lemma	demonštrant
 13860793-n	slk:lemma	pevné teleso
@@ -24034,13 +24034,13 @@
 00081737-r	slk:lemma	každý rok
 13658998-n	slk:lemma	decimeter
 00502161-n	slk:lemma	scrabble
-02552222-s	slk:lemma	prirodzene vysušený
+02552222-a	slk:lemma	prirodzene vysušený
 08063650-n	slk:lemma	autopredajca
 10197525-n	slk:lemma	imbecil
 06799897-n	slk:lemma	čiara
-00668053-s	slk:lemma	súčasný
+00668053-a	slk:lemma	súčasný
 05549830-n	slk:lemma	telo
-01314537-s	slk:lemma	dedičný
+01314537-a	slk:lemma	dedičný
 15241186-n	slk:lemma	doba lovu
 02640503-a	slk:lemma	plošný
 10311021-n	slk:lemma	posol
@@ -24048,12 +24048,12 @@
 01635432-v	slk:lemma	vyvolať si v duchu obraz
 15160866-n	slk:lemma	kvartálny deň
 02240481-v	slk:lemma	vyhľadávať
-00418364-s	slk:lemma	dokonale čistý
+00418364-a	slk:lemma	dokonale čistý
 00007846-n	slk:lemma	človek
 07427337-n	slk:lemma	slabnutie
 03115301-n	slk:lemma	niť
 00084223-r	slk:lemma	obzvlášť
-01497245-s	slk:lemma	podstatný
+01497245-a	slk:lemma	podstatný
 10245236-n	slk:lemma	pán domu
 00321731-n	slk:lemma	kvapkanie
 00596644-v	slk:lemma	zažívať
@@ -24071,7 +24071,7 @@
 04205759-n	slk:lemma	strela
 00996485-v	slk:lemma	podpisovať
 09483340-n	slk:lemma	rieka Pearl
-00136884-s	slk:lemma	splatný
+00136884-a	slk:lemma	splatný
 07342049-n	slk:lemma	opakovanie
 05090255-n	slk:lemma	odstup
 00658052-v	slk:lemma	hodnotiť
@@ -24080,14 +24080,14 @@
 06612266-n	slk:lemma	táranie
 00658942-a	slk:lemma	rovinný
 06440102-n	slk:lemma	Kniha proroka Micheáša
-00901060-s	slk:lemma	základný
+00901060-a	slk:lemma	základný
 02132745-v	slk:lemma	okáliť
 00153809-n	slk:lemma	riešenie
 03056368-n	slk:lemma	uhoľná baňa
 07134850-n	slk:lemma	rozprávanie
 10660471-n	slk:lemma	čierny pasažier
 03158668-n	slk:lemma	stena stĺpového podstavca
-01930004-s	slk:lemma	nereagujúci
+01930004-a	slk:lemma	nereagujúci
 00269018-n	slk:lemma	obnova
 02289295-v	slk:lemma	získavať
 02635659-v	slk:lemma	nechávať
@@ -24095,31 +24095,31 @@
 00751567-v	slk:lemma	dávať povel
 09490825-n	slk:lemma	obor ľudožrút
 14890183-n	slk:lemma	milimetrový papier
-00260780-s	slk:lemma	buržoázny
+00260780-a	slk:lemma	buržoázny
 06300193-n	slk:lemma	koreň
-01968352-s	slk:lemma	večerný
+01968352-a	slk:lemma	večerný
 08991182-n	slk:lemma	Samoa
 03678558-n	slk:lemma	nádoba na odpad
 13375323-n	slk:lemma	revolvingový úver
-00279092-s	slk:lemma	lesklý
+00279092-a	slk:lemma	lesklý
 00345641-n	slk:lemma	obrátenie, otočenie
-01564603-s	slk:lemma	nehybný
+01564603-a	slk:lemma	nehybný
 06413889-n	slk:lemma	brožúrka
 00990963-n	slk:lemma	streľba do vlastných radov
 02313008-n	slk:lemma	kráľovná
 08663156-n	slk:lemma	špička
 00642980-v	slk:lemma	integrovať
 00015498-v	slk:lemma	driemať
-00547317-s	slk:lemma	hutný
+00547317-a	slk:lemma	hutný
 01803936-v	slk:lemma	ovládnuť (niekoho)
 00941990-v	slk:lemma	mlieť (ústami)
 00823884-n	slk:lemma	očkovanie
-00766102-s	slk:lemma	rovný
+00766102-a	slk:lemma	rovný
 00386965-v	slk:lemma	prehodiť
 03089014-n	slk:lemma	vedenie
 02798370-a	slk:lemma	sociálny
-01037885-s	slk:lemma	zahraničný
-01626562-s	slk:lemma	hrozný
+01037885-a	slk:lemma	zahraničný
+01626562-a	slk:lemma	hrozný
 02492362-v	slk:lemma	pobaviť sa
 01871680-v	slk:lemma	tlačiť
 04247736-n	slk:lemma	denný bar
@@ -24127,12 +24127,12 @@
 07504841-n	slk:lemma	pozornosť
 06877008-n	slk:lemma	gesto
 06732169-n	slk:lemma	matematický výrok
-00251134-s	slk:lemma	hrdinský
+00251134-a	slk:lemma	hrdinský
 09359150-n	slk:lemma	Moreau
 04664778-n	slk:lemma	ostražitosť
 13997253-n	slk:lemma	poroba
 05122850-n	slk:lemma	minorita
-00444984-s	slk:lemma	priľahlý
+00444984-a	slk:lemma	priľahlý
 07578093-n	slk:lemma	hody
 00910203-n	slk:lemma	prepis
 00509607-v	slk:lemma	pokvapkať
@@ -24150,13 +24150,13 @@
 10236946-n	slk:lemma	príbuzný
 07374633-n	slk:lemma	konsolidácia
 06611376-n	slk:lemma	kravina
-01757211-s	slk:lemma	dočasný
+01757211-a	slk:lemma	dočasný
 02992032-n	slk:lemma	väzenská cela
 01327301-v	slk:lemma	likvidovať
-00377224-s	slk:lemma	orgovánovo modrý
-01948958-s	slk:lemma	delikátny
+00377224-a	slk:lemma	orgovánovo modrý
+01948958-a	slk:lemma	delikátny
 13855627-n	slk:lemma	rozdiel
-02446931-s	slk:lemma	krehký
+02446931-a	slk:lemma	krehký
 00684838-v	slk:lemma	zahrnúť
 02210855-v	slk:lemma	zaobstarávať si
 14828511-n	slk:lemma	cytozín
@@ -24167,21 +24167,21 @@
 08716738-n	slk:lemma	Kambodžské kráľovstvo
 00915830-v	slk:lemma	zašuškať
 14627081-n	slk:lemma	vzácny kov
-01051814-s	slk:lemma	neblahý
+01051814-a	slk:lemma	neblahý
 08212347-n	slk:lemma	robotníci
 00392588-v	slk:lemma	vylepšiť
-00280463-s	slk:lemma	jasný
+00280463-a	slk:lemma	jasný
 03601840-n	slk:lemma	stropný trám
 08949093-n	slk:lemma	Holandské kráľovstvo
 02710402-v	slk:lemma	stretnúť sa
 00055315-n	slk:lemma	opustenie
 07454758-n	slk:lemma	štátnica
-01935744-s	slk:lemma	legendárny
+01935744-a	slk:lemma	legendárny
 01148614-n	slk:lemma	uväznenie
 08477912-n	slk:lemma	ženské pohlavie
 09474663-n	slk:lemma	okolitá hornina
 02089984-v	slk:lemma	točiť
-00766102-s	slk:lemma	otvorený
+00766102-a	slk:lemma	otvorený
 01619231-v	slk:lemma	zrušiť
 02880546-n	slk:lemma	sláčikové nástroje
 02770170-v	slk:lemma	zúriť
@@ -24192,7 +24192,7 @@
 03480863-n	slk:lemma	povraz na dvíhanie a spúšťanie
 02296153-v	slk:lemma	postúpiť
 00042769-r	slk:lemma	žiaľbohu
-00010726-s	slk:lemma	žravý
+00010726-a	slk:lemma	žravý
 02096167-v	slk:lemma	otáčať sa
 03257877-n	slk:lemma	spotrebný tovar s dlhou životnosťou
 09725772-n	slk:lemma	Pakistanec
@@ -24206,7 +24206,7 @@
 00794981-v	slk:lemma	stanovovať lehotu
 00008997-r	slk:lemma	absolútne
 02267060-v	slk:lemma	spotrebovať
-00847715-s	slk:lemma	z milosti
+00847715-a	slk:lemma	z milosti
 12719277-n	slk:lemma	čeľaď žeruchovitých bylín
 01182709-v	slk:lemma	poskytovať
 00798717-v	slk:lemma	zamietnuť
@@ -24216,7 +24216,7 @@
 02024508-v	slk:lemma	zvolať (zasadnutie)
 07829412-n	slk:lemma	omáčka
 02713594-n	slk:lemma	prístavba
-01789117-s	slk:lemma	mramorový
+01789117-a	slk:lemma	mramorový
 00968211-v	slk:lemma	rozchýriť sa
 08388636-n	slk:lemma	zoznam peerov
 06600684-n	slk:lemma	odbočka
@@ -24237,7 +24237,7 @@
 05496802-n	slk:lemma	telencefalon
 01860795-v	slk:lemma	zadržať
 02675935-v	slk:lemma	pokryť (náklady)
-00726317-s	slk:lemma	bezbranný
+00726317-a	slk:lemma	bezbranný
 01568630-v	slk:lemma	potlačiť
 00099089-v	slk:lemma	zahojiť sa
 15271008-n	slk:lemma	prestávka
@@ -24253,7 +24253,7 @@
 00410520-r	slk:lemma	vôbec nie
 14816899-n	slk:lemma	komplementárna DNA
 14498404-n	slk:lemma	znečistenie
-00301951-s	slk:lemma	nespočítateľný
+00301951-a	slk:lemma	nespočítateľný
 00747135-v	slk:lemma	diktovať
 05397468-n	slk:lemma	tkaninový mok
 04008947-n	slk:lemma	hrot
@@ -24271,8 +24271,8 @@
 14276649-n	slk:lemma	zoonóza
 01134781-v	slk:lemma	odpaľovať
 13554800-n	slk:lemma	sekvenčná operácia
-00590271-s	slk:lemma	nervózny
-01367431-s	slk:lemma	veselý
+00590271-a	slk:lemma	nervózny
+01367431-a	slk:lemma	veselý
 02053941-v	slk:lemma	blížiť sa
 02384686-v	slk:lemma	zavolať
 06894544-n	slk:lemma	umelý jazyk
@@ -24283,7 +24283,7 @@
 01418536-v	slk:lemma	obracať
 01528069-v	slk:lemma	vkladať
 00427853-n	slk:lemma	kúpanie
-02218314-s	slk:lemma	všelijaký
+02218314-a	slk:lemma	všelijaký
 09610660-n	slk:lemma	komunikant
 01850315-v	slk:lemma	pohnúť sa
 10193967-n	slk:lemma	ženáč
@@ -24298,10 +24298,10 @@
 00006105-r	slk:lemma	zväčša
 04239074-n	slk:lemma	posúvacie dvere
 10162991-n	slk:lemma	šéf
-00974697-s	slk:lemma	pomalý
+00974697-a	slk:lemma	pomalý
 06833544-n	slk:lemma	W
 08340153-n	slk:lemma	IC
-01149358-s	slk:lemma	rozosmiaty
+01149358-a	slk:lemma	rozosmiaty
 05614175-n	slk:lemma	dôvtip
 04980008-n	slk:lemma	aróma
 02424128-v	slk:lemma	prinucovať
@@ -24311,7 +24311,7 @@
 01070892-n	slk:lemma	potlačenie
 00230331-r	slk:lemma	zvonka
 14304060-n	slk:lemma	syndróm
-02477557-s	slk:lemma	integrovaný
+02477557-a	slk:lemma	integrovaný
 00913705-n	slk:lemma	výroba
 02862444-a	slk:lemma	nukleárny
 00347180-n	slk:lemma	trepanie
@@ -24320,7 +24320,7 @@
 00729108-n	slk:lemma	úloha
 03336839-n	slk:lemma	pilník
 02555126-a	slk:lemma	mokrý
-01384212-s	slk:lemma	šíry
+01384212-a	slk:lemma	šíry
 01675963-v	slk:lemma	zdobiť
 05790758-n	slk:lemma	obľúbenec
 07246742-n	slk:lemma	výčitka
@@ -24357,7 +24357,7 @@
 01494310-v	slk:lemma	položiť
 03426134-n	slk:lemma	benzínová nádrž
 02400139-n	slk:lemma	turovité
-00669853-s	slk:lemma	prekliaty
+00669853-a	slk:lemma	prekliaty
 10418101-n	slk:lemma	zosobnenie
 03327234-n	slk:lemma	ohrada
 09345127-n	slk:lemma	Madeira
@@ -24365,13 +24365,13 @@
 02346136-v	slk:lemma	dovážať
 04164199-n	slk:lemma	horná galéria
 03236735-n	slk:lemma	šaty
-00661640-s	slk:lemma	nasekaný
-00657804-s	slk:lemma	kubický
-01131454-s	slk:lemma	otrasný
+00661640-a	slk:lemma	nasekaný
+00657804-a	slk:lemma	kubický
+01131454-a	slk:lemma	otrasný
 00002942-v	slk:lemma	zrýchlene dýchať
 02159271-n	slk:lemma	trieda Insecta
 15229677-n	slk:lemma	prvá hodina posvätného ofícia
-00527188-s	slk:lemma	celkový
+00527188-a	slk:lemma	celkový
 02669125-a	slk:lemma	brachiálny
 08539893-n	slk:lemma	predmestie
 00066397-n	slk:lemma	chyba
@@ -24379,7 +24379,7 @@
 00992518-v	slk:lemma	podať si ruky
 00806049-v	slk:lemma	prideliť
 08049401-n	slk:lemma	zväz
-00906655-s	slk:lemma	odsudzujúci
+00906655-a	slk:lemma	odsudzujúci
 01992503-v	slk:lemma	pokročiť
 07672135-n	slk:lemma	jedlý tuk
 06767035-n	slk:lemma	uváženie
@@ -24401,7 +24401,7 @@
 14033802-n	slk:lemma	teplota vznietenia
 05770664-n	slk:lemma	vyšší poznávací proces
 02962200-n	slk:lemma	karburátor
-01239410-s	slk:lemma	plazivý
+01239410-a	slk:lemma	plazivý
 04340231-n	slk:lemma	povrchová baňa
 10045454-n	slk:lemma	pedagóg
 15140190-n	slk:lemma	PN
@@ -24414,11 +24414,11 @@
 02942577-n	slk:lemma	medailónik
 10325243-n	slk:lemma	svätý
 02993702-a	slk:lemma	humanitárny
-01294975-s	slk:lemma	budúci
-01632066-s	slk:lemma	obranný
+01294975-a	slk:lemma	budúci
+01632066-a	slk:lemma	obranný
 06667792-n	slk:lemma	právny zákonník
 01931768-v	slk:lemma	usmerňovať
-01722140-s	slk:lemma	opodstatnený
+01722140-a	slk:lemma	opodstatnený
 02061799-a	slk:lemma	idúci na odbyt
 09008333-n	slk:lemma	Kazaň
 04033287-n	slk:lemma	kráľovná
@@ -24426,7 +24426,7 @@
 14180327-n	slk:lemma	svrab
 01404389-v	slk:lemma	odbiť
 01761706-v	slk:lemma	triasť
-01294583-s	slk:lemma	smerujúci dovnútra
+01294583-a	slk:lemma	smerujúci dovnútra
 00066781-r	slk:lemma	dopredu
 03854065-n	slk:lemma	organ
 00871942-v	slk:lemma	naznačovať
@@ -24453,12 +24453,12 @@
 07037465-n	slk:lemma	hudobné dielo
 00951781-n	slk:lemma	komercializácia
 03381126-n	slk:lemma	obuv
-02180277-s	slk:lemma	naozajstný
+02180277-a	slk:lemma	naozajstný
 06155567-n	slk:lemma	história
 09795556-n	slk:lemma	rentiér
 04492264-n	slk:lemma	hlavné železničné spojenie
 00721302-v	slk:lemma	presvedčiť sa
-01807964-s	slk:lemma	rozkošný
+01807964-a	slk:lemma	rozkošný
 09795010-n	slk:lemma	anotátor
 00192836-v	slk:lemma	rozprúdiť
 00463234-v	slk:lemma	skrotiť
@@ -24474,7 +24474,7 @@
 03351434-n	slk:lemma	rybárske náčinie
 01378331-v	slk:lemma	pokrývať rozsievaním
 02692686-v	slk:lemma	predísť
-00611281-s	slk:lemma	bežný
+00611281-a	slk:lemma	bežný
 06642138-n	slk:lemma	správa
 01413871-a	slk:lemma	nepravdepodobný
 09885145-n	slk:lemma	kupujúci
@@ -24486,7 +24486,7 @@
 01012561-v	slk:lemma	dosvedčovať
 10515194-n	slk:lemma	reformista
 06885389-n	slk:lemma	kladná identifikácia
-01415219-s	slk:lemma	nedôležitý
+01415219-a	slk:lemma	nedôležitý
 09285128-n	slk:lemma	rieka Fox
 08355791-n	slk:lemma	vláda Spojených štátov amerických
 13900088-n	slk:lemma	toroid
@@ -24512,7 +24512,7 @@
 01581217-v	slk:lemma	zaplaviť
 10414612-n	slk:lemma	penzista
 07433973-n	slk:lemma	deformácia
-01464700-s	slk:lemma	nežný
+01464700-a	slk:lemma	nežný
 03707597-n	slk:lemma	magnetické nahrávacie zariadenie
 02073041-n	slk:lemma	Sirenia
 04529962-n	slk:lemma	kýlová plocha
@@ -24522,19 +24522,19 @@
 09173777-n	slk:lemma	hora Orizaba
 00040353-v	slk:lemma	vyfintiť sa
 06427831-n	slk:lemma	editácia
-00979366-s	slk:lemma	rýchly
-01789481-s	slk:lemma	pehatý
+00979366-a	slk:lemma	rýchly
+01789481-a	slk:lemma	pehatý
 04096066-n	slk:lemma	cestná komunikácia
 11537506-n	slk:lemma	machovina
 06292000-n	slk:lemma	nadpis
 06669513-n	slk:lemma	dvojaké meradlo
-02367319-s	slk:lemma	extra
+02367319-a	slk:lemma	extra
 00014034-v	slk:lemma	zatriasť sa
 08943242-n	slk:lemma	Martinique
 06290637-n	slk:lemma	tvar
 13371760-n	slk:lemma	zlato
 02575082-v	slk:lemma	zrádzať
-01780596-s	slk:lemma	morálny
+01780596-a	slk:lemma	morálny
 13305673-n	slk:lemma	ocenenie
 02899439-n	slk:lemma	mostík okuliarov
 07601999-n	slk:lemma	čokoláda
@@ -24543,7 +24543,7 @@
 07901587-n	slk:lemma	pijatika
 00062330-r	slk:lemma	vedome
 13937554-n	slk:lemma	odmietnutie
-02395910-s	slk:lemma	božský
+02395910-a	slk:lemma	božský
 08179689-n	slk:lemma	ľud
 00105479-n	slk:lemma	odpal
 00407215-r	slk:lemma	celonárodne
@@ -24559,10 +24559,10 @@
 03051249-n	slk:lemma	kolík na bielizeň
 01211019-n	slk:lemma	povzbudenie
 00502847-r	slk:lemma	milo
-00063953-s	slk:lemma	netaktný
+00063953-a	slk:lemma	netaktný
 07901587-n	slk:lemma	chlast
 10235549-n	slk:lemma	príbuzná osoba
-02215382-s	slk:lemma	svojho druhu
+02215382-a	slk:lemma	svojho druhu
 01807882-v	slk:lemma	lákať
 04847733-n	slk:lemma	ľudská cnosť
 08428019-n	slk:lemma	pochod
@@ -24570,7 +24570,7 @@
 01717117-a	slk:lemma	zrejmý
 01209220-n	slk:lemma	podpora
 13688033-n	slk:lemma	marka
-02388921-s	slk:lemma	domáci
+02388921-a	slk:lemma	domáci
 14438898-n	slk:lemma	povesť
 09870208-n	slk:lemma	pästiar
 06217103-n	slk:lemma	demokracia
@@ -24592,9 +24592,9 @@
 00653620-v	slk:lemma	prirovnať
 00046534-v	slk:lemma	obliekať
 02977822-n	slk:lemma	kord pneumatiky
-02515001-s	slk:lemma	podlý
+02515001-a	slk:lemma	podlý
 15223750-n	slk:lemma	jesenná rovnodennosť
-01610261-s	slk:lemma	neviditeľný
+01610261-a	slk:lemma	neviditeľný
 03119203-n	slk:lemma	vidiecky obchod
 03923918-n	slk:lemma	ihla magnetofónu
 00072012-v	slk:lemma	ísť na stranu (WC, odskočiť si)
@@ -24617,7 +24617,7 @@
 05456082-n	slk:lemma	slepá škvrna
 10277132-n	slk:lemma	obedujúci hosť
 14931879-n	slk:lemma	výlevná hornina
-02415294-s	slk:lemma	tenulinký
+02415294-a	slk:lemma	tenulinký
 04849972-n	slk:lemma	nevinnosť
 05168261-n	slk:lemma	dôležitosť
 02423183-v	slk:lemma	umožniť
@@ -24650,10 +24650,10 @@
 00243918-n	slk:lemma	varenie
 01102436-n	slk:lemma	zverejnenie
 01101913-v	slk:lemma	zdolávať
-00179190-s	slk:lemma	kanonizovaný
+00179190-a	slk:lemma	kanonizovaný
 02171633-n	slk:lemma	Scarabeidae
 08543916-n	slk:lemma	Corn Belt
-02370625-s	slk:lemma	neznámy
+02370625-a	slk:lemma	neznámy
 02707251-v	slk:lemma	vydržať
 01261974-n	slk:lemma	impulz
 14322699-n	slk:lemma	bolesť
@@ -24664,11 +24664,11 @@
 02694933-v	slk:lemma	zameriavať
 01171183-v	slk:lemma	opíjať sa
 09630641-n	slk:lemma	chudák
-01178134-s	slk:lemma	chorobne vyzerajúci
+01178134-a	slk:lemma	chorobne vyzerajúci
 07456638-n	slk:lemma	atletika
 13619307-n	slk:lemma	pinta
 04847733-n	slk:lemma	základná čnosť
-01732601-s	slk:lemma	blížiaci sa
+01732601-a	slk:lemma	blížiaci sa
 00319939-n	slk:lemma	stíhať
 05589756-n	slk:lemma	kostrčový stavec
 01093380-n	slk:lemma	prepočet
@@ -24680,7 +24680,7 @@
 01743605-n	slk:lemma	pytón
 04587648-n	slk:lemma	oblok
 09989290-n	slk:lemma	madam
-00011327-s	slk:lemma	žravý
+00011327-a	slk:lemma	žravý
 06793426-n	slk:lemma	leták
 14325335-n	slk:lemma	bolesť chrbta
 00019448-v	slk:lemma	pôsobiť
@@ -24689,14 +24689,14 @@
 04796086-n	slk:lemma	zvyčajnosť
 00670261-v	slk:lemma	vyhodnocovať
 07467393-n	slk:lemma	semifinále
-01386538-s	slk:lemma	mamutí
+01386538-a	slk:lemma	mamutí
 02955767-n	slk:lemma	plášť
 13289467-n	slk:lemma	podiel
 08507558-n	slk:lemma	počiatok
 08242100-n	slk:lemma	káder
-00282675-s	slk:lemma	mäkký
-00697691-s	slk:lemma	nedefinovateľný
-00432453-s	slk:lemma	jasný
+00282675-a	slk:lemma	mäkký
+00697691-a	slk:lemma	nedefinovateľný
+00432453-a	slk:lemma	jasný
 08082236-n	slk:lemma	kresťanstvo
 00859153-v	slk:lemma	povzbudiť
 07025604-n	slk:lemma	afroamerická hudba
@@ -24711,10 +24711,10 @@
 01108148-v	slk:lemma	premáhať
 02106006-v	slk:lemma	pociťovať
 13434120-n	slk:lemma	asexuálna reprodukcia
-01389170-s	slk:lemma	obrovský
+01389170-a	slk:lemma	obrovský
 00833575-a	slk:lemma	neschopný prevádzky
 04288272-n	slk:lemma	struna
-01159119-s	slk:lemma	intoxikačný
+01159119-a	slk:lemma	intoxikačný
 00223250-v	slk:lemma	dokladať
 01193886-n	slk:lemma	oslobodenie obžalovaného
 01026095-v	slk:lemma	menovať
@@ -24724,11 +24724,11 @@
 08070850-n	slk:lemma	investičná spoločnosť
 01236296-n	slk:lemma	boj
 02166460-v	slk:lemma	zvážiť
-01625063-s	slk:lemma	odporný
-00547317-s	slk:lemma	obsiahnutý
-00304144-s	slk:lemma	divý
+01625063-a	slk:lemma	odporný
+00547317-a	slk:lemma	obsiahnutý
+00304144-a	slk:lemma	divý
 02561332-v	slk:lemma	využívať
-02408977-s	slk:lemma	regionálny
+02408977-a	slk:lemma	regionálny
 00007015-r	slk:lemma	okolo
 03617095-n	slk:lemma	pec
 02790222-a	slk:lemma	roľnícky
@@ -24745,7 +24745,7 @@
 00429964-r	slk:lemma	priskoro
 03009920-n	slk:lemma	námorná mapa
 00348801-n	slk:lemma	trasenie
-02577734-s	slk:lemma	materiálny
+02577734-a	slk:lemma	materiálny
 08236438-n	slk:lemma	združenie
 02519666-v	slk:lemma	poslúchnuť
 05929670-n	slk:lemma	hlavná postava
@@ -24753,14 +24753,14 @@
 05807012-n	slk:lemma	schopnosť
 09324474-n	slk:lemma	rieka Kasai
 00895983-n	slk:lemma	školenie
-00084795-s	slk:lemma	agresívny
-00646117-s	slk:lemma	úžasný
-01625492-s	slk:lemma	strašidelný
+00084795-a	slk:lemma	agresívny
+00646117-a	slk:lemma	úžasný
+01625492-a	slk:lemma	strašidelný
 02157731-v	slk:lemma	zahmlievať
 02031158-v	slk:lemma	rozdeliť
 07214894-n	slk:lemma	odhalenie
 02842445-a	slk:lemma	jazykovedný
-00414354-s	slk:lemma	moderný
+00414354-a	slk:lemma	moderný
 05651399-n	slk:lemma	pamäť
 06518719-n	slk:lemma	lístok
 00641252-v	slk:lemma	strhnúť
@@ -24781,7 +24781,7 @@
 02539101-v	slk:lemma	miešať sa
 09777012-n	slk:lemma	agent
 09692250-n	slk:lemma	Bask
-00448314-s	slk:lemma	bezprostredne blízky
+00448314-a	slk:lemma	bezprostredne blízky
 00027384-r	slk:lemma	a predsa
 02968473-n	slk:lemma	koč
 02880008-n	slk:lemma	prova
@@ -24794,14 +24794,14 @@
 06043075-n	slk:lemma	lekárstvo
 04295881-n	slk:lemma	športový štadión
 02727462-v	slk:lemma	pobudnúť
-01710946-s	slk:lemma	neplatený
+01710946-a	slk:lemma	neplatený
 08954057-n	slk:lemma	Shetlandské ostrovy
 08414964-n	slk:lemma	vyšetrovacia porota
 13383090-n	slk:lemma	šek
 03731882-n	slk:lemma	maliarska palička
 00341560-v	slk:lemma	pokračovať
 04827957-n	slk:lemma	hriech
-02413390-s	slk:lemma	priezračný
+02413390-a	slk:lemma	priezračný
 00782057-v	slk:lemma	naliehavo žiadať
 00072012-v	slk:lemma	pocikať sa
 00742320-v	slk:lemma	odovzdať (informáciu)
@@ -24809,16 +24809,16 @@
 02295979-v	slk:lemma	podriaďovať záujmom obce
 00902932-v	slk:lemma	priať
 05893916-n	slk:lemma	falošná predstava
-00520892-s	slk:lemma	totálny
+00520892-a	slk:lemma	totálny
 02274482-v	slk:lemma	chápať sa
 00831651-v	slk:lemma	oboznamovať
 01826498-v	slk:lemma	uprednostňovať
 13368052-n	slk:lemma	rezerva
-01010271-s	slk:lemma	posledný
+01010271-a	slk:lemma	posledný
 14441825-n	slk:lemma	dominancia
 14407795-n	slk:lemma	posadnutosť
 00050652-v	slk:lemma	obliekať si
-01742119-s	slk:lemma	nenásilný
+01742119-a	slk:lemma	nenásilný
 00583246-n	slk:lemma	profesia
 07294423-n	slk:lemma	zaslúžená odplata
 13740168-n	slk:lemma	šifra
@@ -24837,7 +24837,7 @@
 08407619-n	slk:lemma	výstava
 00065639-v	slk:lemma	trpieť
 08356074-n	slk:lemma	výkonný úrad prezidenta
-01564881-s	slk:lemma	zmrazený
+01564881-a	slk:lemma	zmrazený
 05770926-n	slk:lemma	proces myslenia
 07974025-n	slk:lemma	vrstva
 02653996-v	slk:lemma	postaviť stan
@@ -24865,16 +24865,16 @@
 02283324-v	slk:lemma	uchovať si
 08684294-n	slk:lemma	dvor
 03048883-n	slk:lemma	uzavretý obvod
-02090228-s	slk:lemma	nevyslovený
+02090228-a	slk:lemma	nevyslovený
 12301180-n	slk:lemma	olivovník
-00447472-s	slk:lemma	vedľajší
+00447472-a	slk:lemma	vedľajší
 00273601-n	slk:lemma	pokles
 00690614-v	slk:lemma	vnímať
 00345641-n	slk:lemma	previnutie
 00115554-r	slk:lemma	radšej
 03051307-a	slk:lemma	bulharský
 00939452-n	slk:lemma	skladanie
-00279092-s	slk:lemma	lesknúci sa
+00279092-a	slk:lemma	lesknúci sa
 02615804-a	slk:lemma	amaurotický
 01770501-v	slk:lemma	rozrušiť
 02746841-n	slk:lemma	ateliér
@@ -24888,10 +24888,10 @@
 13305932-n	slk:lemma	kapitálové náklady
 14480772-n	slk:lemma	pevný stav
 02171039-v	slk:lemma	dávať pozor
-02569558-s	slk:lemma	múdry
+02569558-a	slk:lemma	múdry
 00317888-v	slk:lemma	predlžovať
 00926472-v	slk:lemma	predpovedať
-01898722-s	slk:lemma	rozvážny
+01898722-a	slk:lemma	rozvážny
 07254267-n	slk:lemma	rezignácia
 00883139-n	slk:lemma	nadýchnutie
 01356086-n	slk:lemma	rad Eubacteriales
@@ -24903,7 +24903,7 @@
 00796886-n	slk:lemma	podnikanie
 00494269-v	slk:lemma	oddeliť
 05830059-n	slk:lemma	nepríjemnosť
-00687614-s	slk:lemma	údajný
+00687614-a	slk:lemma	údajný
 01916229-a	slk:lemma	diskutabilný
 02066510-v	slk:lemma	vlniť sa
 00004288-r	slk:lemma	negatívne
@@ -24932,14 +24932,14 @@
 03443149-n	slk:lemma	bránková tyč
 02392762-v	slk:lemma	ponechávať
 06471345-n	slk:lemma	doklad
-00294579-s	slk:lemma	nečinný
-02101942-s	slk:lemma	bulvárny
+00294579-a	slk:lemma	nečinný
+02101942-a	slk:lemma	bulvárny
 14937521-n	slk:lemma	sadrovec
 02918112-n	slk:lemma	aréna
 06551627-n	slk:lemma	verejná listina
 01668603-v	slk:lemma	opracovať
 04633197-n	slk:lemma	živosť
-01086453-s	slk:lemma	plný
+01086453-a	slk:lemma	plný
 04934546-n	slk:lemma	hustota
 01448100-v	slk:lemma	vyťahovať
 00031974-a	slk:lemma	aktívny
@@ -24950,7 +24950,7 @@
 01249060-n	slk:lemma	obnovenie
 00256309-n	slk:lemma	opláchnutie
 01280014-v	slk:lemma	skriviť
-01392633-s	slk:lemma	malinký
+01392633-a	slk:lemma	malinký
 14736972-n	slk:lemma	jednoduchý proteín
 06542569-n	slk:lemma	odklad výkonu rozhodnutia
 06688522-n	slk:lemma	memoriál
@@ -24962,14 +24962,14 @@
 07967982-n	slk:lemma	rasa
 09288946-n	slk:lemma	Gila
 01673668-n	slk:lemma	Sauria
-02340458-s	slk:lemma	prostý
+02340458-a	slk:lemma	prostý
 04268799-n	slk:lemma	iskrište
 04796291-n	slk:lemma	obvyklosť
 08696931-n	slk:lemma	európsky národ
-00763272-s	slk:lemma	diverzný
+00763272-a	slk:lemma	diverzný
 00244787-r	slk:lemma	neuveriteľne
 03250588-n	slk:lemma	brúska
-00833018-s	slk:lemma	v prevádzke
+00833018-a	slk:lemma	v prevádzke
 07151380-n	slk:lemma	spôsob vyjadrovania
 02951843-n	slk:lemma	strieška
 00803617-n	slk:lemma	dohľad
@@ -24980,7 +24980,7 @@
 00089351-n	slk:lemma	reštitúcia
 05074774-n	slk:lemma	pozícia
 00475183-v	slk:lemma	oddestilovať
-02020609-s	slk:lemma	monotónny
+02020609-a	slk:lemma	monotónny
 03944024-n	slk:lemma	čap
 00014201-v	slk:lemma	chvieť sa
 03202760-n	slk:lemma	polovodičová dióda
@@ -25004,12 +25004,12 @@
 02444662-v	slk:lemma	dať oprávnenie
 08568978-n	slk:lemma	krajný bod
 09491966-n	slk:lemma	netvor
-02240275-s	slk:lemma	menčestrový
+02240275-a	slk:lemma	menčestrový
 00119578-r	slk:lemma	ale naproti tomu
 14528873-n	slk:lemma	oslobodenie
 00211061-r	slk:lemma	obvykle
 06410904-n	slk:lemma	kniha
-00339742-s	slk:lemma	sebaistý
+00339742-a	slk:lemma	sebaistý
 02205272-v	slk:lemma	brať
 07295391-n	slk:lemma	ukončenie (pracovného) pomeru
 08439022-n	slk:lemma	džungľa
@@ -25020,7 +25020,7 @@
 00227165-v	slk:lemma	umocniť sa
 08989556-n	slk:lemma	Kingstown
 08717209-n	slk:lemma	Kamerun
-00927978-s	slk:lemma	zbavený
+00927978-a	slk:lemma	zbavený
 09163192-n	slk:lemma	Viet Nam
 01320479-n	slk:lemma	netypický počet chromozómov
 00623151-v	slk:lemma	popisovať
@@ -25038,7 +25038,7 @@
 00850425-n	slk:lemma	hybridizácia
 00521296-v	slk:lemma	narušiť
 02640226-v	slk:lemma	pozastavovať sa
-01025212-s	slk:lemma	nezdolný
+01025212-a	slk:lemma	nezdolný
 05568767-n	slk:lemma	lakťový nerv
 15251757-n	slk:lemma	tristoročné jubileum
 02064887-v	slk:lemma	presmerovať
@@ -25085,7 +25085,7 @@
 03519578-n	slk:lemma	hlavná cesta
 02271544-a	slk:lemma	naivný
 00006484-n	slk:lemma	bunka
-01442079-s	slk:lemma	celoročný
+01442079-a	slk:lemma	celoročný
 01209079-n	slk:lemma	sociálna práca
 01235258-n	slk:lemma	odplata
 09405396-n	slk:lemma	bystrina
@@ -25101,7 +25101,7 @@
 01343204-v	slk:lemma	upevniť
 02827606-n	slk:lemma	opasok
 13300828-n	slk:lemma	odškodnenie
-02229961-s	slk:lemma	podriadený
+02229961-a	slk:lemma	podriadený
 00355080-r	slk:lemma	hodne
 10627082-n	slk:lemma	duša
 14285662-n	slk:lemma	zranenie
@@ -25126,20 +25126,20 @@
 11434016-n	slk:lemma	pohroma
 01461822-a	slk:lemma	milovaný
 04538552-n	slk:lemma	zverák
-01074335-s	slk:lemma	soľnonosný
+01074335-a	slk:lemma	soľnonosný
 01715185-v	slk:lemma	odohrať
 07205718-n	slk:lemma	zavrhnutie
 01639714-v	slk:lemma	načrtávať
 04576002-n	slk:lemma	invalidný vozík
 02547586-v	slk:lemma	pomôcť si
 00123170-v	slk:lemma	meniť
-00900071-s	slk:lemma	mystický
+00900071-a	slk:lemma	mystický
 05640729-n	slk:lemma	odbornosť
-01234527-s	slk:lemma	postavený šikmo
-00178811-s	slk:lemma	licencovaný
+01234527-a	slk:lemma	postavený šikmo
+00178811-a	slk:lemma	licencovaný
 00854717-n	slk:lemma	perverzia
 06943558-n	slk:lemma	baltoslovanský jazyk
-01842963-s	slk:lemma	premyslený
+01842963-a	slk:lemma	premyslený
 03894051-n	slk:lemma	detektor častíc
 01590007-v	slk:lemma	oprieť sa
 04649051-n	slk:lemma	žartovnosť
@@ -25150,13 +25150,13 @@
 10857849-n	slk:lemma	Cesare Borgia
 02140033-v	slk:lemma	odkryť
 00817311-v	slk:lemma	pripustiť
-00969264-s	slk:lemma	trochu neobvyklý
+00969264-a	slk:lemma	trochu neobvyklý
 02838592-a	slk:lemma	fotografický
 01619354-v	slk:lemma	pretvárať
 00376994-n	slk:lemma	prasknutie
 02430929-n	slk:lemma	rod jeleň
 00740577-v	slk:lemma	dať na vedomie
-00305700-s	slk:lemma	búrlivý
+00305700-a	slk:lemma	búrlivý
 01672767-n	slk:lemma	Lepidosauria
 00076196-n	slk:lemma	prehrešok
 08190754-n	slk:lemma	vojenská jednotka
@@ -25190,7 +25190,7 @@
 06135806-n	slk:lemma	metrológia
 00443984-v	slk:lemma	taviť sa
 09088718-n	slk:lemma	Salina
-01403760-s	slk:lemma	ilegálny
+01403760-a	slk:lemma	ilegálny
 10006842-n	slk:lemma	utečenec
 13284283-n	slk:lemma	odmena
 00688377-v	slk:lemma	spoľahnúť sa (na)
@@ -25229,21 +25229,21 @@
 08309409-n	slk:lemma	schôdza
 06501311-n	slk:lemma	politika strany
 02208903-v	slk:lemma	najať si
-02229961-s	slk:lemma	otrocký
+02229961-a	slk:lemma	otrocký
 06655388-n	slk:lemma	postup
 09029457-n	slk:lemma	Sudán
-02068730-s	slk:lemma	predchádzajúci
+02068730-a	slk:lemma	predchádzajúci
 00912473-v	slk:lemma	kričať
-02476485-s	slk:lemma	spojenecký
+02476485-a	slk:lemma	spojenecký
 02450505-v	slk:lemma	zabrániť
-01581305-s	slk:lemma	zvyšný
+01581305-a	slk:lemma	zvyšný
 00213186-n	slk:lemma	odstúpenie
 05484862-n	slk:lemma	zadný lalok
 07523180-n	slk:lemma	nesmelosť
-01814711-s	slk:lemma	vládny
+01814711-a	slk:lemma	vládny
 09191635-n	slk:lemma	vzdušná bublina
 09625789-n	slk:lemma	neveriaci
-00348018-s	slk:lemma	statický
+00348018-a	slk:lemma	statický
 07887099-n	slk:lemma	čapované pivo
 01280014-v	slk:lemma	ohýbať
 02231661-v	slk:lemma	komunikovať
@@ -25252,14 +25252,14 @@
 01686439-a	slk:lemma	svojský
 00208273-r	slk:lemma	usilovne
 02345048-v	slk:lemma	vykradnúť
-00329034-s	slk:lemma	rozdelený
+00329034-a	slk:lemma	rozdelený
 00039941-r	slk:lemma	viditeľne
 02218173-v	slk:lemma	vyzdvihnúť
 02603699-v	slk:lemma	jestvovať
 00236989-a	slk:lemma	jednostranný
 09969062-n	slk:lemma	poradca
 02437905-v	slk:lemma	koordinovať
-02503216-s	slk:lemma	neplatný
+02503216-a	slk:lemma	neplatný
 03043274-n	slk:lemma	poliklinika
 14448333-n	slk:lemma	bieda
 00314384-r	slk:lemma	čestne
@@ -25269,11 +25269,11 @@
 01919931-a	slk:lemma	hlučný
 04202417-n	slk:lemma	predajňa
 02641463-v	slk:lemma	zatajiť
-00727113-s	slk:lemma	odkázaný na
+00727113-a	slk:lemma	odkázaný na
 00373544-n	slk:lemma	vzostup
 01822248-v	slk:lemma	vyjadriť účasť
-01114973-s	slk:lemma	úprimný
-02059381-s	slk:lemma	nebezpečný
+01114973-a	slk:lemma	úprimný
+02059381-a	slk:lemma	nebezpečný
 00691944-v	slk:lemma	stotožňovať sa (s)
 02416955-v	slk:lemma	podnikať finančnú operáciu
 01064148-n	slk:lemma	relax
@@ -25294,7 +25294,7 @@
 00706693-v	slk:lemma	predkladať
 13374281-n	slk:lemma	platba v splátkach
 13266170-n	slk:lemma	štipendium
-00919919-s	slk:lemma	nedočkavý
+00919919-a	slk:lemma	nedočkavý
 02133185-v	slk:lemma	všimnúť si
 08212347-n	slk:lemma	ľudia
 02586619-v	slk:lemma	spravovať
@@ -25313,10 +25313,10 @@
 13272545-n	slk:lemma	pozornosť podniku
 13342987-n	slk:lemma	špekulácia
 02670890-v	slk:lemma	slúžiť
-00782216-s	slk:lemma	hmlistý
+00782216-a	slk:lemma	hmlistý
 01070102-v	slk:lemma	komunikovať
 06617866-n	slk:lemma	pomalý pohyb
-01386538-s	slk:lemma	obrovitý
+01386538-a	slk:lemma	obrovitý
 01212882-n	slk:lemma	podpora
 01248852-n	slk:lemma	obnova
 00022099-v	slk:lemma	privádzať k vedomiu
@@ -25326,13 +25326,13 @@
 01684663-v	slk:lemma	maľovať
 10509810-n	slk:lemma	realitný agent
 06609403-n	slk:lemma	nezmysel
-00906099-s	slk:lemma	chválorečný
+00906099-a	slk:lemma	chválorečný
 07351195-n	slk:lemma	pohyb
 07970406-n	slk:lemma	rodinná jednotka
 07054336-n	slk:lemma	baletná hudba
 01453433-v	slk:lemma	vliecť
-00597148-s	slk:lemma	porušený
-01259391-s	slk:lemma	slabý
+00597148-a	slk:lemma	porušený
+01259391-a	slk:lemma	slabý
 01009240-v	slk:lemma	hovoriť
 00334996-v	slk:lemma	prerušovať
 00045092-r	slk:lemma	zoči-voči (niekomu)
@@ -25342,17 +25342,17 @@
 07234657-n	slk:lemma	obviňovanie sa
 02747177-n	slk:lemma	nádoba na popol
 00029378-n	slk:lemma	udalosť
-00526062-s	slk:lemma	celkový
+00526062-a	slk:lemma	celkový
 05551617-n	slk:lemma	mužské prsia
 00182406-v	slk:lemma	dodať
 04854389-n	slk:lemma	nespravodlivosť
 15169421-n	slk:lemma	šero
 07535670-n	slk:lemma	ľutovanie
 01953467-a	slk:lemma	nespracovaný
-01405523-s	slk:lemma	nerozlúštiteľný
+01405523-a	slk:lemma	nerozlúštiteľný
 05162985-n	slk:lemma	nevýhoda
 08236438-n	slk:lemma	konzorcium
-00803432-s	slk:lemma	prenikavý
+00803432-a	slk:lemma	prenikavý
 03081021-n	slk:lemma	element
 14507651-n	slk:lemma	porucha metabolizmu porfyrínu
 02848523-n	slk:lemma	krídlo veterného mlyna
@@ -25364,7 +25364,7 @@
 00007015-r	slk:lemma	asi
 00049003-n	slk:lemma	vstup
 10071139-n	slk:lemma	vyhnanec
-01116118-s	slk:lemma	pravý
+01116118-a	slk:lemma	pravý
 14408086-n	slk:lemma	ťažkosť
 02100709-a	slk:lemma	nižší
 02764378-a	slk:lemma	pomocný
@@ -25372,7 +25372,7 @@
 13807636-n	slk:lemma	sémantický vzťah
 05089947-n	slk:lemma	oddelenie
 14830364-n	slk:lemma	deoxyribonukleová kyselina
-01465214-s	slk:lemma	ľúbostný
+01465214-a	slk:lemma	ľúbostný
 07083732-n	slk:lemma	intonácia
 00505114-r	slk:lemma	jedine že
 01617192-v	slk:lemma	vytvoriť
@@ -25381,14 +25381,14 @@
 01840238-v	slk:lemma	letieť
 01146039-n	slk:lemma	uzda
 00431552-n	slk:lemma	hobby
-02433975-s	slk:lemma	unavený
+02433975-a	slk:lemma	unavený
 01211699-v	slk:lemma	manipulovať
 04906273-n	slk:lemma	poslušnosť
 01841347-v	slk:lemma	uberať sa
-01866812-s	slk:lemma	zbytočný
+01866812-a	slk:lemma	zbytočný
 05321307-n	slk:lemma	vnútorné ucho
-01046226-s	slk:lemma	nárečový
-00724397-s	slk:lemma	istý
+01046226-a	slk:lemma	nárečový
+00724397-a	slk:lemma	istý
 01462005-v	slk:lemma	zlúčiť
 05785067-n	slk:lemma	posúdenie
 02199999-n	slk:lemma	čeľaď komárovité
@@ -25398,14 +25398,14 @@
 13615036-n	slk:lemma	dutá miera
 00422551-n	slk:lemma	mučenie
 03368878-n	slk:lemma	dymový ťah
-02515001-s	slk:lemma	naničhodný
+02515001-a	slk:lemma	naničhodný
 15252021-n	slk:lemma	päťstoročné jubileum
-00010726-s	slk:lemma	vlčí
+00010726-a	slk:lemma	vlčí
 00322488-n	slk:lemma	obalenie
 04799344-n	slk:lemma	zahraničnosť
 02559752-v	slk:lemma	pozastavovať
 00621058-v	slk:lemma	ujasniť
-02394793-s	slk:lemma	neslušný
+02394793-a	slk:lemma	neslušný
 01382086-a	slk:lemma	početný
 00515069-n	slk:lemma	smiešnosť
 02943241-n	slk:lemma	optické šošovky
@@ -25414,7 +25414,7 @@
 06753800-n	slk:lemma	počiatočný úsudok
 07047373-n	slk:lemma	symfonická báseň
 05399847-n	slk:lemma	krv
-01313649-s	slk:lemma	pustý
+01313649-a	slk:lemma	pustý
 00404170-n	slk:lemma	aktualizácia
 00232386-n	slk:lemma	zrušenie
 03044462-a	slk:lemma	arabský
@@ -25441,16 +25441,16 @@
 13602526-n	slk:lemma	elektromagnetická jednotka
 08060878-n	slk:lemma	spoločnosť partnerov
 07863229-n	slk:lemma	opekaná zemiaková kaša s kapustou
-00357556-s	slk:lemma	charakteristický
+00357556-a	slk:lemma	charakteristický
 08732116-n	slk:lemma	Kolumbijská republika
 00335384-n	slk:lemma	sklonenie
 02220461-v	slk:lemma	prepísať (majetok)
 00809654-v	slk:lemma	obísť
 03142636-a	slk:lemma	vredovitý
-01066787-s	slk:lemma	prevažujúci
+01066787-a	slk:lemma	prevažujúci
 07742704-n	slk:lemma	bobuľa
 05303232-n	slk:lemma	krčok maternice
-00158864-s	slk:lemma	pridaný
+00158864-a	slk:lemma	pridaný
 02426799-v	slk:lemma	navracať
 13653902-n	slk:lemma	extrémnosť
 10104209-n	slk:lemma	majster
@@ -25458,9 +25458,9 @@
 10006842-n	slk:lemma	dezertér
 00113009-r	slk:lemma	nanovo
 06277280-n	slk:lemma	televízne vysielanie
-00751099-s	slk:lemma	jednoducho ovládateľný
+00751099-a	slk:lemma	jednoducho ovládateľný
 01522276-v	slk:lemma	namotať si
-00459330-s	slk:lemma	nahý
+00459330-a	slk:lemma	nahý
 03760671-n	slk:lemma	mikroskop
 13098420-n	slk:lemma	žila
 15195477-n	slk:lemma	Pamiatka zosnulých
@@ -25470,14 +25470,14 @@
 03492250-n	slk:lemma	útočisko
 00876874-n	slk:lemma	zmyslové vnímanie
 02256354-v	slk:lemma	vyplatiť
-01732601-s	slk:lemma	budúci
+01732601-a	slk:lemma	budúci
 01199755-v	slk:lemma	vdýchnuť
 02145814-v	slk:lemma	ukryť sa
 01202068-v	slk:lemma	vypiť zhlboka
 05935060-n	slk:lemma	pamäť
 00345761-v	slk:lemma	začínať
 10627082-n	slk:lemma	vedomie
-02090228-s	slk:lemma	tichý
+02090228-a	slk:lemma	tichý
 00595333-n	slk:lemma	úrad starostu
 13470491-n	slk:lemma	pokles
 01111816-v	slk:lemma	bodovať
@@ -25500,7 +25500,7 @@
 00674196-a	slk:lemma	strojový
 10253611-n	slk:lemma	dedič odkazu
 06768735-n	slk:lemma	nesprávne prehlásenie
-00065064-s	slk:lemma	pozitívny
+00065064-a	slk:lemma	pozitívny
 14530061-n	slk:lemma	citlivosť
 09169930-n	slk:lemma	Veľká piesočná púšť
 08971025-n	slk:lemma	Mozambik
@@ -25509,7 +25509,7 @@
 06629392-n	slk:lemma	rozlúčka
 00222479-r	slk:lemma	neskoro
 02857477-n	slk:lemma	penzión
-02449952-s	slk:lemma	otravný
+02449952-a	slk:lemma	otravný
 08674739-n	slk:lemma	kus zeme
 06223669-n	slk:lemma	teizmus
 00599472-n	slk:lemma	povinnosti tajomníka
@@ -25541,7 +25541,7 @@
 05123416-n	slk:lemma	rozmer
 05618056-n	slk:lemma	inteligencia
 09163192-n	slk:lemma	Vietnamská socialistická republika
-01810189-s	slk:lemma	ostrý
+01810189-a	slk:lemma	ostrý
 02294179-v	slk:lemma	deliť
 13903576-n	slk:lemma	obvod
 14202417-n	slk:lemma	nádor
@@ -25562,8 +25562,8 @@
 00372448-n	slk:lemma	uloženie
 06878580-n	slk:lemma	úškrn
 01233993-v	slk:lemma	prikryť strechou
-02229961-s	slk:lemma	špinavý
-00587376-s	slk:lemma	žieravý
+02229961-a	slk:lemma	špinavý
+00587376-a	slk:lemma	žieravý
 07501545-n	slk:lemma	antipatia
 08439955-n	slk:lemma	pracovníci
 02974615-a	slk:lemma	palestínsky
@@ -25578,12 +25578,12 @@
 00072989-v	slk:lemma	vylučovať
 07235335-n	slk:lemma	návrh trestnej žaloby
 05329735-n	slk:lemma	endokrinná žľaza
-02038126-s	slk:lemma	silný
-01065861-s	slk:lemma	narodený ako slobodný občan
+02038126-a	slk:lemma	silný
+01065861-a	slk:lemma	narodený ako slobodný občan
 04496872-n	slk:lemma	pohár
 00085829-n	slk:lemma	zabavenie
-01300661-s	slk:lemma	prísny
-02248693-s	slk:lemma	kultúrny
+01300661-a	slk:lemma	prísny
+02248693-a	slk:lemma	kultúrny
 02321757-v	slk:lemma	ukradnúť
 01642924-v	slk:lemma	vytvoriť
 00584820-a	slk:lemma	konštruktívny
@@ -25611,7 +25611,7 @@
 12689641-n	slk:lemma	čeľaď Erythroxylaceae
 01461328-v	slk:lemma	zostaviť
 02592667-v	slk:lemma	tútorovať
-01462324-s	slk:lemma	milovaný
+01462324-a	slk:lemma	milovaný
 14878483-n	slk:lemma	plyn vo fľaši
 00352331-n	slk:lemma	zníženie
 08965598-n	slk:lemma	Francúzsky Sudán
@@ -25642,11 +25642,11 @@
 00029343-a	slk:lemma	majetnícky
 13329047-n	slk:lemma	daňový odpočet
 01508368-v	slk:lemma	vrhnúť
-01647983-s	slk:lemma	mladistvý
+01647983-a	slk:lemma	mladistvý
 02871858-a	slk:lemma	oblastný
-00179815-s	slk:lemma	nepovolený
-00068180-s	slk:lemma	považovaný
-01580775-s	slk:lemma	predpísaný
+00179815-a	slk:lemma	nepovolený
+00068180-a	slk:lemma	považovaný
+01580775-a	slk:lemma	predpísaný
 00378985-n	slk:lemma	zostavenie
 05701738-n	slk:lemma	nevedomý proces
 01517081-a	slk:lemma	vojenský
@@ -25655,16 +25655,16 @@
 02201644-v	slk:lemma	prideliť
 00842989-v	slk:lemma	obviňovať
 01812720-v	slk:lemma	vdychovať
-02065958-s	slk:lemma	protikladný
+02065958-a	slk:lemma	protikladný
 00057042-r	slk:lemma	vôbec nie
 00156601-v	slk:lemma	pribudnúť
 00340192-n	slk:lemma	predbiehanie
 02572119-v	slk:lemma	šudiť
-02469407-s	slk:lemma	reprezentatívny
+02469407-a	slk:lemma	reprezentatívny
 00907147-v	slk:lemma	sťažovať sa
 00112231-a	slk:lemma	analytický
 08196230-n	slk:lemma	americké vojenské letectvo
-00453053-s	slk:lemma	intímny
+00453053-a	slk:lemma	intímny
 07568706-n	slk:lemma	pokrm z múky
 01496021-a	slk:lemma	minimálny
 00528339-v	slk:lemma	zotavovať sa
@@ -25718,10 +25718,10 @@
 11629501-n	slk:lemma	čeľaď Cupressaceae
 01816431-v	slk:lemma	vyhovovať
 00496127-r	slk:lemma	naschvál
-00856011-s	slk:lemma	emocionálny
+00856011-a	slk:lemma	emocionálny
 14729737-n	slk:lemma	aktomyozín
 01012561-v	slk:lemma	potvrdzovať
-01750386-s	slk:lemma	dokonalý
+01750386-a	slk:lemma	dokonalý
 05752544-n	slk:lemma	získavanie
 01494188-n	slk:lemma	čeľaď Sphyrnidae
 04764741-n	slk:lemma	zvyčajnosť
@@ -25739,7 +25739,7 @@
 01495725-a	slk:lemma	maximálny
 05263029-n	slk:lemma	kozia brada
 00699815-v	slk:lemma	vymedziť
-00590271-s	slk:lemma	nepokojný
+00590271-a	slk:lemma	nepokojný
 10202624-n	slk:lemma	osoba vykonávajúca funkciu
 11466043-n	slk:lemma	teplo
 08888676-n	slk:lemma	Eire
@@ -25755,10 +25755,10 @@
 01534147-v	slk:lemma	zašpiniť
 02771004-n	slk:lemma	spätný kláves
 00647270-n	slk:lemma	kvantitatívna analýza
-02552315-s	slk:lemma	(vy)sušený na vzduchu
+02552315-a	slk:lemma	(vy)sušený na vzduchu
 02034300-v	slk:lemma	odvracať
 04277669-n	slk:lemma	vreteno
-00398978-s	slk:lemma	strakatý
+00398978-a	slk:lemma	strakatý
 09542339-n	slk:lemma	démon
 05891572-n	slk:lemma	schéma
 09466280-n	slk:lemma	vesmír
@@ -25769,9 +25769,9 @@
 02401809-v	slk:lemma	vykopnúť
 00088655-r	slk:lemma	bez prípravy
 13816649-n	slk:lemma	miera
-01936778-s	slk:lemma	fantastický
+01936778-a	slk:lemma	fantastický
 01813499-v	slk:lemma	potešovať
-02032617-s	slk:lemma	pravý krajný
+02032617-a	slk:lemma	pravý krajný
 01041762-v	slk:lemma	predvolať
 08512736-n	slk:lemma	vymedzenie
 10209731-n	slk:lemma	poisťovací agent
@@ -25790,7 +25790,7 @@
 00897241-v	slk:lemma	pozdravovať sa
 06734322-n	slk:lemma	dôkazový materiál
 10148035-n	slk:lemma	ženích
-01523567-s	slk:lemma	pohybujúci sa
+01523567-a	slk:lemma	pohybujúci sa
 00359238-n	slk:lemma	strihanie
 00586598-v	slk:lemma	zadržiavať
 05823054-n	slk:lemma	ospravedlnenie
@@ -25804,12 +25804,12 @@
 01580467-v	slk:lemma	ovíňať
 05702275-n	slk:lemma	pozornosť
 06762380-n	slk:lemma	obmedzenie
-01126841-s	slk:lemma	žalostný
+01126841-a	slk:lemma	žalostný
 00470988-r	slk:lemma	bez ceremónií
 01325451-a	slk:lemma	poučný
 07317764-n	slk:lemma	zlyhanie
 06285559-n	slk:lemma	podraďovacie súvetie
-00168910-s	slk:lemma	budiaci dôveru
+00168910-a	slk:lemma	budiaci dôveru
 13440935-n	slk:lemma	Booleova operácia
 02027612-v	slk:lemma	zhromažďovať sa
 15209413-n	slk:lemma	kalendárny mesiac
@@ -25824,7 +25824,7 @@
 02478701-v	slk:lemma	potvrdzovať platnosť
 00313647-n	slk:lemma	cestovanie na lodi
 13289020-n	slk:lemma	podielnictvo na zisku
-02552415-s	slk:lemma	suchý
+02552415-a	slk:lemma	suchý
 01219827-a	slk:lemma	náš
 00017881-r	slk:lemma	v tom istom okamihu
 01156834-v	slk:lemma	dať si (niečo na zjedenie)
@@ -25832,7 +25832,7 @@
 00466524-n	slk:lemma	hra na údery
 09010453-n	slk:lemma	Čeľabinsk
 09622302-n	slk:lemma	milovník
-02023430-s	slk:lemma	chudobný
+02023430-a	slk:lemma	chudobný
 09762509-n	slk:lemma	majster
 03227184-n	slk:lemma	dvojkrídlové okno
 09268236-n	slk:lemma	Dneper
@@ -25844,7 +25844,7 @@
 00622384-v	slk:lemma	vyviesť z konceptu
 13385913-n	slk:lemma	peňažná mena
 10650162-n	slk:lemma	štátnik
-01465214-s	slk:lemma	romantický
+01465214-a	slk:lemma	romantický
 00737188-n	slk:lemma	nenormálnosť
 00072586-v	slk:lemma	močiť
 00077419-n	slk:lemma	získavanie
@@ -25852,11 +25852,11 @@
 06497872-n	slk:lemma	latinka
 00087188-r	slk:lemma	energicky
 04625129-n	slk:lemma	stavovské sebavedomie
-00032497-s	slk:lemma	gymnastický
+00032497-a	slk:lemma	gymnastický
 02715229-n	slk:lemma	anténa
 14103288-n	slk:lemma	ochorenie srdca
 07184149-n	slk:lemma	škriepka
-02398378-s	slk:lemma	korenistý
+02398378-a	slk:lemma	korenistý
 06138582-n	slk:lemma	poznávacia psychológia
 11450566-n	slk:lemma	elektrika
 01013367-v	slk:lemma	klásť dôraz
@@ -25875,7 +25875,7 @@
 04074482-n	slk:lemma	terapia
 00023244-v	slk:lemma	odenergizovať
 05565337-n	slk:lemma	pravica
-01781076-s	slk:lemma	duševný
+01781076-a	slk:lemma	duševný
 13914608-n	slk:lemma	blok
 05939636-n	slk:lemma	klamná predstava
 14796073-n	slk:lemma	fenol
@@ -25909,8 +25909,8 @@
 09010785-n	slk:lemma	Nová Zem
 15238472-n	slk:lemma	doba prázdnin
 02201644-v	slk:lemma	podeliť
-02414323-s	slk:lemma	veľmi jemný
-00482673-s	slk:lemma	relatívny
+02414323-a	slk:lemma	veľmi jemný
+00482673-a	slk:lemma	relatívny
 01990281-v	slk:lemma	vynárať sa
 07888378-n	slk:lemma	hostinec
 13957601-n	slk:lemma	prítomnosť
@@ -25921,7 +25921,7 @@
 00005815-v	slk:lemma	kašľať
 00005779-r	slk:lemma	ohromne
 10276764-n	slk:lemma	šaľo
-01366062-s	slk:lemma	žalostný
+01366062-a	slk:lemma	žalostný
 00196485-n	slk:lemma	nahradzovanie
 00223362-n	slk:lemma	harikari, seppuku
 00910555-v	slk:lemma	protestovať
@@ -25940,7 +25940,7 @@
 13300411-n	slk:lemma	omeškanie platby
 10025730-n	slk:lemma	donátor
 08887841-n	slk:lemma	Severné Írsko
-01612627-s	slk:lemma	súhlasiaci
+01612627-a	slk:lemma	súhlasiaci
 01113806-v	slk:lemma	prehrávať
 01857717-v	slk:lemma	rozbehnúť
 00657604-n	slk:lemma	zdravotná starostlivosť
@@ -25948,7 +25948,7 @@
 00069531-a	slk:lemma	estetický
 02313250-v	slk:lemma	zbavovať
 02208903-v	slk:lemma	požičať
-00360950-s	slk:lemma	celibátny
+00360950-a	slk:lemma	celibátny
 03048883-n	slk:lemma	CC - uzatvorený obvod
 05261404-n	slk:lemma	ochlpenie tváre
 14074041-n	slk:lemma	zdravotná komplikácia
@@ -25966,18 +25966,18 @@
 08160276-n	slk:lemma	občania
 01028655-n	slk:lemma	uctievanie
 00390842-v	slk:lemma	zakrývať
-01697878-s	slk:lemma	zaliaty slnkom
+01697878-a	slk:lemma	zaliaty slnkom
 00248534-n	slk:lemma	solenie
 12202712-n	slk:lemma	Tilia
 00630380-v	slk:lemma	uvažovať o
-00602563-s	slk:lemma	polemický
+00602563-a	slk:lemma	polemický
 15242955-n	slk:lemma	veky
 01078783-v	slk:lemma	čeliť
 08365344-n	slk:lemma	netrhová ekonomika
 05841351-n	slk:lemma	architektonický štýl
 07251779-n	slk:lemma	potlesk
 02502085-n	slk:lemma	Dermoptera
-00358534-s	slk:lemma	elektronegatívny
+00358534-a	slk:lemma	elektronegatívny
 01759326-v	slk:lemma	podnecovať
 03797182-n	slk:lemma	šatka
 09428293-n	slk:lemma	breh, morský
@@ -26023,17 +26023,17 @@
 08929922-n	slk:lemma	Francúzsko
 09463721-n	slk:lemma	Tupungato
 01762525-n	slk:lemma	rod článkonožcov
-01066787-s	slk:lemma	prevažný
+01066787-a	slk:lemma	prevažný
 10345804-n	slk:lemma	narátor
 02099669-v	slk:lemma	prehrabnúť si
 09918762-n	slk:lemma	potomok
-02101942-s	slk:lemma	škandalózny
+02101942-a	slk:lemma	škandalózny
 07492516-n	slk:lemma	radosť
 00844298-v	slk:lemma	posťažovať sa
 09176608-n	slk:lemma	Mauna Loa
 02663643-v	slk:lemma	záležať na
 06338908-n	slk:lemma	označenie
-00413861-s	slk:lemma	klasický
+00413861-a	slk:lemma	klasický
 08276539-n	slk:lemma	predškolské zariadenie
 02163746-v	slk:lemma	vyšpehovať
 09605289-n	slk:lemma	dospelý
@@ -26052,7 +26052,7 @@
 00376063-n	slk:lemma	obmena
 01056411-n	slk:lemma	zastávka
 00754280-n	slk:lemma	habaďúra
-01940651-s	slk:lemma	pragmatický
+01940651-a	slk:lemma	pragmatický
 06598915-n	slk:lemma	obsah
 01686956-v	slk:lemma	vyobraziť
 02971940-n	slk:lemma	gramofónová prenoska
@@ -26070,13 +26070,13 @@
 02224055-v	slk:lemma	zbavovať sa
 00073897-r	slk:lemma	predovšetkým
 05238036-n	slk:lemma	puzdro
-01533535-s	slk:lemma	priveľký
+01533535-a	slk:lemma	priveľký
 03100490-n	slk:lemma	dopravný prostriedok
 07092158-n	slk:lemma	literárny žáner
 00509846-n	slk:lemma	veselosť
 01810466-n	slk:lemma	rad Columbiformes
 10116370-n	slk:lemma	konzervatívec
-00195684-s	slk:lemma	desivý
+00195684-a	slk:lemma	desivý
 13775523-n	slk:lemma	lodný náklad
 02037272-a	slk:lemma	bezcharakterný
 05016171-n	slk:lemma	páľava
@@ -26085,10 +26085,10 @@
 09369692-n	slk:lemma	neutrónová hviezda
 13512725-n	slk:lemma	meiotické delenie
 00017865-v	slk:lemma	ísť spať
-02570046-s	slk:lemma	múdry
+02570046-a	slk:lemma	múdry
 05871362-n	slk:lemma	základ
 05017909-n	slk:lemma	nedohľadnosť
-02507772-s	slk:lemma	univerzálny
+02507772-a	slk:lemma	univerzálny
 03099454-n	slk:lemma	kláštor
 07035598-n	slk:lemma	černošský spirituál
 00965687-v	slk:lemma	dostaviť sa
@@ -26115,7 +26115,7 @@
 00419685-v	slk:lemma	povoľovať
 08482113-n	slk:lemma	krídlo
 01481599-n	slk:lemma	podtrieda pásožiabrovce
-00063953-s	slk:lemma	hlúpy
+00063953-a	slk:lemma	hlúpy
 00331461-r	slk:lemma	pravidelne
 00039318-r	slk:lemma	samozrejme
 01131993-n	slk:lemma	pestúnska starostlivosť
@@ -26178,12 +26178,12 @@
 09145655-n	slk:lemma	Odessa
 09973624-n	slk:lemma	kormidelník
 03473966-n	slk:lemma	rúcho
-00974519-s	slk:lemma	staromódny
+00974519-a	slk:lemma	staromódny
 08540903-n	slk:lemma	mesto
 01782650-v	slk:lemma	desiť sa
 01111028-v	slk:lemma	prebojúvať
 00074624-n	slk:lemma	zabudnutie
-00910101-s	slk:lemma	rovinný
+00910101-a	slk:lemma	rovinný
 01712704-v	slk:lemma	urobiť
 00752954-n	slk:lemma	úskok
 13002433-n	slk:lemma	rod Amanita
@@ -26210,15 +26210,15 @@
 00399223-n	slk:lemma	zmena
 01902783-v	slk:lemma	doletieť po vetri
 05565337-n	slk:lemma	pravá ruka
-01625063-s	slk:lemma	odpudzujúci
-01520091-s	slk:lemma	úplný
+01625063-a	slk:lemma	odpudzujúci
+01520091-a	slk:lemma	úplný
 08834654-n	slk:lemma	Západná Austrália
 06998748-n	slk:lemma	vizuálna zložka
 14732472-n	slk:lemma	rohovina
 05808557-n	slk:lemma	lingvistický proces
 01194711-n	slk:lemma	faktická evikcia
 08910668-n	slk:lemma	Perzia
-02074929-s	slk:lemma	hlúpy
+02074929-a	slk:lemma	hlúpy
 00833702-v	slk:lemma	trénovať
 00345761-v	slk:lemma	dávať sa
 00796886-n	slk:lemma	úsilie
@@ -26229,7 +26229,7 @@
 01097192-v	slk:lemma	naverbovať
 09977660-n	slk:lemma	zločinec
 06379439-n	slk:lemma	selanka
-02130821-s	slk:lemma	váhavý
+02130821-a	slk:lemma	váhavý
 02926188-a	slk:lemma	magnetický
 00798539-v	slk:lemma	odvrhovať
 00212678-n	slk:lemma	labutia pieseň
@@ -26251,7 +26251,7 @@
 09632518-n	slk:lemma	pracovník
 00528339-v	slk:lemma	spamätať sa
 13858392-n	slk:lemma	rozpor
-00382173-s	slk:lemma	ružový
+00382173-a	slk:lemma	ružový
 13592219-n	slk:lemma	počet mŕtvych
 00387310-v	slk:lemma	obrátiť
 00770270-n	slk:lemma	prestúpenie
@@ -26268,23 +26268,23 @@
 09712195-n	slk:lemma	Guatemalčan
 01463963-v	slk:lemma	organizovať
 06439408-n	slk:lemma	Joel
-01181446-s	slk:lemma	svetácky
+01181446-a	slk:lemma	svetácky
 02732433-n	slk:lemma	akvadukt
-02521036-s	slk:lemma	dobrovoľný
+02521036-a	slk:lemma	dobrovoľný
 00769944-n	slk:lemma	únos dopravného prostriedku
 00851994-n	slk:lemma	regulácia pôrodnosti
 00477941-v	slk:lemma	zhyzdiť
-00048858-s	slk:lemma	prídavný
+00048858-a	slk:lemma	prídavný
 00813044-v	slk:lemma	rozvážiť si
 06833776-n	slk:lemma	ypsilon, tvrdé y
-00714763-s	slk:lemma	želací
+00714763-a	slk:lemma	želací
 00550771-n	slk:lemma	stvárnenie
 00269018-n	slk:lemma	kultivácia
 01535246-v	slk:lemma	oprať
 03077419-a	slk:lemma	žurnalistický
 05713737-n	slk:lemma	čuchové vnímanie
-01074335-s	slk:lemma	obsahujúci soľ
-02126430-s	slk:lemma	situovaný
+01074335-a	slk:lemma	obsahujúci soľ
+02126430-a	slk:lemma	situovaný
 00871942-v	slk:lemma	zvestúvať
 04743024-n	slk:lemma	identickosť
 03120491-n	slk:lemma	dvorec
@@ -26305,7 +26305,7 @@
 04413631-n	slk:lemma	konečná stanica
 00293307-n	slk:lemma	brodenie sa
 01458302-n	slk:lemma	bičík
-01153595-s	slk:lemma	pripomínajúci bavlnu
+01153595-a	slk:lemma	pripomínajúci bavlnu
 07223450-n	slk:lemma	reči
 00003431-v	slk:lemma	rihať
 14442933-n	slk:lemma	domínium
@@ -26325,13 +26325,13 @@
 03025070-n	slk:lemma	basa
 01245813-n	slk:lemma	hod kockou
 02419773-v	slk:lemma	narobiť sa
-00934966-s	slk:lemma	lacný
+00934966-a	slk:lemma	lacný
 00063630-r	slk:lemma	dohromady
 09175322-n	slk:lemma	Pasto
 07237409-n	slk:lemma	žaloba
 00694068-v	slk:lemma	ceniť si
 01570935-v	slk:lemma	zaškrtiť
-02384077-s	slk:lemma	mnohovravný
+02384077-a	slk:lemma	mnohovravný
 01339730-a	slk:lemma	navrhnutý
 00501140-r	slk:lemma	zásadne
 13419325-n	slk:lemma	konvertibilný cenný papier
@@ -26343,15 +26343,15 @@
 08651832-n	slk:lemma	brlohy
 00266806-n	slk:lemma	oprava
 00289860-r	slk:lemma	skrátka
-01991586-s	slk:lemma	verný
+01991586-a	slk:lemma	verný
 00372226-n	slk:lemma	hromadenie
 02916350-n	slk:lemma	projektil
 03240892-n	slk:lemma	stĺpová vŕtačka
 04295881-n	slk:lemma	aréna
-02241988-s	slk:lemma	skalnatý
+02241988-a	slk:lemma	skalnatý
 10060621-n	slk:lemma	enviromentalista
 00257864-r	slk:lemma	od slova do slova
-01038332-s	slk:lemma	interný
+01038332-a	slk:lemma	interný
 07541760-n	slk:lemma	spokojnosť
 05694791-n	slk:lemma	zvádzanie
 02267529-v	slk:lemma	utratiť
@@ -26359,7 +26359,7 @@
 00721431-n	slk:lemma	postavenie
 06507941-n	slk:lemma	lístok na výsledky
 00523513-n	slk:lemma	šport
-02562705-s	slk:lemma	tesný
+02562705-a	slk:lemma	tesný
 04407435-n	slk:lemma	chrám
 00499263-n	slk:lemma	pingpong
 02894605-n	slk:lemma	hrádza
@@ -26408,8 +26408,8 @@
 04442831-n	slk:lemma	tabakové listy
 15005716-n	slk:lemma	strešná krytina
 00223500-v	slk:lemma	vysiľovať
-02574481-s	slk:lemma	lesný
-01263971-s	slk:lemma	chladnokrvný
+02574481-a	slk:lemma	lesný
+01263971-a	slk:lemma	chladnokrvný
 09421191-n	slk:lemma	rieka Sambre
 14422035-n	slk:lemma	kontinuita
 02681518-n	slk:lemma	okrasa
@@ -26431,7 +26431,7 @@
 03706415-n	slk:lemma	magnetická pamäť
 01484097-n	slk:lemma	žralok mako
 07143624-n	slk:lemma	konzultácia
-01126291-s	slk:lemma	hnusný
+01126291-a	slk:lemma	hnusný
 00158996-n	slk:lemma	hypnotizmus
 03728437-n	slk:lemma	zápalka
 01850315-v	slk:lemma	posúvať sa
@@ -26441,10 +26441,10 @@
 01534147-v	slk:lemma	zabrýzgať sa
 04158138-n	slk:lemma	pohár
 05413465-n	slk:lemma	tyreokalcitonín
-02369027-s	slk:lemma	horký
+02369027-a	slk:lemma	horký
 05146178-n	slk:lemma	vymeranie daní
-01024228-s	slk:lemma	pružný
-00969556-s	slk:lemma	kuriózny
+01024228-a	slk:lemma	pružný
+00969556-a	slk:lemma	kuriózny
 00081072-v	slk:lemma	podávať
 02297142-v	slk:lemma	podávať
 02324182-v	slk:lemma	požičať
@@ -26454,7 +26454,7 @@
 00306900-n	slk:lemma	etapa
 00479076-n	slk:lemma	ihrisková hra
 00056930-v	slk:lemma	porodiť
-02298152-s	slk:lemma	klasický
+02298152-a	slk:lemma	klasický
 09886220-n	slk:lemma	darebák
 04379243-n	slk:lemma	stôl
 08606370-n	slk:lemma	Národný park Katmai
@@ -26476,11 +26476,11 @@
 09379111-n	slk:lemma	otvor
 00220522-n	slk:lemma	zabíjanie
 01522376-a	slk:lemma	mobilný
-02502578-s	slk:lemma	nepotrebný
+02502578-a	slk:lemma	nepotrebný
 13721695-n	slk:lemma	kilotona
 05321917-n	slk:lemma	kostený labyrint
 07024929-n	slk:lemma	polyfónna hudba
-01950198-s	slk:lemma	drsný
+01950198-a	slk:lemma	drsný
 00784083-n	slk:lemma	drobná krádež
 00713952-n	slk:lemma	nakladanie
 01467370-v	slk:lemma	olemovať
@@ -26488,9 +26488,9 @@
 03530910-n	slk:lemma	opláštenie
 14395240-n	slk:lemma	nepríčetnosť
 01976220-v	slk:lemma	namáčať
-00294579-s	slk:lemma	ľahostajný
+00294579-a	slk:lemma	ľahostajný
 04230808-n	slk:lemma	sukňa
-00793592-s	slk:lemma	druhotriedny
+00793592-a	slk:lemma	druhotriedny
 12916935-n	slk:lemma	čeľaď Euphorbiaceae
 09018848-n	slk:lemma	Gruzínsko
 02575082-v	slk:lemma	oklamať
@@ -26517,8 +26517,8 @@
 00623151-v	slk:lemma	popísať
 03400231-n	slk:lemma	pekáč
 02727883-v	slk:lemma	predať sa
-00282675-s	slk:lemma	hladký
-00447472-s	slk:lemma	priľahlý
+00282675-a	slk:lemma	hladký
+00447472-a	slk:lemma	priľahlý
 03931044-n	slk:lemma	obraz
 01359303-v	slk:lemma	povoľovať
 02456493-v	slk:lemma	uložiť do hrobu
@@ -26532,9 +26532,9 @@
 00775831-v	slk:lemma	vzpierať sa
 02740764-n	slk:lemma	pancierová doska
 13398953-n	slk:lemma	úver
-00848466-s	slk:lemma	obligatórny
+00848466-a	slk:lemma	obligatórny
 00894552-n	slk:lemma	cvik
-01710543-s	slk:lemma	splatný
+01710543-a	slk:lemma	splatný
 02613275-v	slk:lemma	vykonať pobožnosť
 00191142-n	slk:lemma	zámena
 07155661-n	slk:lemma	nárečie
@@ -26571,18 +26571,18 @@
 10480253-n	slk:lemma	profesionál
 13993210-n	slk:lemma	domáce pravidlo
 13300922-n	slk:lemma	trest
-01509066-s	slk:lemma	mierny
+01509066-a	slk:lemma	mierny
 01871949-a	slk:lemma	nevýhodný
 02108026-v	slk:lemma	vytrpieť si
 02351010-v	slk:lemma	oceňovať
 00879271-n	slk:lemma	revízia
-01523567-s	slk:lemma	pohyblivý
+01523567-a	slk:lemma	pohyblivý
 00150432-r	slk:lemma	celkom
 00909219-v	slk:lemma	nadávať
 00229605-v	slk:lemma	pozdvihovať na vyššiu úroveň
 14016361-n	slk:lemma	malátnosť
 07208338-n	slk:lemma	protestovanie
-02506922-s	slk:lemma	mnohostranný
+02506922-a	slk:lemma	mnohostranný
 07695965-n	slk:lemma	obložený chlieb
 01821996-v	slk:lemma	ľutovať (niekoho)
 08592656-n	slk:lemma	demarkačná línia
@@ -26594,7 +26594,7 @@
 14001031-n	slk:lemma	osobná nezávislosť
 00806314-v	slk:lemma	podporiť
 01857392-v	slk:lemma	pobudnúť
-02110778-s	slk:lemma	nespojitý
+02110778-a	slk:lemma	nespojitý
 05154517-n	slk:lemma	plus
 14510955-n	slk:lemma	otrava námeľom
 09629477-n	slk:lemma	predavač cestov. lístkov
@@ -26603,32 +26603,32 @@
 15169421-n	slk:lemma	mrk
 13365137-n	slk:lemma	depozitný certifikát
 02100709-a	slk:lemma	mladší
-01431112-s	slk:lemma	nezmyselný
+01431112-a	slk:lemma	nezmyselný
 10630188-n	slk:lemma	rečník
 01378123-v	slk:lemma	trúsiť
 00123170-v	slk:lemma	zmeniť si
 00252019-v	slk:lemma	rozvíjať
 08486971-n	slk:lemma	Svetová organizácia obchodu
 00988028-v	slk:lemma	stelesňovať
-02062133-s	slk:lemma	na predaj
+02062133-a	slk:lemma	na predaj
 00806484-n	slk:lemma	kontrola akosti
 00964694-v	slk:lemma	prediskutovať
 02079029-a	slk:lemma	sarkastický
-01140054-s	slk:lemma	príjemný
-01591394-s	slk:lemma	panovnícky
+01140054-a	slk:lemma	príjemný
+01591394-a	slk:lemma	panovnícky
 07370125-n	slk:lemma	vstup
 10083823-n	slk:lemma	aristokratka
 00378365-r	slk:lemma	úprimne
 00888693-n	slk:lemma	školské vyučovanie
-01648491-s	slk:lemma	detský
+01648491-a	slk:lemma	detský
 04160847-n	slk:lemma	reflektor
-00552089-s	slk:lemma	vykonaný
+00552089-a	slk:lemma	vykonaný
 01209135-v	slk:lemma	zasiahnuť
 08364959-n	slk:lemma	trhová ekonomika
 09926426-n	slk:lemma	klasik
 10753779-n	slk:lemma	podliak
 05474738-n	slk:lemma	odstredivý nerv
-01074335-s	slk:lemma	bohatý na soľ
+01074335-a	slk:lemma	bohatý na soľ
 00966809-v	slk:lemma	ohlásiť
 15251336-n	slk:lemma	sté výročie
 01467370-v	slk:lemma	ohraničovať
@@ -26637,7 +26637,7 @@
 07933274-n	slk:lemma	čaj
 03416094-n	slk:lemma	portál žeriava
 00325343-r	slk:lemma	zboku
-02517169-s	slk:lemma	preskúmateľný
+02517169-a	slk:lemma	preskúmateľný
 02469835-v	slk:lemma	zjednocovať sa
 00057257-r	slk:lemma	podrobne
 10111023-n	slk:lemma	slobodný človek
@@ -26650,10 +26650,10 @@
 14966667-n	slk:lemma	olej
 08511241-n	slk:lemma	rub
 02083806-v	slk:lemma	rozkývať sa
-01419462-s	slk:lemma	obdobný
+01419462-a	slk:lemma	obdobný
 08434259-n	slk:lemma	sieť
-02018649-s	slk:lemma	všedný
-01009206-s	slk:lemma	začínajúci
+02018649-a	slk:lemma	všedný
+01009206-a	slk:lemma	začínajúci
 09243100-n	slk:lemma	Coeur d'Alene
 00493703-v	slk:lemma	devalvovať
 00052791-n	slk:lemma	núdzové pristátie
@@ -26677,31 +26677,31 @@
 12694707-n	slk:lemma	čeľaď mahagónových stromov a kríkov
 01171183-v	slk:lemma	srknúť si
 14687633-n	slk:lemma	ľahký petrolej
-02397496-s	slk:lemma	korenistý
+02397496-a	slk:lemma	korenistý
 00165942-n	slk:lemma	akcia
 13622451-n	slk:lemma	peck
 08710678-n	slk:lemma	Bermudské ostrovy
 05728493-n	slk:lemma	dátová štruktúra
 03532672-n	slk:lemma	háčik
 00074790-n	slk:lemma	sprostosť
-01335903-s	slk:lemma	rýchly
+01335903-a	slk:lemma	rýchly
 00318816-v	slk:lemma	predlžovať
 02785874-a	slk:lemma	oblastný
 03313873-n	slk:lemma	plocha
 00831074-v	slk:lemma	dávať inštrukcie
-00167077-s	slk:lemma	príťažlivý
+00167077-a	slk:lemma	príťažlivý
 02444662-v	slk:lemma	poveriť
 10677713-n	slk:lemma	sponzor
 01975138-a	slk:lemma	podstatný
 01101913-v	slk:lemma	víťaziť
-00475308-s	slk:lemma	zapálený
+00475308-a	slk:lemma	zapálený
 00363493-v	slk:lemma	zastaviť
 15211806-n	slk:lemma	jún
 00732037-a	slk:lemma	neutrálny
 01970826-v	slk:lemma	poklesnúť
 10667187-n	slk:lemma	idiot
 07212190-n	slk:lemma	informovanie
-01901186-s	slk:lemma	opozdený
+01901186-a	slk:lemma	opozdený
 03777283-n	slk:lemma	napodobenina
 10564905-n	slk:lemma	autor textu
 02068735-n	slk:lemma	čeľaď delfínovité
@@ -26722,24 +26722,24 @@
 00124008-n	slk:lemma	pozdĺžne ostreľovanie
 03992703-n	slk:lemma	keramické výrobky
 01101913-v	slk:lemma	premôcť
-01487943-s	slk:lemma	kľúčový
+01487943-a	slk:lemma	kľúčový
 03686658-n	slk:lemma	rýchlomer
 08223802-n	slk:lemma	komunita
-01977488-s	slk:lemma	starostlivý
+01977488-a	slk:lemma	starostlivý
 02443849-v	slk:lemma	uvádzať do činnosti
 00062806-n	slk:lemma	dosiahnutie
 10028638-n	slk:lemma	vojenský zbeh
 01027379-n	slk:lemma	ceremónia
 00975452-n	slk:lemma	preniknutie
-01309657-s	slk:lemma	nepoučený
-01802774-s	slk:lemma	strašný
+01309657-a	slk:lemma	nepoučený
+01802774-a	slk:lemma	strašný
 10779504-n	slk:lemma	obchodník s bielym mäsom
 00276813-n	slk:lemma	znečisťovanie
 01212882-n	slk:lemma	priľnavosť
 02578510-v	slk:lemma	dodržiavať
 02522864-v	slk:lemma	zdolávať
 00264775-n	slk:lemma	humanizácia
-00798103-s	slk:lemma	nadratý
+00798103-a	slk:lemma	nadratý
 00193486-v	slk:lemma	kombinovať
 13512725-n	slk:lemma	redukčné delenie
 03975232-n	slk:lemma	ručička
@@ -26758,7 +26758,7 @@
 15153787-n	slk:lemma	staroba
 00927017-a	slk:lemma	existujúci
 03673767-n	slk:lemma	podšívka
-01674134-s	slk:lemma	hotový
+01674134-a	slk:lemma	hotový
 08703035-n	slk:lemma	krajina v Strednej Amerike
 01280488-v	slk:lemma	ohnúť
 07770571-n	slk:lemma	jedlé semená rastlín
@@ -26770,7 +26770,7 @@
 15163797-n	slk:lemma	nedeľa
 02231661-v	slk:lemma	odovzdávať
 00518395-v	slk:lemma	pomáhať
-02097480-s	slk:lemma	zvodný
+02097480-a	slk:lemma	zvodný
 08737041-n	slk:lemma	Guatemala
 02349212-v	slk:lemma	odovzdať
 00415963-r	slk:lemma	príliš veľa
@@ -26779,7 +26779,7 @@
 01127245-n	slk:lemma	nátlak silou
 00213186-n	slk:lemma	zrieknutie sa
 02620587-v	slk:lemma	tvoriť
-02074673-s	slk:lemma	zúrivý
+02074673-a	slk:lemma	zúrivý
 03427656-n	slk:lemma	logické hradlo
 00307631-n	slk:lemma	jazda
 05120116-n	slk:lemma	nadbytok
@@ -26803,7 +26803,7 @@
 13417071-n	slk:lemma	akcia na meno
 02502902-n	slk:lemma	rad Proboscidea
 03314378-n	slk:lemma	ochranná maska
-00027599-s	slk:lemma	prijímaný
+00027599-a	slk:lemma	prijímaný
 01578993-v	slk:lemma	nabrať
 01523105-v	slk:lemma	natáčať
 00793037-v	slk:lemma	zvolať
@@ -26811,14 +26811,14 @@
 08759013-n	slk:lemma	Slovenská republika
 02953420-a	slk:lemma	ortodoxný
 03773268-n	slk:lemma	scénografia
-01423851-s	slk:lemma	obývateľný
+01423851-a	slk:lemma	obývateľný
 00632627-v	slk:lemma	usudzovať
 03504723-n	slk:lemma	riaditeľstvo
 03100897-n	slk:lemma	dopravný pás
 01651293-v	slk:lemma	začať
 15248269-n	slk:lemma	epocha
-01761375-s	slk:lemma	zakázaný
-00526062-s	slk:lemma	všeobecný
+01761375-a	slk:lemma	zakázaný
+00526062-a	slk:lemma	všeobecný
 03117939-n	slk:lemma	duplikát
 02083806-v	slk:lemma	rozohňovať
 02370806-n	slk:lemma	kopytník
@@ -26835,7 +26835,7 @@
 08690792-n	slk:lemma	okraj
 06609403-n	slk:lemma	komický obrad
 04649261-n	slk:lemma	hravosť
-02124253-s	slk:lemma	funkčný
+02124253-a	slk:lemma	funkčný
 01195536-a	slk:lemma	pomocný
 00047534-r	slk:lemma	rovnako
 02083806-v	slk:lemma	vzbudiť sa
@@ -26845,19 +26845,19 @@
 10428004-n	slk:lemma	fyzik
 05035961-n	slk:lemma	energia
 04190747-n	slk:lemma	plášť
-00733743-s	slk:lemma	uprednostňovaný
+00733743-a	slk:lemma	uprednostňovaný
 00997794-v	slk:lemma	schvaľovať
 00697188-a	slk:lemma	jasný
 00137709-n	slk:lemma	rohový kop
 01113806-v	slk:lemma	zaostať
-01320705-s	slk:lemma	nevinný
+01320705-a	slk:lemma	nevinný
 05478336-n	slk:lemma	druhý hlavový nerv
 01863593-v	slk:lemma	brzdiť
 03049326-n	slk:lemma	uzavretý regulačný obvod
 06473563-n	slk:lemma	formulár
 08799271-n	slk:lemma	Judea
 04749991-n	slk:lemma	odchýlka
-01912858-s	slk:lemma	jednoduchý
+01912858-a	slk:lemma	jednoduchý
 03519578-n	slk:lemma	hlavná hradská
 01240935-v	slk:lemma	pichať
 01220984-n	slk:lemma	chovanie
@@ -26872,7 +26872,7 @@
 04776699-n	slk:lemma	nehybnosť
 00637259-v	slk:lemma	kalkulovať
 00042614-r	slk:lemma	smutno
-02401288-s	slk:lemma	nepodliehajúci dani
+02401288-a	slk:lemma	nepodliehajúci dani
 00296263-n	slk:lemma	oboplávanie
 01522276-v	slk:lemma	namotávať sa
 02163746-v	slk:lemma	spozorovať
@@ -26921,7 +26921,7 @@
 06064462-n	slk:lemma	toxikológia
 01469263-v	slk:lemma	postaviť na seba
 00621058-v	slk:lemma	vyjasniť
-00063953-s	slk:lemma	nehorázny
+00063953-a	slk:lemma	nehorázny
 09627117-n	slk:lemma	predchodca
 02648639-v	slk:lemma	bývať
 03882058-n	slk:lemma	diel
@@ -26935,18 +26935,18 @@
 02843495-a	slk:lemma	svadobný
 02165304-v	slk:lemma	nakúkať
 00798539-v	slk:lemma	odbiť (niekoho)
-01565608-s	slk:lemma	animovaný
+01565608-a	slk:lemma	animovaný
 09250678-n	slk:lemma	rieka Kolumbia
 03099945-n	slk:lemma	konvertor
 00530208-n	slk:lemma	drevákový tanec
 00884540-v	slk:lemma	sľúbiť
 05491993-n	slk:lemma	mozog
 01378556-v	slk:lemma	rozšíriť sa
-00689878-s	slk:lemma	odpočítateľný (od základu dane)
+00689878-a	slk:lemma	odpočítateľný (od základu dane)
 02931013-n	slk:lemma	koč
 02396088-n	slk:lemma	ošípaná
 13901211-n	slk:lemma	sud
-02123579-s	slk:lemma	elitný
+02123579-a	slk:lemma	elitný
 00290579-n	slk:lemma	pochod
 00885925-v	slk:lemma	urobiť láskavosť
 01853461-a	slk:lemma	druhotný
@@ -26955,27 +26955,27 @@
 00424599-n	slk:lemma	ukrutnosť
 00878636-v	slk:lemma	doručiť
 00731222-n	slk:lemma	poverenie
-01991586-s	slk:lemma	spoľahlivý
+01991586-a	slk:lemma	spoľahlivý
 10582154-n	slk:lemma	sluha
 02984781-a	slk:lemma	firemný
 00997794-v	slk:lemma	schváliť
-01574925-s	slk:lemma	prízračný
+01574925-a	slk:lemma	prízračný
 02484570-v	slk:lemma	zastreliť
 07505538-n	slk:lemma	neúčasť
 01684426-a	slk:lemma	orientačný
 09807754-n	slk:lemma	človek s modrou krvou
 09463362-n	slk:lemma	Tunguska
 02055649-v	slk:lemma	pohnať
-00431004-s	slk:lemma	nekonkrétny
+00431004-a	slk:lemma	nekonkrétny
 06453324-n	slk:lemma	Ketubim
 06413889-n	slk:lemma	letáčik
 00969873-v	slk:lemma	roznášať sa
 05167237-n	slk:lemma	asertívnosť
 02676054-v	slk:lemma	odkazovať (na)
-01518860-s	slk:lemma	bojový
+01518860-a	slk:lemma	bojový
 04694809-n	slk:lemma	vyrážka
 10665698-n	slk:lemma	žiak
-00860127-s	slk:lemma	pokusný
+00860127-a	slk:lemma	pokusný
 00528339-v	slk:lemma	vytiahnuť z vody
 07964144-n	slk:lemma	zladenie farieb
 00705924-v	slk:lemma	prekračovať hranicu
@@ -26988,23 +26988,23 @@
 14686585-n	slk:lemma	palivová nafta
 13353858-n	slk:lemma	peniaze
 00829107-v	slk:lemma	vyučiť
-01258264-s	slk:lemma	studený
+01258264-a	slk:lemma	studený
 00621734-v	slk:lemma	miasť
 00915722-n	slk:lemma	kultivovanie pôdy
 00818974-v	slk:lemma	naliehať
 04891010-n	slk:lemma	objektívnosť v usudzovaní
 06833112-n	slk:lemma	S
-00019505-s	slk:lemma	prístupný
+00019505-a	slk:lemma	prístupný
 05421586-n	slk:lemma	kŕčová žila
 09248724-n	slk:lemma	rieka Cocytus
 08414964-n	slk:lemma	obžalovacia porota
-00579622-s	slk:lemma	dôležitý
+00579622-a	slk:lemma	dôležitý
 01523654-v	slk:lemma	odviť
 01054335-n	slk:lemma	držanie
 09466757-n	slk:lemma	horný plášť
 00752954-n	slk:lemma	podvod
 02672540-v	slk:lemma	opravovať
-02316992-s	slk:lemma	krútiaci sa
+02316992-a	slk:lemma	krútiaci sa
 01203277-n	slk:lemma	tvorivá technika nových myšlienok
 07152463-n	slk:lemma	heslo
 00618451-v	slk:lemma	určovať
@@ -27033,15 +27033,15 @@
 02548588-v	slk:lemma	plniť si úlohu
 07770869-n	slk:lemma	betelový orech
 02879638-a	slk:lemma	pontifikálny
-00514175-s	slk:lemma	protestný
+00514175-a	slk:lemma	protestný
 01659248-v	slk:lemma	vyformovať
 08539893-n	slk:lemma	okraj mesta
 13272545-n	slk:lemma	darček zdarma
 00459498-v	slk:lemma	švihať
-00922840-s	slk:lemma	bežný
+00922840-a	slk:lemma	bežný
 02554922-v	slk:lemma	propagovať
 00924873-v	slk:lemma	podozrievať
-01044730-s	slk:lemma	bezstarostný
+01044730-a	slk:lemma	bezstarostný
 05222940-n	slk:lemma	priehradka
 10334782-n	slk:lemma	podvodník
 00348541-v	slk:lemma	hýbať sa
@@ -27054,7 +27054,7 @@
 00719494-n	slk:lemma	povinnosť
 00085512-r	slk:lemma	vyslovene
 00002137-n	slk:lemma	abstraktná entita
-01066787-s	slk:lemma	obvyklý
+01066787-a	slk:lemma	obvyklý
 04857738-n	slk:lemma	smelosť
 02469835-v	slk:lemma	zjednocovať
 07496463-n	slk:lemma	trápenie
@@ -27082,17 +27082,17 @@
 07731952-n	slk:lemma	jedlá kukurica
 00353469-n	slk:lemma	znižovanie
 00148422-r	slk:lemma	mimo kontroly
-00570322-s	slk:lemma	nepremožiteľný
-02418692-s	slk:lemma	nemožný
+00570322-a	slk:lemma	nepremožiteľný
+02418692-a	slk:lemma	nemožný
 03733281-n	slk:lemma	labyrint
 06466787-n	slk:lemma	žalm
 00072012-v	slk:lemma	robiť kaluže
 06695227-n	slk:lemma	prianie
-01246148-s	slk:lemma	protipôsobiaci
+01246148-a	slk:lemma	protipôsobiaci
 08946909-n	slk:lemma	Grenada
 14788332-n	slk:lemma	kyselina maslová
 13592384-n	slk:lemma	počet
-01199083-s	slk:lemma	rozmanitý
+01199083-a	slk:lemma	rozmanitý
 05313344-n	slk:lemma	riasnaté teliesko
 09771435-n	slk:lemma	ctiteľ
 03400798-n	slk:lemma	palivový článok
@@ -27116,7 +27116,7 @@
 10314836-n	slk:lemma	pôrodná baba
 13279262-n	slk:lemma	výplata
 01523986-v	slk:lemma	nakrútiť si
-01618376-s	slk:lemma	evidentný
+01618376-a	slk:lemma	evidentný
 00211110-n	slk:lemma	ukončenie
 04878861-n	slk:lemma	nevernosť
 05315095-n	slk:lemma	spojivka
@@ -27142,7 +27142,7 @@
 00544549-v	slk:lemma	vytiahnuť z
 08549292-n	slk:lemma	geto
 09717047-n	slk:lemma	Riman
-00853473-s	slk:lemma	nevhodný
+00853473-a	slk:lemma	nevhodný
 14018567-n	slk:lemma	opitosť
 09464805-n	slk:lemma	rieka Tyne
 14500567-n	slk:lemma	zmätok
@@ -27151,16 +27151,16 @@
 05849284-n	slk:lemma	rys
 02469835-v	slk:lemma	spájať sa
 01639714-v	slk:lemma	kresliť
-00782216-s	slk:lemma	matný
+00782216-a	slk:lemma	matný
 03916720-n	slk:lemma	vonkajšie zariadenie
 04493505-n	slk:lemma	rúra
 03160309-n	slk:lemma	hať
-02436995-s	slk:lemma	prísny
+02436995-a	slk:lemma	prísny
 03206718-n	slk:lemma	maskovanie
 13300922-n	slk:lemma	pokuta
 13910384-n	slk:lemma	miesto
 04187061-n	slk:lemma	pošva
-01610484-s	slk:lemma	pozorovaný
+01610484-a	slk:lemma	pozorovaný
 01183573-v	slk:lemma	uspokojovať
 00940384-v	slk:lemma	verbalizovať
 14830992-n	slk:lemma	kódovaná DNA
@@ -27184,10 +27184,10 @@
 13609214-n	slk:lemma	jednotka hmotnosti
 00746718-v	slk:lemma	vydávať príkaz(y)
 06452363-n	slk:lemma	Tanach
-00807399-s	slk:lemma	pochmúrny
+00807399-a	slk:lemma	pochmúrny
 03686470-n	slk:lemma	poschodie
 02881567-a	slk:lemma	sexuálny
-01874331-s	slk:lemma	amatérsky
+01874331-a	slk:lemma	amatérsky
 07228971-n	slk:lemma	poďakovanie
 01835496-v	slk:lemma	presúvať
 02143539-v	slk:lemma	odkryť
@@ -27202,7 +27202,7 @@
 01504625-a	slk:lemma	melodický
 00947719-n	slk:lemma	zneužitie
 01384439-v	slk:lemma	zbierať
-02229961-s	slk:lemma	nekvalifikovaný
+02229961-a	slk:lemma	nekvalifikovaný
 10186578-n	slk:lemma	obchodník s pánskou galantériou
 00036061-n	slk:lemma	aplikácia
 00999245-n	slk:lemma	nastavenie
@@ -27250,7 +27250,7 @@
 05803747-n	slk:lemma	úverová bonita
 03189707-n	slk:lemma	denník
 10037385-n	slk:lemma	pijan
-01620286-s	slk:lemma	nejasný
+01620286-a	slk:lemma	nejasný
 02416030-v	slk:lemma	fušovať
 06664594-n	slk:lemma	kánon
 01956955-v	slk:lemma	ísť stopom
@@ -27270,7 +27270,7 @@
 02710402-v	slk:lemma	stretávať sa
 00397016-r	slk:lemma	hojne
 15231964-n	slk:lemma	doba kamenná
-00922840-s	slk:lemma	nudný
+00922840-a	slk:lemma	nudný
 11875100-n	slk:lemma	Brassica
 04019101-n	slk:lemma	verejná preprava
 07232988-n	slk:lemma	verejné odsúdenie
@@ -27289,7 +27289,7 @@
 01087740-n	slk:lemma	národná podpora
 00371264-v	slk:lemma	ohriať
 01104624-v	slk:lemma	podviesť
-02314451-s	slk:lemma	cik-cak
+02314451-a	slk:lemma	cik-cak
 00342640-v	slk:lemma	predbehnúť
 05793000-n	slk:lemma	vysvetlenie
 02110220-v	slk:lemma	poznávať (zo skúsenosti)
@@ -27302,7 +27302,7 @@
 05785508-n	slk:lemma	rozjímanie
 02802976-a	slk:lemma	hviezdny
 03015254-n	slk:lemma	komoda
-01664015-s	slk:lemma	šťastný
+01664015-a	slk:lemma	šťastný
 00165942-n	slk:lemma	krok
 00966640-v	slk:lemma	poznačiť odchod
 08625462-n	slk:lemma	ľavica
@@ -27317,12 +27317,12 @@
 14459422-n	slk:lemma	bezchybnosť
 05773049-n	slk:lemma	argument
 06611376-n	slk:lemma	hovno
-02071973-s	slk:lemma	obdobný
+02071973-a	slk:lemma	obdobný
 04335435-n	slk:lemma	dielensky vozík
 07294019-n	slk:lemma	dôsledok
 04405540-n	slk:lemma	video zariadenie
 10340312-n	slk:lemma	hudobník
-00363031-s	slk:lemma	veselý
+00363031-a	slk:lemma	veselý
 05288091-n	slk:lemma	chrupavka
 07052291-n	slk:lemma	sloha
 02704349-v	slk:lemma	mať rozmery
@@ -27332,7 +27332,7 @@
 00276620-n	slk:lemma	špinenie
 02604477-v	slk:lemma	spolunažívať
 00965035-v	slk:lemma	podávať hlásenie
-01467534-s	slk:lemma	malý
+01467534-a	slk:lemma	malý
 05621439-n	slk:lemma	dôvtip
 01227908-n	slk:lemma	rešpekt
 00059086-r	slk:lemma	oveľa
@@ -27352,18 +27352,18 @@
 02920259-n	slk:lemma	poschodové lôžko
 00269140-v	slk:lemma	odstavovať
 03055670-n	slk:lemma	kočiar so štvorzáprahom
-00968010-s	slk:lemma	podivný
+00968010-a	slk:lemma	podivný
 04717139-n	slk:lemma	spôsobilosť
-00042837-s	slk:lemma	opačný
+00042837-a	slk:lemma	opačný
 09505418-n	slk:lemma	božstvo
 03871083-n	slk:lemma	balík
-02269142-s	slk:lemma	nulový
+02269142-a	slk:lemma	nulový
 01006421-v	slk:lemma	črtať
 01883898-a	slk:lemma	obozretný
 02498320-v	slk:lemma	objednávať
 10091256-n	slk:lemma	pracovník v teréne
 08835390-n	slk:lemma	Nullarborská planina
-00237788-s	slk:lemma	dvojstranný
+00237788-a	slk:lemma	dvojstranný
 02421199-v	slk:lemma	podrobovať sa
 02884450-n	slk:lemma	sedlo pohoniča
 10102369-n	slk:lemma	predok
@@ -27433,14 +27433,14 @@
 04928903-n	slk:lemma	tvar
 13653902-n	slk:lemma	vrchol
 13858833-n	slk:lemma	opak
-02465115-s	slk:lemma	spoľahlivý
+02465115-a	slk:lemma	spoľahlivý
 01012073-v	slk:lemma	potvrdzovať
 04869106-n	slk:lemma	česť
 00232863-n	slk:lemma	odvolanie
 00993956-n	slk:lemma	podporná paľba
 04880573-n	slk:lemma	naivita
 06338908-n	slk:lemma	pomenovanie
-01462324-s	slk:lemma	drahý
+01462324-a	slk:lemma	drahý
 05138208-n	slk:lemma	cena
 15229408-n	slk:lemma	kanonická hodina
 03021866-a	slk:lemma	krovinatý
@@ -27449,14 +27449,14 @@
 01059400-a	slk:lemma	upevnený
 12584365-n	slk:lemma	palma katechová
 01064151-v	slk:lemma	prediskutovať
-01304802-s	slk:lemma	poradenský
+01304802-a	slk:lemma	poradenský
 00331950-n	slk:lemma	hýbanie sa
 02350175-v	slk:lemma	vyslobodiť
 13326450-n	slk:lemma	odpisová norma
 07319103-n	slk:lemma	úspech
 07506149-n	slk:lemma	neľútostnosť
 03987079-n	slk:lemma	obraz
-02124253-s	slk:lemma	schopný prevádzky
+02124253-a	slk:lemma	schopný prevádzky
 01752495-v	slk:lemma	rodiť
 04646548-n	slk:lemma	úprimnosť
 01926311-v	slk:lemma	bežať
@@ -27470,9 +27470,9 @@
 00010466-r	slk:lemma	naplno
 07548978-n	slk:lemma	nenávisť
 13896369-n	slk:lemma	prehnutie
-02344070-s	slk:lemma	nefalšovaný
+02344070-a	slk:lemma	nefalšovaný
 08568978-n	slk:lemma	najvzdialenejšie miesto
-00063953-s	slk:lemma	nemiestny
+00063953-a	slk:lemma	nemiestny
 08225090-n	slk:lemma	susedia
 08111157-n	slk:lemma	kmeň
 00468480-n	slk:lemma	futbal
@@ -27487,7 +27487,7 @@
 10355449-n	slk:lemma	zelenáč
 13402690-n	slk:lemma	daňová pohľadávka
 03962685-n	slk:lemma	platforma
-01797633-s	slk:lemma	nastavený
+01797633-a	slk:lemma	nastavený
 13583724-n	slk:lemma	jednotka miery
 00790509-v	slk:lemma	čakať
 00232863-n	slk:lemma	zrušenie
@@ -27509,8 +27509,8 @@
 00042769-r	slk:lemma	nanešťastie
 00965035-v	slk:lemma	popísať
 06468328-n	slk:lemma	prehľad
-02182562-s	slk:lemma	pokrytecký
-00280463-s	slk:lemma	oslnivý
+02182562-a	slk:lemma	pokrytecký
+00280463-a	slk:lemma	oslnivý
 00640434-n	slk:lemma	rozbor trhu
 00408205-r	slk:lemma	nevyhnutne
 00817167-v	slk:lemma	zapierať
@@ -27532,7 +27532,7 @@
 12485122-n	slk:lemma	čeľaď Loganiaceae
 04829550-n	slk:lemma	súcit
 02832678-a	slk:lemma	hubovitý
-00440292-s	slk:lemma	tupý
+00440292-a	slk:lemma	tupý
 01061017-v	slk:lemma	vyjadrovať
 00939857-v	slk:lemma	osvetľovať
 01577093-v	slk:lemma	potápať
@@ -27544,7 +27544,7 @@
 02294179-v	slk:lemma	dať diel
 03639230-n	slk:lemma	pristávací klzák
 02386612-a	slk:lemma	malý
-00476663-s	slk:lemma	preplnený
+00476663-a	slk:lemma	preplnený
 00444846-n	slk:lemma	potápanie s výstrojou
 05964445-n	slk:lemma	väčšinové pravidlo
 13737480-n	slk:lemma	štvrťka
@@ -27555,11 +27555,11 @@
 15112932-n	slk:lemma	kyselina xantogenová
 04085873-n	slk:lemma	obloženie kameňom
 03916720-n	slk:lemma	počítačové periférie
-01142196-s	slk:lemma	dobrotivý
+01142196-a	slk:lemma	dobrotivý
 02530167-v	slk:lemma	pokúšať sa
 01280488-v	slk:lemma	ohýbať sa
 00144405-r	slk:lemma	na chvíľu
-01142196-s	slk:lemma	milostivý
+01142196-a	slk:lemma	milostivý
 05151088-n	slk:lemma	praktickosť
 01434278-v	slk:lemma	odvážať
 00223500-v	slk:lemma	ochabnúť
@@ -27597,7 +27597,7 @@
 05154517-n	slk:lemma	klad
 06200344-n	slk:lemma	záľuba
 05047279-n	slk:lemma	priorita
-00813589-s	slk:lemma	prvotný
+00813589-a	slk:lemma	prvotný
 01411085-v	slk:lemma	zbičovať
 06730068-n	slk:lemma	predmet žaloby
 15278825-n	slk:lemma	miera rastu
@@ -27623,17 +27623,17 @@
 05084201-n	slk:lemma	diaľka
 01441100-v	slk:lemma	prenikať cez (niečo)
 08049401-n	slk:lemma	asociácia
-01940651-s	slk:lemma	racionálny
-00554098-s	slk:lemma	odlišný
+01940651-a	slk:lemma	racionálny
+00554098-a	slk:lemma	odlišný
 09416570-n	slk:lemma	Rockies, Rocky Mountains
 00774107-n	slk:lemma	sexuálny prečin
 00623151-v	slk:lemma	zistiť zmysel
 07486229-n	slk:lemma	želanie
 06642356-n	slk:lemma	novinka
-02123007-s	slk:lemma	šantiaci
+02123007-a	slk:lemma	šantiaci
 00063630-r	slk:lemma	celkom
 06878071-n	slk:lemma	úškrn
-00505853-s	slk:lemma	bez seberovného
+00505853-a	slk:lemma	bez seberovného
 07679356-n	slk:lemma	chlieb
 05020358-n	slk:lemma	elastickosť
 00092366-n	slk:lemma	aukcia
@@ -27641,7 +27641,7 @@
 03423224-n	slk:lemma	plynová pec
 00984609-n	slk:lemma	výzvedy
 13262663-n	slk:lemma	špinavé peniaze
-00803275-s	slk:lemma	náhly
+00803275-a	slk:lemma	náhly
 07404944-n	slk:lemma	lavína
 13509196-n	slk:lemma	pokles
 00839194-v	slk:lemma	oblafnúť
@@ -27650,8 +27650,8 @@
 00005779-r	slk:lemma	nesmierne
 00142191-v	slk:lemma	vytvarovať
 07569106-n	slk:lemma	múka
-00933415-s	slk:lemma	nákladný
-00978754-s	slk:lemma	priamy
+00933415-a	slk:lemma	nákladný
+00978754-a	slk:lemma	priamy
 13305794-n	slk:lemma	náklady obetovanej príležitosti
 12633994-n	slk:lemma	jabloň
 07654667-n	slk:lemma	plátok
@@ -27663,7 +27663,7 @@
 14446298-n	slk:lemma	pohodlie
 07059962-n	slk:lemma	populárna hudba
 08293336-n	slk:lemma	flotila
-01789481-s	slk:lemma	škvrnitý
+01789481-a	slk:lemma	škvrnitý
 06831498-n	slk:lemma	d
 01796346-v	slk:lemma	rozveseľovať
 13561896-n	slk:lemma	náhodný proces
@@ -27680,7 +27680,7 @@
 01812720-v	slk:lemma	vnucovať
 15251757-n	slk:lemma	trojstoročie
 00273445-v	slk:lemma	adaptovať
-00533452-s	slk:lemma	jasný
+00533452-a	slk:lemma	jasný
 00415333-n	slk:lemma	lobbizmus
 01815669-a	slk:lemma	nepredvídateľný
 05033906-n	slk:lemma	imunita
@@ -27690,12 +27690,12 @@
 00397576-v	slk:lemma	rozpadávať sa
 00751567-v	slk:lemma	nariadiť
 07050619-n	slk:lemma	pohrebná pieseň
-01676026-s	slk:lemma	nadmerný
+01676026-a	slk:lemma	nadmerný
 02176268-v	slk:lemma	vydať zvuk
 01156834-v	slk:lemma	prijímať potravu
 01995549-v	slk:lemma	postupovať
 14558995-n	slk:lemma	pokles orgánu
-01951197-s	slk:lemma	hrubý
+01951197-a	slk:lemma	hrubý
 01856553-n	slk:lemma	divá hus
 13312962-n	slk:lemma	koncesný poplatok
 03085602-n	slk:lemma	počítačová obrazovka
@@ -27739,7 +27739,7 @@
 06724323-n	slk:lemma	svätá pravda
 09186709-n	slk:lemma	rieka Acheron
 01189282-n	slk:lemma	usvedčenie
-02312450-s	slk:lemma	naklonený
+02312450-a	slk:lemma	naklonený
 08491826-n	slk:lemma	správna oblasť
 06726158-n	slk:lemma	vyhlásenie
 06372680-n	slk:lemma	báj
@@ -27758,7 +27758,7 @@
 00617748-v	slk:lemma	spliesť si
 00333829-n	slk:lemma	rozrušenie
 02132099-v	slk:lemma	ohliadať sa
-01676517-s	slk:lemma	ohromný
+01676517-a	slk:lemma	ohromný
 01875295-v	slk:lemma	hojdať sa
 01731351-a	slk:lemma	terajší
 02773838-n	slk:lemma	kufor
@@ -27772,7 +27772,7 @@
 03291551-n	slk:lemma	zákop
 01911232-v	slk:lemma	prechádzať okolo niečoho
 01082606-v	slk:lemma	začať (niečo)
-01362387-s	slk:lemma	žalostný
+01362387-a	slk:lemma	žalostný
 02031622-v	slk:lemma	oddeliť
 03673027-n	slk:lemma	zaoceánsky parník
 02725714-v	slk:lemma	vyhýbať sa
@@ -27803,14 +27803,14 @@
 10738515-n	slk:lemma	zástupca odborov
 10316013-n	slk:lemma	odborník vo vojenskej vede
 05833840-n	slk:lemma	myšlienka
-00798103-s	slk:lemma	opitý
+00798103-a	slk:lemma	opitý
 10069427-n	slk:lemma	popravca
 00331655-n	slk:lemma	posun
 01208597-n	slk:lemma	útočisko
 14548343-n	slk:lemma	nespôsobilosť
 00231916-r	slk:lemma	nevoľky
 09075842-n	slk:lemma	GA
-00066933-s	slk:lemma	bezpečný
+00066933-a	slk:lemma	bezpečný
 15140190-n	slk:lemma	pracovná neschopnosť
 00345454-n	slk:lemma	točenie
 14625458-n	slk:lemma	kov
@@ -27825,7 +27825,7 @@
 03779370-n	slk:lemma	forma
 00881998-v	slk:lemma	zablahoželať
 02350175-v	slk:lemma	zbaviť
-01019713-s	slk:lemma	mäkký
+01019713-a	slk:lemma	mäkký
 08513718-n	slk:lemma	priestor
 04316646-n	slk:lemma	zadná časť lode
 00910555-v	slk:lemma	namietnuť
@@ -27836,7 +27836,7 @@
 05397468-n	slk:lemma	telesná tekutina
 14493145-n	slk:lemma	núdza
 15275598-n	slk:lemma	oneskorenie
-02341864-s	slk:lemma	riadny
+02341864-a	slk:lemma	riadny
 01749017-v	slk:lemma	tlačiť kurzívou
 02699941-v	slk:lemma	patriť sa
 06845599-n	slk:lemma	továrenská značka
@@ -27878,10 +27878,10 @@
 14498096-n	slk:lemma	špina
 02323449-n	slk:lemma	dvojitozubec
 08675967-n	slk:lemma	mestské územie
-01627315-s	slk:lemma	všivavý
+01627315-a	slk:lemma	všivavý
 00303940-v	slk:lemma	rozšíriť
 02609614-v	slk:lemma	nastať
-02038994-s	slk:lemma	odhodlaný
+02038994-a	slk:lemma	odhodlaný
 09370552-n	slk:lemma	Niagara
 03483637-n	slk:lemma	núdzová brzda
 01091427-v	slk:lemma	prebojovať
@@ -27894,7 +27894,7 @@
 06758225-n	slk:lemma	podvod
 05736149-n	slk:lemma	ohodnotenie
 00705517-v	slk:lemma	vziať si na mušku (niekoho)
-00856651-s	slk:lemma	oduševnený
+00856651-a	slk:lemma	oduševnený
 10355142-n	slk:lemma	nestranný
 05223550-n	slk:lemma	brázda
 09238674-n	slk:lemma	Pohorie Kaukaz
@@ -27922,7 +27922,7 @@
 10028977-n	slk:lemma	kresliar
 02637730-a	slk:lemma	rozhodcovský
 05948537-n	slk:lemma	náboženský kult
-00933415-s	slk:lemma	drahý
+00933415-a	slk:lemma	drahý
 10405410-n	slk:lemma	majiteľ patentu
 03185746-n	slk:lemma	ozdobný vzor
 02216710-v	slk:lemma	podporovať
@@ -27931,15 +27931,15 @@
 09815455-n	slk:lemma	asignatár
 09727826-n	slk:lemma	Polynézan
 00871942-v	slk:lemma	veštiť
-00672382-s	slk:lemma	na zákazku
-00348018-s	slk:lemma	stabilný
+00672382-a	slk:lemma	na zákazku
+00348018-a	slk:lemma	stabilný
 01827858-v	slk:lemma	pokochať sa pohľadom
 05317354-n	slk:lemma	rohovka
 00775831-v	slk:lemma	oponovať
 00380881-n	slk:lemma	dav
 07467846-n	slk:lemma	športové stretnutie
 05619743-n	slk:lemma	geniálne nadanie
-00904745-s	slk:lemma	hanebný
+00904745-a	slk:lemma	hanebný
 13387209-n	slk:lemma	papierové peniaze
 06447221-n	slk:lemma	Prvý Jánov list
 00267522-n	slk:lemma	udržiavanie
@@ -27966,22 +27966,22 @@
 14033185-n	slk:lemma	dôležitý okamih
 08252602-n	slk:lemma	párty
 07976936-n	slk:lemma	dvojica
-01870636-s	slk:lemma	laický
+01870636-a	slk:lemma	laický
 00105958-v	slk:lemma	cítiť sa
 06172502-n	slk:lemma	dešifrovanie
-01320705-s	slk:lemma	počestný
+01320705-a	slk:lemma	počestný
 15285622-n	slk:lemma	úmrtnosť detí do jedného roka
 07584938-n	slk:lemma	silná hovädzia polievka
 01883898-a	slk:lemma	predvídajúci
-01136248-s	slk:lemma	nevľúdny
-01389170-s	slk:lemma	silný
+01136248-a	slk:lemma	nevľúdny
+01389170-a	slk:lemma	silný
 00823532-n	slk:lemma	ochrana
 12994979-n	slk:lemma	kmeň Eumycota
 03223162-n	slk:lemma	zámka dverí
-01936184-s	slk:lemma	rozprávkový
+01936184-a	slk:lemma	rozprávkový
 12300625-n	slk:lemma	Olea
 00502710-r	slk:lemma	špeciálne
-01400961-s	slk:lemma	justičný
+01400961-a	slk:lemma	justičný
 07512315-n	slk:lemma	vážnosť
 09693982-n	slk:lemma	Barbadosan
 06413889-n	slk:lemma	leták
@@ -27994,7 +27994,7 @@
 02766390-v	slk:lemma	žiariť
 09249418-n	slk:lemma	Colorado
 02302817-v	slk:lemma	roznášať
-02076988-s	slk:lemma	duševne chorý
+02076988-a	slk:lemma	duševne chorý
 00537682-n	slk:lemma	ľudový tanec
 06605396-n	slk:lemma	dysfemizmus
 04890112-n	slk:lemma	rozvážnosť
@@ -28027,7 +28027,7 @@
 00780615-n	slk:lemma	podvodník
 14478291-n	slk:lemma	úpadok
 09393524-n	slk:lemma	pláž
-00459553-s	slk:lemma	nahý ako ho Pánboh stvoril
+00459553-a	slk:lemma	nahý ako ho Pánboh stvoril
 02811774-a	slk:lemma	chápadlovitý
 06760722-n	slk:lemma	machinácie
 01790020-v	slk:lemma	rozrušiť sa
@@ -28044,7 +28044,7 @@
 04173172-n	slk:lemma	sekvencia
 02066939-v	slk:lemma	pritiecť
 01214265-v	slk:lemma	pochytiť
-01780740-s	slk:lemma	duševný
+01780740-a	slk:lemma	duševný
 00046534-v	slk:lemma	obliekať sa
 00019448-v	slk:lemma	ovplyvňovať
 02478701-v	slk:lemma	urobiť platným
@@ -28059,10 +28059,10 @@
 00859758-v	slk:lemma	zabaviť
 00808182-n	slk:lemma	reštrikcia
 10317884-n	slk:lemma	mliekár
-01982186-s	slk:lemma	charakteristický
+01982186-a	slk:lemma	charakteristický
 00252019-v	slk:lemma	vyvíjať sa
 09304750-n	slk:lemma	jama
-00403072-s	slk:lemma	premenlivý
+00403072-a	slk:lemma	premenlivý
 00007739-v	slk:lemma	mrkať
 00666510-v	slk:lemma	dokazovať
 00941990-v	slk:lemma	vyjadrovať sa
@@ -28070,7 +28070,7 @@
 10091012-n	slk:lemma	špeh
 00597629-n	slk:lemma	vedenie školy
 00475647-v	slk:lemma	robiť čistky
-01935935-s	slk:lemma	neskutočný
+01935935-a	slk:lemma	neskutočný
 10472799-n	slk:lemma	princ
 07970721-n	slk:lemma	klan
 02294436-v	slk:lemma	poskytnúť
@@ -28102,7 +28102,7 @@
 14375576-n	slk:lemma	nervozita
 02852523-n	slk:lemma	kváder
 02538626-a	slk:lemma	inflačný
-00152629-s	slk:lemma	onemený
+00152629-a	slk:lemma	onemený
 00256309-n	slk:lemma	premytie
 00755447-v	slk:lemma	prosiť
 00027268-v	slk:lemma	rozširovať
@@ -28126,15 +28126,15 @@
 00799537-n	slk:lemma	kandidovanie
 13604275-n	slk:lemma	metrická jednotka
 00672433-v	slk:lemma	stanovovať
-00989647-s	slk:lemma	vytiahnutý
+00989647-a	slk:lemma	vytiahnutý
 03986355-n	slk:lemma	portfólio
-00143854-s	slk:lemma	pancierovaný
+00143854-a	slk:lemma	pancierovaný
 15153787-n	slk:lemma	roky staroby
 03832673-n	slk:lemma	notebook
 05955323-n	slk:lemma	pravidlo
 07339098-n	slk:lemma	šok
 02566528-v	slk:lemma	prehrešovať
-00070427-s	slk:lemma	zmyslový
+00070427-a	slk:lemma	zmyslový
 01171183-v	slk:lemma	vyslopať
 10569744-n	slk:lemma	asistent
 00067966-a	slk:lemma	rozvážny
@@ -28142,7 +28142,7 @@
 00795720-n	slk:lemma	projekt
 00579712-v	slk:lemma	podrobiť sa
 01064062-v	slk:lemma	podceniť
-01580775-s	slk:lemma	potrebný
+01580775-a	slk:lemma	potrebný
 09379111-n	slk:lemma	trhlina
 01825237-v	slk:lemma	chcieť
 01116026-n	slk:lemma	nákup, telefonický nákup
@@ -28157,13 +28157,13 @@
 02410855-v	slk:lemma	robiť
 00205891-n	slk:lemma	strata
 01562584-n	slk:lemma	čeľaď penicovité
-02406370-s	slk:lemma	nepokojný
+02406370-a	slk:lemma	nepokojný
 08700255-n	slk:lemma	ázijská krajina
 13366537-n	slk:lemma	existenčné minimum
 00751567-v	slk:lemma	komandovať
-01313004-s	slk:lemma	spustnutý
+01313004-a	slk:lemma	spustnutý
 01486312-v	slk:lemma	dať do obalu
-02543034-s	slk:lemma	pripútaný na lôžko
+02543034-a	slk:lemma	pripútaný na lôžko
 00230033-v	slk:lemma	pridať na kvalite
 01789514-v	slk:lemma	otravovať
 01726390-n	slk:lemma	podrad Ophidia
@@ -28173,8 +28173,8 @@
 10134178-n	slk:lemma	pastier kôz
 02818832-n	slk:lemma	posteľ
 03078287-n	slk:lemma	komunikačný systém
-00830051-s	slk:lemma	múdry
-01578856-s	slk:lemma	eventuálny
+00830051-a	slk:lemma	múdry
+01578856-a	slk:lemma	eventuálny
 05241662-n	slk:lemma	spinálna bunka
 02121620-n	slk:lemma	mačka
 14333645-n	slk:lemma	bolesť pri močení
@@ -28191,7 +28191,7 @@
 04473432-n	slk:lemma	tranzit
 03926575-n	slk:lemma	fotografia
 00217956-v	slk:lemma	skropiť
-00224515-s	slk:lemma	nepriaznivý
+00224515-a	slk:lemma	nepriaznivý
 02550296-v	slk:lemma	postarať sa
 05630277-n	slk:lemma	peklo
 04089376-n	slk:lemma	lano
@@ -28214,7 +28214,7 @@
 00404403-n	slk:lemma	zmena tvaru
 05710687-n	slk:lemma	odhalenie
 08750612-n	slk:lemma	Havana
-00969556-s	slk:lemma	neobyčajný
+00969556-a	slk:lemma	neobyčajný
 01673668-n	slk:lemma	Lacertilia
 04397645-n	slk:lemma	koktailové šaty
 01113068-n	slk:lemma	predaj
@@ -28234,19 +28234,19 @@
 13854649-n	slk:lemma	opozícia
 05154517-n	slk:lemma	pozitívna vlastnosť
 00246940-n	slk:lemma	praženie
-01600713-s	slk:lemma	severný
+01600713-a	slk:lemma	severný
 09477718-n	slk:lemma	rieka Weser
 13775706-n	slk:lemma	prúd
 02728440-n	slk:lemma	bielizeň
-02502994-s	slk:lemma	nepatrný
+02502994-a	slk:lemma	nepatrný
 01182654-n	slk:lemma	súdny spor
 05718254-n	slk:lemma	zvukový vnem
 00205046-v	slk:lemma	polepšiť
 15185837-n	slk:lemma	11. november
-02218314-s	slk:lemma	mnohoraký
+02218314-a	slk:lemma	mnohoraký
 00173353-r	slk:lemma	hlboko
 01487914-n	slk:lemma	rod Rhincodon
-01277426-s	slk:lemma	základný
+01277426-a	slk:lemma	základný
 00369532-n	slk:lemma	rozťahovanie
 04385431-n	slk:lemma	koncovka
 01991204-v	slk:lemma	vyvierať
@@ -28254,33 +28254,33 @@
 00006269-n	slk:lemma	život, živé organizmy
 01976220-v	slk:lemma	ponoriť sa
 14515633-n	slk:lemma	pole pôsobnosti
-02074673-s	slk:lemma	démonický
+02074673-a	slk:lemma	démonický
 10182499-n	slk:lemma	domáci
 06876309-n	slk:lemma	pohyb
-02342899-s	slk:lemma	kvalitný
+02342899-a	slk:lemma	kvalitný
 01166093-v	slk:lemma	uplatniť
-02182562-s	slk:lemma	farizejský
-00032733-s	slk:lemma	pohotový
+02182562-a	slk:lemma	farizejský
+00032733-a	slk:lemma	pohotový
 04794751-n	slk:lemma	ordinárnosť
 05814291-n	slk:lemma	vec
 05057695-n	slk:lemma	VHF
-02355248-s	slk:lemma	spoluvinný
+02355248-a	slk:lemma	spoluvinný
 05872477-n	slk:lemma	zákon
 09223725-n	slk:lemma	kryt
 02656390-v	slk:lemma	poskytnúť úkryt
 01604330-n	slk:lemma	dravý vták
 00046344-n	slk:lemma	šaškovina
-01455732-s	slk:lemma	tichý
+01455732-a	slk:lemma	tichý
 02829565-a	slk:lemma	zákonodarný
 00719705-n	slk:lemma	drobná práca
 01009240-v	slk:lemma	prehlasovať
 02162947-v	slk:lemma	zablyšťať sa
-01045518-s	slk:lemma	formálny
+01045518-a	slk:lemma	formálny
 01108627-v	slk:lemma	premáhať
 13318804-n	slk:lemma	úrok z úrokov
 14548343-n	slk:lemma	neschopnosť
 04263760-n	slk:lemma	zdroj osvetlenia
-01482140-s	slk:lemma	manželský
+01482140-a	slk:lemma	manželský
 02478701-v	slk:lemma	potvrdiť
 00752431-n	slk:lemma	lož
 08220228-n	slk:lemma	eskadra
@@ -28299,7 +28299,7 @@
 01635432-v	slk:lemma	predstaviť si
 07369604-n	slk:lemma	adaptácia
 03475823-n	slk:lemma	vlasová kozmetika
-02349274-s	slk:lemma	vrchný
+02349274-a	slk:lemma	vrchný
 05670710-n	slk:lemma	vec
 07999699-n	slk:lemma	rad
 03557141-n	slk:lemma	kocka ľadu
@@ -28315,7 +28315,7 @@
 09799461-n	slk:lemma	zástanca
 00214020-v	slk:lemma	zvlhčiť sa
 00224901-v	slk:lemma	oslabiť
-02186132-s	slk:lemma	nulový
+02186132-a	slk:lemma	nulový
 15267536-n	slk:lemma	záver
 09408540-n	slk:lemma	rieka Rýn
 00882523-v	slk:lemma	nechávať pozdraviť
@@ -28328,7 +28328,7 @@
 11911591-n	slk:lemma	čeľaď Asteraceae
 01527420-a	slk:lemma	metalizovaný
 06552639-n	slk:lemma	amnestia
-00150505-s	slk:lemma	plynulý
+00150505-a	slk:lemma	plynulý
 00335182-r	slk:lemma	narýchlo pripravený
 01975312-n	slk:lemma	podtrieda Malacostrata
 07470671-n	slk:lemma	zápas
@@ -28352,7 +28352,7 @@
 01062997-n	slk:lemma	pauza
 05379247-n	slk:lemma	ľadvinová žila
 00429949-n	slk:lemma	zábava
-00324481-s	slk:lemma	hybný
+00324481-a	slk:lemma	hybný
 11664929-n	slk:lemma	oddelenie Anthophyta
 00633443-v	slk:lemma	predpokladať
 00390842-v	slk:lemma	zadržiavať
@@ -28380,7 +28380,7 @@
 15159819-n	slk:lemma	dátum
 00964694-v	slk:lemma	pozhovárať sa
 02143283-v	slk:lemma	odhaľovať
-00936297-s	slk:lemma	skúsenejší
+00936297-a	slk:lemma	skúsenejší
 14830364-n	slk:lemma	DNA
 13267411-n	slk:lemma	cenová intervencia
 01601234-v	slk:lemma	držať
@@ -28391,7 +28391,7 @@
 01038666-v	slk:lemma	podrkovať si
 15250178-n	slk:lemma	narodeniny
 01739099-v	slk:lemma	budovať
-01501821-s	slk:lemma	sladký
+01501821-a	slk:lemma	sladký
 02525447-v	slk:lemma	zaúčinkovať
 00874621-n	slk:lemma	neschválenie
 00018526-v	slk:lemma	budiť sa
@@ -28427,7 +28427,7 @@
 07885223-n	slk:lemma	drink
 00235435-n	slk:lemma	štart
 07858978-n	slk:lemma	med
-01181446-s	slk:lemma	pozemský
+01181446-a	slk:lemma	pozemský
 03231024-n	slk:lemma	rysovacia doska
 13381734-n	slk:lemma	poukážka
 00894738-v	slk:lemma	ospravedlniť
@@ -28452,7 +28452,7 @@
 05850624-n	slk:lemma	stránka
 01182709-v	slk:lemma	dodať
 00226566-v	slk:lemma	prehĺbiť sa
-01335458-s	slk:lemma	bystrý
+01335458-a	slk:lemma	bystrý
 01712704-v	slk:lemma	vykonávať
 03887330-n	slk:lemma	podávanie papiera
 02494538-n	slk:lemma	rad Scandentia
@@ -28464,8 +28464,8 @@
 06833890-n	slk:lemma	zet
 06523641-n	slk:lemma	poistka
 00053004-r	slk:lemma	veľmi dobre
-01741669-s	slk:lemma	pokojný
-02418692-s	slk:lemma	nereálny
+01741669-a	slk:lemma	pokojný
+02418692-a	slk:lemma	nereálny
 06832896-n	slk:lemma	kvé
 09849012-n	slk:lemma	kráska
 02372326-v	slk:lemma	opätovať
@@ -28484,7 +28484,7 @@
 00654625-v	slk:lemma	utriediť
 05710481-n	slk:lemma	okruh percepcie
 10570019-n	slk:lemma	tajomník
-00818008-s	slk:lemma	mladý
+00818008-a	slk:lemma	mladý
 00230033-v	slk:lemma	pridávať na kvalite
 14395018-n	slk:lemma	šialenstvo
 05112215-n	slk:lemma	scvrknutie
@@ -28499,7 +28499,7 @@
 15265518-n	slk:lemma	štart
 01789064-n	slk:lemma	rad kurotvaré
 00248977-n	slk:lemma	zlepšovanie
-00330728-s	slk:lemma	stredový
+00330728-a	slk:lemma	stredový
 07419960-n	slk:lemma	úľava
 09364954-n	slk:lemma	rieka Nan
 00371264-v	slk:lemma	vykúriť
@@ -28522,7 +28522,7 @@
 03163798-n	slk:lemma	prevodník údajov
 00035385-r	slk:lemma	zriedkakedy
 02201644-v	slk:lemma	prideľovať
-01726859-s	slk:lemma	prepiaty
+01726859-a	slk:lemma	prepiaty
 14541852-n	slk:lemma	riskovanie
 08353912-n	slk:lemma	reklamná kancelária
 05233741-n	slk:lemma	mandibulárne vrúbkovanie
@@ -28534,7 +28534,7 @@
 08512259-n	slk:lemma	okraj
 08687709-n	slk:lemma	Kozorožec
 09292348-n	slk:lemma	Veľký bariérový útes
-00338013-s	slk:lemma	pochybujúci
+00338013-a	slk:lemma	pochybujúci
 02387486-v	slk:lemma	školiť
 05946687-n	slk:lemma	náboženské presvedčenie
 05853100-n	slk:lemma	sféra
@@ -28558,13 +28558,13 @@
 03179701-n	slk:lemma	stolík
 03574004-n	slk:lemma	nápad
 02014553-v	slk:lemma	vzlietať
-00398978-s	slk:lemma	pestrý
+00398978-a	slk:lemma	pestrý
 13287414-n	slk:lemma	väčšinová účasť
 03021866-a	slk:lemma	porastený kermi
 00405206-n	slk:lemma	zakrivenie
 13721529-n	slk:lemma	čistá tona
 06607809-n	slk:lemma	hlúposť
-01689223-s	slk:lemma	frázovitý
+01689223-a	slk:lemma	frázovitý
 07480068-n	slk:lemma	emócia
 04676308-n	slk:lemma	perspektíva
 01952898-v	slk:lemma	odovzdať
@@ -28581,10 +28581,10 @@
 11433546-n	slk:lemma	kapacita
 03560860-n	slk:lemma	cievka zapaľovania
 04094859-n	slk:lemma	stúpacia rúrka
-01842963-s	slk:lemma	naplánovaný
+01842963-a	slk:lemma	naplánovaný
 08397255-n	slk:lemma	armáda
 01225027-n	slk:lemma	inzultácia
-00729439-s	slk:lemma	nezávislý na cudzej pomoci
+00729439-a	slk:lemma	nezávislý na cudzej pomoci
 00595935-v	slk:lemma	vedieť
 00363493-v	slk:lemma	zadržať (peniaze, majetok)
 14434866-n	slk:lemma	významnosť
@@ -28611,7 +28611,7 @@
 07133701-n	slk:lemma	rozhovor
 01957529-v	slk:lemma	jazdiť
 01850315-v	slk:lemma	presunúť
-00228645-s	slk:lemma	najvhodnejší
+00228645-a	slk:lemma	najvhodnejší
 04335435-n	slk:lemma	ručný vozík
 14411884-n	slk:lemma	móda
 09041785-n	slk:lemma	Istambul
@@ -28636,23 +28636,23 @@
 00571283-n	slk:lemma	znak
 00471437-n	slk:lemma	loptová hra
 09310314-n	slk:lemma	rieka Illinois
-01564603-s	slk:lemma	stuhnutý
+01564603-a	slk:lemma	stuhnutý
 00066025-v	slk:lemma	fňukať
 00066216-n	slk:lemma	nedosiahnutie
 08287844-n	slk:lemma	civilizácia
 00868097-v	slk:lemma	opovážiť sa
 13820544-n	slk:lemma	pomer šírky k výške obrazovky
 03582658-n	slk:lemma	vynález
-01803583-s	slk:lemma	drsný
-00481592-s	slk:lemma	porovnateľný
+01803583-a	slk:lemma	drsný
+00481592-a	slk:lemma	porovnateľný
 01280488-v	slk:lemma	zohnúť sa
 01011031-v	slk:lemma	zaprisahať sa
 01803003-v	slk:lemma	trýzniť
-01755024-s	slk:lemma	ustavičný
+01755024-a	slk:lemma	ustavičný
 01018352-v	slk:lemma	domáhať sa
 00056930-v	slk:lemma	rodiť
 10149527-n	slk:lemma	garant
-02112108-s	slk:lemma	dohodnutý
+02112108-a	slk:lemma	dohodnutý
 02062081-v	slk:lemma	chodiť (tam a späť)
 06546783-n	slk:lemma	postupná listina
 00921300-v	slk:lemma	nasvedčovať (čomu)
@@ -28700,7 +28700,7 @@
 01202068-v	slk:lemma	chlipnúť si
 09629752-n	slk:lemma	cestujúci
 01469263-v	slk:lemma	položiť
-01706465-s	slk:lemma	utajovaný
+01706465-a	slk:lemma	utajovaný
 00082081-v	slk:lemma	napomáhať
 00355919-n	slk:lemma	minimalizácia
 08407330-n	slk:lemma	štatút
@@ -28717,7 +28717,7 @@
 12143572-n	slk:lemma	Zea
 14693733-n	slk:lemma	kremeň
 02200686-v	slk:lemma	podarovať
-02132735-s	slk:lemma	sexuálny
+02132735-a	slk:lemma	sexuálny
 02734423-n	slk:lemma	stavebná ozdoba
 02961099-a	slk:lemma	rakúsky
 01112885-n	slk:lemma	distribuovanie
@@ -28734,11 +28734,11 @@
 07184149-n	slk:lemma	hádka
 00024649-v	slk:lemma	osviežovať
 09264803-n	slk:lemma	delta
-02132224-s	slk:lemma	oplzlý
+02132224-a	slk:lemma	oplzlý
 02705428-v	slk:lemma	natiahnuť sa
 01711445-v	slk:lemma	predviesť (hru)
 00082081-v	slk:lemma	pomôcť
-02456157-s	slk:lemma	nervózny
+02456157-a	slk:lemma	nervózny
 06642356-n	slk:lemma	novina
 08048948-n	slk:lemma	lineárna organizácia
 00403092-n	slk:lemma	poškodenie
@@ -28749,7 +28749,7 @@
 08301155-n	slk:lemma	Medzinárodné rozvojové združenie
 05461179-n	slk:lemma	krycí systém
 05857974-n	slk:lemma	árnosť
-01515280-s	slk:lemma	aktívny
+01515280-a	slk:lemma	aktívny
 02394477-n	slk:lemma	párnokopytník
 08407619-n	slk:lemma	expozícia
 07467212-n	slk:lemma	štvrťfinále
@@ -28760,7 +28760,7 @@
 13148791-n	slk:lemma	čeľaď paprikovité
 09774266-n	slk:lemma	konzultant
 00181640-n	slk:lemma	verejné hlasovanie
-02331857-s	slk:lemma	kvitnúci
+02331857-a	slk:lemma	kvitnúci
 01122754-n	slk:lemma	financovanie pomocou deficitu
 00430140-n	slk:lemma	finančná špekulácia
 14407536-n	slk:lemma	okúzlenie
@@ -28769,7 +28769,7 @@
 01907258-v	slk:lemma	obracať sa
 02179518-v	slk:lemma	vydať zvuk
 02681518-n	slk:lemma	ozdoba
-02421364-s	slk:lemma	opatrný
+02421364-a	slk:lemma	opatrný
 00036935-r	slk:lemma	určite
 08912842-n	slk:lemma	Perzská ríša
 02427103-v	slk:lemma	budovať
@@ -28787,7 +28787,7 @@
 07526757-n	slk:lemma	šťastie
 02564146-v	slk:lemma	uvoľniť
 03204955-n	slk:lemma	smerová anténa
-00218950-s	slk:lemma	krásny
+00218950-a	slk:lemma	krásny
 07539790-n	slk:lemma	otrava
 03431243-n	slk:lemma	pohon
 02140970-n	slk:lemma	podrad Microchiroptera
@@ -28799,7 +28799,7 @@
 03197337-n	slk:lemma	digitálne hodinky
 00220869-v	slk:lemma	zosilňovať
 10639925-n	slk:lemma	športový fanúšik
-00792202-s	slk:lemma	základný
+00792202-a	slk:lemma	základný
 05455690-n	slk:lemma	žltá škvrna
 09939313-n	slk:lemma	zápasník
 00693399-n	slk:lemma	tracheotómia
@@ -28820,8 +28820,8 @@
 04360501-n	slk:lemma	podpora
 02215355-v	slk:lemma	zmocniť sa (územia)
 05098099-n	slk:lemma	extrém
-00053032-s	slk:lemma	prilepený
-00608791-s	slk:lemma	podivný
+00053032-a	slk:lemma	prilepený
+00608791-a	slk:lemma	podivný
 00927711-v	slk:lemma	naznačiť
 13901858-n	slk:lemma	kvapka rosy
 07001717-n	slk:lemma	histogram
@@ -28839,7 +28839,7 @@
 11630351-n	slk:lemma	rod Cupressus
 14452151-n	slk:lemma	pocit plnosti
 00031899-r	slk:lemma	ozaj
-02521183-s	slk:lemma	neplatený
+02521183-a	slk:lemma	neplatený
 14483917-n	slk:lemma	šanca
 04113765-n	slk:lemma	oválna klenba
 15259284-n	slk:lemma	stredovek
@@ -28858,11 +28858,11 @@
 00804476-v	slk:lemma	kapitulovať
 06518068-n	slk:lemma	poukážka
 08699654-n	slk:lemma	Namíbia
-02331857-s	slk:lemma	triumfálny
+02331857-a	slk:lemma	triumfálny
 06799260-n	slk:lemma	škrt
 05556204-n	slk:lemma	prebytočný tuk v okolí pása
 01873530-v	slk:lemma	zvýšiť
-01780343-s	slk:lemma	racionálny
+01780343-a	slk:lemma	racionálny
 10340312-n	slk:lemma	hráč
 15271008-n	slk:lemma	pozastavenie
 01149303-n	slk:lemma	podmienka
@@ -28874,7 +28874,7 @@
 00459013-n	slk:lemma	virtuálna skutočnosť
 08906374-n	slk:lemma	Nepálske kráľovstvo
 09454642-n	slk:lemma	pleso
-00667353-s	slk:lemma	živý
+00667353-a	slk:lemma	živý
 01716491-a	slk:lemma	nechutný
 00858781-v	slk:lemma	podnecovať
 00782527-v	slk:lemma	naviesť
@@ -28888,12 +28888,12 @@
 04262678-n	slk:lemma	audio záznam
 08308313-n	slk:lemma	porada
 05472032-n	slk:lemma	processus coronoideus
-01664015-s	slk:lemma	optimistický
+01664015-a	slk:lemma	optimistický
 00697365-n	slk:lemma	očkovanie
 13299248-n	slk:lemma	celková čiastka
 02637202-v	slk:lemma	zostávať
 01171183-v	slk:lemma	vychľastať
-00844719-s	slk:lemma	pružný
+00844719-a	slk:lemma	pružný
 00557686-v	slk:lemma	prať
 03161450-n	slk:lemma	tlmič
 02006228-a	slk:lemma	sieťový
@@ -28902,20 +28902,20 @@
 01590007-v	slk:lemma	opierať sa o
 00190959-r	slk:lemma	intenzívne
 02081578-v	slk:lemma	nechávať
-01277426-s	slk:lemma	vrchný
+01277426-a	slk:lemma	vrchný
 01405044-v	slk:lemma	zasiahnuť
 06537951-n	slk:lemma	stanovy
 01585759-v	slk:lemma	zbaviť sa
 00348541-v	slk:lemma	rozbiehať sa
-02342608-s	slk:lemma	veľkolepý
+02342608-a	slk:lemma	veľkolepý
 01246926-n	slk:lemma	schovávanie sa
 00733883-n	slk:lemma	prečin
-00906655-s	slk:lemma	znevažujúci
+00906655-a	slk:lemma	znevažujúci
 08844557-n	slk:lemma	Papua Nová Guinea
 02295550-v	slk:lemma	spoločne užívať
 08003935-n	slk:lemma	pridružená firma
 13440935-n	slk:lemma	binárna operácia
-00878086-s	slk:lemma	predbežný
+00878086-a	slk:lemma	predbežný
 08478482-n	slk:lemma	sťahovacia firma
 10746581-n	slk:lemma	poddaný
 11452218-n	slk:lemma	voľná energia
@@ -28927,18 +28927,18 @@
 03860404-n	slk:lemma	záchodová búdka
 10051975-n	slk:lemma	emigrant
 00794079-v	slk:lemma	vyvolávať
-01752953-s	slk:lemma	pokazený
+01752953-a	slk:lemma	pokazený
 10332385-n	slk:lemma	matka
 01181166-v	slk:lemma	posilňovať
 08491027-n	slk:lemma	adresa
-02474476-s	slk:lemma	usporiadaný
+02474476-a	slk:lemma	usporiadaný
 09461515-n	slk:lemma	rieka Trent
 03959350-n	slk:lemma	plán
 00904690-v	slk:lemma	preukázať správnosť (niečoho)
 04264914-n	slk:lemma	vesmírna loď
-02314070-s	slk:lemma	pokrivený
+02314070-a	slk:lemma	pokrivený
 02549581-v	slk:lemma	dohliadať
-00228025-s	slk:lemma	víťazný
+00228025-a	slk:lemma	víťazný
 06756831-n	slk:lemma	lož
 09367991-n	slk:lemma	nevyhnutnosť
 07994941-n	slk:lemma	svorka
@@ -28952,7 +28952,7 @@
 02532458-v	slk:lemma	skúsiť to
 14755077-n	slk:lemma	živočíšny olej
 01097192-v	slk:lemma	narukovať
-00491511-s	slk:lemma	jedinečný
+00491511-a	slk:lemma	jedinečný
 00674196-a	slk:lemma	vyrobený strojom
 00122626-a	slk:lemma	nasledujúci
 04153025-n	slk:lemma	clona
@@ -28968,15 +28968,15 @@
 06599788-n	slk:lemma	téma
 06593803-n	slk:lemma	publikácia
 01327301-v	slk:lemma	zbaviť sa
-01440422-s	slk:lemma	dlhodobo splatný
+01440422-a	slk:lemma	dlhodobo splatný
 02413480-v	slk:lemma	odmakať si
 08246613-n	slk:lemma	hudobné zoskupenie
 00196203-r	slk:lemma	v poriadku
 03781594-n	slk:lemma	mešec
 01222958-v	slk:lemma	obracať
-01866812-s	slk:lemma	márny
+01866812-a	slk:lemma	márny
 02022804-v	slk:lemma	stretnúť
-01532454-s	slk:lemma	priemerný
+01532454-a	slk:lemma	priemerný
 08621598-n	slk:lemma	miesto
 00117959-n	slk:lemma	žmurknutie
 00817167-v	slk:lemma	zaprieť
@@ -28984,7 +28984,7 @@
 00217152-v	slk:lemma	zaliať
 08745011-n	slk:lemma	Heroica Puebla de Zaragoza
 07160883-n	slk:lemma	rečový akt
-00633581-s	slk:lemma	poctivý
+00633581-a	slk:lemma	poctivý
 00014034-v	slk:lemma	triasť sa
 14405225-n	slk:lemma	povznesenie
 00660730-v	slk:lemma	odhadovať nižšie
@@ -28994,7 +28994,7 @@
 01982866-v	slk:lemma	vztýčiť
 05979909-n	slk:lemma	pochybnosť
 06732581-n	slk:lemma	opätovné vyhlásenie
-02516148-s	slk:lemma	vizuálny
+02516148-a	slk:lemma	vizuálny
 05329215-n	slk:lemma	zažívací systém
 10142747-n	slk:lemma	babička
 07553301-n	slk:lemma	pocit spolupatričnosti
@@ -29019,10 +29019,10 @@
 00669243-v	slk:lemma	pomôcť niekomu v ťažkostiach
 05805902-n	slk:lemma	chápanie
 03948459-n	slk:lemma	strelná zbraň
-00127137-s	slk:lemma	predchádzajúci
+00127137-a	slk:lemma	predchádzajúci
 01090446-n	slk:lemma	komercionalizmus
 01523520-v	slk:lemma	odvíjať sa
-01638962-s	slk:lemma	dávny
+01638962-a	slk:lemma	dávny
 03281145-n	slk:lemma	výťah
 10280130-n	slk:lemma	maestro
 00419685-v	slk:lemma	uvoľňovať sa
@@ -29036,7 +29036,7 @@
 02345048-v	slk:lemma	drancovať
 01552519-v	slk:lemma	odsekávať
 02943303-a	slk:lemma	environmentálny
-01642657-s	slk:lemma	revolučný
+01642657-a	slk:lemma	revolučný
 02653996-v	slk:lemma	táboriť vonku
 10412910-n	slk:lemma	šľachtic
 02298632-v	slk:lemma	ponúknuť cenu
@@ -29110,7 +29110,7 @@
 07677982-n	slk:lemma	klobáska
 14418395-n	slk:lemma	jednota
 00597532-n	slk:lemma	hodnosť arcibiskupa
-00640660-s	slk:lemma	úsečný
+00640660-a	slk:lemma	úsečný
 10533013-n	slk:lemma	konkurent
 08276342-n	slk:lemma	školské zariadenie
 00044353-a	slk:lemma	potenciálny
@@ -29124,7 +29124,7 @@
 00424934-n	slk:lemma	brutalita
 01178565-v	slk:lemma	nakŕmiť
 11900569-n	slk:lemma	mak
-00182961-s	slk:lemma	ručne ovládaný
+00182961-a	slk:lemma	ručne ovládaný
 01448100-v	slk:lemma	ťahať
 06343971-n	slk:lemma	titulok novín
 00512487-a	slk:lemma	konkurenčný
@@ -29134,7 +29134,7 @@
 07911677-n	slk:lemma	koktejl
 02153709-v	slk:lemma	hľadať
 01741446-v	slk:lemma	kultivovať
-01154030-s	slk:lemma	páperovitý
+01154030-a	slk:lemma	páperovitý
 06435651-n	slk:lemma	Prvá kniha kroník
 00770141-v	slk:lemma	odhovárať
 06808493-n	slk:lemma	spôsob zápisu
@@ -29180,10 +29180,10 @@
 01552519-v	slk:lemma	ťať
 00899956-v	slk:lemma	salutovať
 02760099-n	slk:lemma	kávomat
-02215087-s	slk:lemma	špecifický
+02215087-a	slk:lemma	špecifický
 08562243-n	slk:lemma	Orient
 09815455-n	slk:lemma	nadobúdateľ
-00854255-s	slk:lemma	emocionálny
+00854255-a	slk:lemma	emocionálny
 08391387-n	slk:lemma	národná garda
 05694791-n	slk:lemma	pokušenie
 13815742-n	slk:lemma	percento
@@ -29195,7 +29195,7 @@
 00117082-r	slk:lemma	spolu (s)
 05488909-n	slk:lemma	spánková brázda
 00859325-v	slk:lemma	tešiť sa
-00731955-s	slk:lemma	spojenecký
+00731955-a	slk:lemma	spojenecký
 00687926-v	slk:lemma	nedôverovať
 01463963-v	slk:lemma	usporadúvať
 00441445-v	slk:lemma	znížiť
@@ -29204,7 +29204,7 @@
 02538765-v	slk:lemma	starieť sa
 05538494-n	slk:lemma	hrádza
 00303221-n	slk:lemma	let balónom
-02516148-s	slk:lemma	optický
+02516148-a	slk:lemma	optický
 03536348-n	slk:lemma	vodorovný povrch
 00953058-v	slk:lemma	rozprávať
 00107230-r	slk:lemma	nezvyčajne
@@ -29214,12 +29214,12 @@
 09743986-n	slk:lemma	obyvateľ Missouri
 00356954-v	slk:lemma	dvíhať sa
 00104539-n	slk:lemma	vrh
-01143138-s	slk:lemma	stupňovitý
+01143138-a	slk:lemma	stupňovitý
 09697986-n	slk:lemma	Čiľan
 03319167-n	slk:lemma	protijadrový kryt
-01649651-s	slk:lemma	mladší
+01649651-a	slk:lemma	mladší
 01410606-a	slk:lemma	podobný
-02050841-s	slk:lemma	agrárny
+02050841-a	slk:lemma	agrárny
 02946921-n	slk:lemma	konzerva
 01296016-v	slk:lemma	zošiť
 02074915-n	slk:lemma	Carnivora
@@ -29239,7 +29239,7 @@
 01982866-v	slk:lemma	dvíhať sa
 07625493-n	slk:lemma	piroh
 06748466-n	slk:lemma	program
-02144436-s	slk:lemma	elastický
+02144436-a	slk:lemma	elastický
 03250588-n	slk:lemma	hladidlo
 09038990-n	slk:lemma	Kurdistan
 07285403-n	slk:lemma	skúsenosť
@@ -29253,12 +29253,12 @@
 02084732-n	slk:lemma	havo
 08358594-n	slk:lemma	kádre
 00366675-n	slk:lemma	napínanie
-01610484-s	slk:lemma	zistený
+01610484-a	slk:lemma	zistený
 05457469-n	slk:lemma	semeno
 00859758-v	slk:lemma	rozosmiať
 06671484-n	slk:lemma	porada
 10317884-n	slk:lemma	predavač mlieka
-01975671-s	slk:lemma	podstatný
+01975671-a	slk:lemma	podstatný
 00156601-v	slk:lemma	zväčšiť
 01570935-v	slk:lemma	drhnúť
 09815790-n	slk:lemma	asistent
@@ -29267,20 +29267,20 @@
 03098140-n	slk:lemma	rozvádzač
 09166304-n	slk:lemma	Lusitánia
 07018931-n	slk:lemma	činohra
-01459755-s	slk:lemma	rozkošný
+01459755-a	slk:lemma	rozkošný
 00096333-r	slk:lemma	hore
 00019613-n	slk:lemma	základ
 02130524-v	slk:lemma	kuknúť (pozrieť)
 05125377-n	slk:lemma	dosah
 01776974-a	slk:lemma	psychoaktívny
 00463234-v	slk:lemma	stlmiť
-00848679-s	slk:lemma	predpísaný
-00699521-s	slk:lemma	primárny
+00848679-a	slk:lemma	predpísaný
+00699521-a	slk:lemma	primárny
 01767949-v	slk:lemma	urobiť dojem
 09230041-n	slk:lemma	nora
 00873682-v	slk:lemma	ohlásiť
 00732746-n	slk:lemma	narušenie morálky
-01152521-s	slk:lemma	oceľový
+01152521-a	slk:lemma	oceľový
 07152259-n	slk:lemma	volebné heslo
 15206590-n	slk:lemma	štvrťrok
 11416722-n	slk:lemma	dopad
@@ -29294,29 +29294,29 @@
 03665366-n	slk:lemma	zdroj svetla
 00072730-v	slk:lemma	pomočiť
 13243780-n	slk:lemma	podnik jednotlivca
-02514380-s	slk:lemma	hnusný
+02514380-a	slk:lemma	hnusný
 00811171-v	slk:lemma	obchádzať
-01395821-s	slk:lemma	pokojný
+01395821-a	slk:lemma	pokojný
 13337770-n	slk:lemma	firemná obligácia
-00195383-s	slk:lemma	hrozný
+00195383-a	slk:lemma	hrozný
 13358549-n	slk:lemma	peňažný fond
-00448314-s	slk:lemma	blížiaci sa
+00448314-a	slk:lemma	blížiaci sa
 01381549-v	slk:lemma	dať dohromady
 09476123-n	slk:lemma	úroveň vody
 14806838-n	slk:lemma	chemikália
 05564323-n	slk:lemma	predlaktie
 02295842-v	slk:lemma	užívať spoločne
 05128870-n	slk:lemma	plošná výmera
-00998207-s	slk:lemma	páperovitý
+00998207-a	slk:lemma	páperovitý
 00696189-v	slk:lemma	pozrieť sa (na)
 00712135-v	slk:lemma	odhadovať
 00695226-v	slk:lemma	určiť cenu
 01782650-v	slk:lemma	zľaknúť sa
-02321809-s	slk:lemma	svalnatý
+02321809-a	slk:lemma	svalnatý
 00442361-a	slk:lemma	ďaleký
 07177924-n	slk:lemma	dohoda
 12299988-n	slk:lemma	čeľaď olivovité
-00915420-s	slk:lemma	fotografický
+00915420-a	slk:lemma	fotografický
 02767701-a	slk:lemma	lodný
 02532458-v	slk:lemma	skúšať to
 00755745-v	slk:lemma	vyžiadať
@@ -29346,12 +29346,12 @@
 11410625-n	slk:lemma	výsledok
 03429914-n	slk:lemma	sieťka
 06609403-n	slk:lemma	nemohra
-02077904-s	slk:lemma	cvoknutý
+02077904-a	slk:lemma	cvoknutý
 01094725-n	slk:lemma	obchodovanie
 15143012-n	slk:lemma	počiatočné štádium
 13721529-n	slk:lemma	malá tona
 08596076-n	slk:lemma	piesočnaté pobrežie
-02083908-s	slk:lemma	intelektuálsky
+02083908-a	slk:lemma	intelektuálsky
 01989053-v	slk:lemma	padnúť
 00231887-n	slk:lemma	zrušenie právnej normy
 00205891-n	slk:lemma	obeť
@@ -29368,19 +29368,19 @@
 01304570-a	slk:lemma	informačný
 05627785-n	slk:lemma	nebo
 02172888-v	slk:lemma	zaznievať
-01740358-s	slk:lemma	fanaticky nacionalistický
-00798103-s	slk:lemma	nacenganý
-01116118-s	slk:lemma	skutočný
+01740358-a	slk:lemma	fanaticky nacionalistický
+00798103-a	slk:lemma	nacenganý
+01116118-a	slk:lemma	skutočný
 05844663-n	slk:lemma	farba
 00677544-v	slk:lemma	prebrať
-01035007-s	slk:lemma	cudzokrajný
+01035007-a	slk:lemma	cudzokrajný
 00103834-n	slk:lemma	pohon
 00412839-n	slk:lemma	kanibalizmus
 00755745-v	slk:lemma	očakávať
 07136206-n	slk:lemma	dialóg
-01912858-s	slk:lemma	neskúsený
+01912858-a	slk:lemma	neskúsený
 03530041-n	slk:lemma	samonavádzacie zariadenie
-00160768-s	slk:lemma	samostatný
+00160768-a	slk:lemma	samostatný
 12710693-n	slk:lemma	sladký pomarančovník
 09303008-n	slk:lemma	pahorok
 04247736-n	slk:lemma	bufet
@@ -29389,7 +29389,7 @@
 05469424-n	slk:lemma	Paciniho teliesko
 03675558-n	slk:lemma	zápalná šnúra
 00239230-n	slk:lemma	iniciatíva
-00766102-s	slk:lemma	úprimný
+00766102-a	slk:lemma	úprimný
 08707917-n	slk:lemma	Angola
 02801184-n	slk:lemma	bazilika
 13275288-n	slk:lemma	trovy
@@ -29409,17 +29409,17 @@
 14709265-n	slk:lemma	lieh
 04405540-n	slk:lemma	televízne príslušenstvo
 00043609-n	slk:lemma	zbavenie sa niečoho
-00697691-s	slk:lemma	neurčitý
+00697691-a	slk:lemma	neurčitý
 08151490-n	slk:lemma	nasledovník kultu
 12808227-n	slk:lemma	rad Polemoniales
 00553362-n	slk:lemma	zlom
 05013204-n	slk:lemma	absolútny bod mrazu
 00252662-n	slk:lemma	zbavenie
 00748282-v	slk:lemma	uložiť
-00792202-s	slk:lemma	nezvratný
+00792202-a	slk:lemma	nezvratný
 02351010-v	slk:lemma	oceniť
 00391599-n	slk:lemma	demontáž
-01602966-s	slk:lemma	južný
+01602966-a	slk:lemma	južný
 01235946-n	slk:lemma	represálie
 01819147-v	slk:lemma	odrádzať
 13353280-n	slk:lemma	majetok
@@ -29441,14 +29441,14 @@
 05426243-n	slk:lemma	vrstva tkaniva
 01188725-v	slk:lemma	vyžadovať si
 09081955-n	slk:lemma	Lewiston
-01287486-s	slk:lemma	badateľný
+01287486-a	slk:lemma	badateľný
 04340750-n	slk:lemma	truhlica
 09025584-n	slk:lemma	Cartagena
 00767826-n	slk:lemma	napadnutie
 01105737-n	slk:lemma	plavba
 10084295-n	slk:lemma	dievča
 00133160-n	slk:lemma	úder chrbtom ruky
-00874226-s	slk:lemma	energický
+00874226-a	slk:lemma	energický
 00015388-n	slk:lemma	zviera
 05332802-n	slk:lemma	ľadvina
 00229260-n	slk:lemma	uzatvorenie
@@ -29456,13 +29456,13 @@
 04136510-n	slk:lemma	okenné krídlo
 08517127-n	slk:lemma	okraj
 13735355-n	slk:lemma	násobok, spoločný
-01728919-s	slk:lemma	uplynulý
+01728919-a	slk:lemma	uplynulý
 01824532-v	slk:lemma	zaželať
 00123500-r	slk:lemma	ekonomicky
 08295580-n	slk:lemma	OSN
 08717730-n	slk:lemma	Kapverdské ostrovy
 09320985-n	slk:lemma	rieka James
-00893118-s	slk:lemma	nádejný
+00893118-a	slk:lemma	nádejný
 01083645-n	slk:lemma	rozdelenie
 04627000-n	slk:lemma	vrelosť
 09270894-n	slk:lemma	zem
@@ -29475,7 +29475,7 @@
 00220023-n	slk:lemma	vražda
 02991555-n	slk:lemma	cela
 08651247-n	slk:lemma	miesto
-00829041-s	slk:lemma	povolený na odstrel
+00829041-a	slk:lemma	povolený na odstrel
 09008130-n	slk:lemma	Nižný Novgorod
 08565506-n	slk:lemma	nirvána
 07000195-n	slk:lemma	graf
@@ -29492,13 +29492,13 @@
 02424128-v	slk:lemma	prinútiť
 07199191-n	slk:lemma	kvíz
 04658268-n	slk:lemma	agresivita
-01822563-s	slk:lemma	vykonateľný
+01822563-a	slk:lemma	vykonateľný
 14173484-n	slk:lemma	bolesť v krku
 05910940-n	slk:lemma	agenda
-00758800-s	slk:lemma	zdvorilý
+00758800-a	slk:lemma	zdvorilý
 00389083-v	slk:lemma	zničiť
 05048123-n	slk:lemma	súbežnosť
-00076127-s	slk:lemma	akceptujúci
+00076127-a	slk:lemma	akceptujúci
 15207872-n	slk:lemma	synodický mesiac
 06453723-n	slk:lemma	Zákon
 02708420-v	slk:lemma	stráviť
@@ -29513,7 +29513,7 @@
 08077292-n	slk:lemma	administratívny orgán
 00485711-a	slk:lemma	všeobecný
 10251779-n	slk:lemma	školák
-02144436-s	slk:lemma	ťažný
+02144436-a	slk:lemma	ťažný
 01673503-n	slk:lemma	šupináče
 00822101-v	slk:lemma	dávať notársky overovať
 00041954-r	slk:lemma	hlavne
@@ -29561,17 +29561,17 @@
 03907654-n	slk:lemma	zariadenie na výkon trestu
 13640716-n	slk:lemma	lx
 02619424-v	slk:lemma	navštevovať
-02144436-s	slk:lemma	poddajný
+02144436-a	slk:lemma	poddajný
 00551210-v	slk:lemma	prehlbovať hlas
 00187526-v	slk:lemma	vkladať
-02355248-s	slk:lemma	zúčastnený
+02355248-a	slk:lemma	zúčastnený
 05624700-n	slk:lemma	kreatívne myslenie
 01064151-v	slk:lemma	preberať
 09382990-n	slk:lemma	Pacifik
 13516597-n	slk:lemma	mitotické delenie
 02443849-v	slk:lemma	prevádzkovať
 07052291-n	slk:lemma	strofa
-02332845-s	slk:lemma	nepochybný
+02332845-a	slk:lemma	nepochybný
 00214951-v	slk:lemma	mokriť sa
 08541841-n	slk:lemma	geografické pásmo
 03063073-n	slk:lemma	kávová šálka
@@ -29595,7 +29595,7 @@
 14825062-n	slk:lemma	krycí materiál
 09281545-n	slk:lemma	rieka Flint
 06808493-n	slk:lemma	spôsob záznamu
-00378782-s	slk:lemma	olivovozelený
+00378782-a	slk:lemma	olivovozelený
 07360647-n	slk:lemma	infekcia
 14490564-n	slk:lemma	dlh
 03763968-n	slk:lemma	vojenská uniforma
@@ -29635,11 +29635,11 @@
 01232684-n	slk:lemma	návšteva
 02698319-v	slk:lemma	určovať
 01580467-v	slk:lemma	obkľúčiť
-01384730-s	slk:lemma	kolosálny
+01384730-a	slk:lemma	kolosálny
 08682819-n	slk:lemma	západ USA
 00786195-n	slk:lemma	pokus
 00793037-v	slk:lemma	zvolávať
-01116118-s	slk:lemma	poctivý
+01116118-a	slk:lemma	poctivý
 00317207-n	slk:lemma	prinášanie
 02549392-v	slk:lemma	poslúžiť
 02222318-v	slk:lemma	zahadzovať
@@ -29670,7 +29670,7 @@
 04491388-n	slk:lemma	policajný obušok
 02520730-v	slk:lemma	dohnať
 02661252-v	slk:lemma	odlišovať sa
-00640660-s	slk:lemma	krátky
+00640660-a	slk:lemma	krátky
 05029706-n	slk:lemma	odolnosť
 15290337-n	slk:lemma	štádium
 00598753-v	slk:lemma	dobehnúť
@@ -29698,7 +29698,7 @@
 10753779-n	slk:lemma	záporná postava
 01875295-v	slk:lemma	pohojdať sa
 02297142-v	slk:lemma	ponúknuť
-00412788-s	slk:lemma	barbarský
+00412788-a	slk:lemma	barbarský
 05633385-n	slk:lemma	nápad
 05799212-n	slk:lemma	skúška
 00281752-n	slk:lemma	priblíženie k letisku
@@ -29711,14 +29711,14 @@
 01017643-v	slk:lemma	obhajovať
 01767949-v	slk:lemma	vzbudiť dojem
 06815714-n	slk:lemma	partitúra
-01041209-s	slk:lemma	tolerantný
+01041209-a	slk:lemma	tolerantný
 01446283-n	slk:lemma	čeľaď Cyprinodontidae
 01006421-v	slk:lemma	načrtávať
 07251984-n	slk:lemma	povýšenie
 09822955-n	slk:lemma	auditor
 12663359-n	slk:lemma	káva Robusta
 06399995-n	slk:lemma	odsek
-00658513-s	slk:lemma	kolineárny
+00658513-a	slk:lemma	kolineárny
 01108971-n	slk:lemma	úschova
 06481156-n	slk:lemma	cenné papiere
 07512147-n	slk:lemma	vážnosť
@@ -29740,7 +29740,7 @@
 04040247-n	slk:lemma	radiálna pneumatika
 02590340-v	slk:lemma	osídľovať
 02833576-n	slk:lemma	skosenie
-01178458-s	slk:lemma	nadmerne zväčšený
+01178458-a	slk:lemma	nadmerne zväčšený
 00632627-v	slk:lemma	dedukovať
 00987071-v	slk:lemma	popísať
 00123170-v	slk:lemma	zmeniť sa
@@ -29750,14 +29750,14 @@
 01229976-v	slk:lemma	bodať
 06732350-n	slk:lemma	vyhlásenie
 13764540-n	slk:lemma	náručie
-01313649-s	slk:lemma	opustený
+01313649-a	slk:lemma	opustený
 00195024-r	slk:lemma	pravidelne
 07517550-n	slk:lemma	urážka
 07840804-n	slk:lemma	vajce
 00588703-n	slk:lemma	úrad admirála
 07120524-n	slk:lemma	volanie
 00262881-v	slk:lemma	narušovať
-02164913-s	slk:lemma	krehký
+02164913-a	slk:lemma	krehký
 00039941-r	slk:lemma	zjavne
 04464615-n	slk:lemma	guľový ovládač
 01632537-a	slk:lemma	oficiálny
@@ -29767,7 +29767,7 @@
 13165815-n	slk:lemma	kmeň
 09384921-n	slk:lemma	rieka Parana
 14006945-n	slk:lemma	aktívnosť
-01636205-s	slk:lemma	oprávnený
+01636205-a	slk:lemma	oprávnený
 00510364-v	slk:lemma	robiť machule
 01820302-v	slk:lemma	vychutnávať
 05728678-n	slk:lemma	návrh
@@ -29784,7 +29784,7 @@
 05238036-n	slk:lemma	ochranný obal
 02924713-n	slk:lemma	zbernica počítača
 00632627-v	slk:lemma	sformulovať
-02363614-s	slk:lemma	imúnny
+02363614-a	slk:lemma	imúnny
 04876053-n	slk:lemma	neúprimnosť
 05846054-n	slk:lemma	pravidlo
 03322099-n	slk:lemma	gazdovstvo
@@ -29829,7 +29829,7 @@
 05032351-n	slk:lemma	statočnosť
 02467662-v	slk:lemma	rezať
 00820976-v	slk:lemma	svedčiť
-01309657-s	slk:lemma	detinský
+01309657-a	slk:lemma	detinský
 00071840-r	slk:lemma	naokolo
 07399917-n	slk:lemma	vírenie
 00859325-v	slk:lemma	rozveseliť sa
@@ -29853,11 +29853,11 @@
 05870180-n	slk:lemma	zloženina
 13658657-n	slk:lemma	milimeter
 00503164-v	slk:lemma	povzbudzovať
-00152629-s	slk:lemma	nemý
+00152629-a	slk:lemma	nemý
 01028748-v	slk:lemma	nazývať
 02471327-v	slk:lemma	hlásiť sa
 00608162-n	slk:lemma	výroba šiat
-01407738-s	slk:lemma	nemanželský
+01407738-a	slk:lemma	nemanželský
 00257269-v	slk:lemma	rozšíriť sa
 10066732-n	slk:lemma	odhadca
 00023271-n	slk:lemma	poznanie
@@ -29865,7 +29865,7 @@
 00144405-r	slk:lemma	chvíľku
 14452294-n	slk:lemma	sýtosť
 14493145-n	slk:lemma	zbedačenie
-00566961-s	slk:lemma	susedný
+00566961-a	slk:lemma	susedný
 00793785-v	slk:lemma	zvádzať
 10548419-n	slk:lemma	predavačka
 09624168-n	slk:lemma	osoba mužského pohlavia
@@ -29879,7 +29879,7 @@
 09389601-n	slk:lemma	rieka Penobscot
 01808374-v	slk:lemma	mať odpor
 00107987-r	slk:lemma	kúsok po kúsku
-01520091-s	slk:lemma	totálny
+01520091-a	slk:lemma	totálny
 05651971-n	slk:lemma	vnem
 00860292-v	slk:lemma	aplaudovať
 00834009-v	slk:lemma	oklamať
@@ -29905,7 +29905,7 @@
 02157731-v	slk:lemma	zatemňovať sa
 01169194-a	slk:lemma	operačný
 05243879-n	slk:lemma	kožná vrstva
-01925708-s	slk:lemma	rozumný
+01925708-a	slk:lemma	rozumný
 08301155-n	slk:lemma	IDA
 13149039-n	slk:lemma	Piper
 00661713-v	slk:lemma	porovnať
@@ -29936,22 +29936,22 @@
 02663141-v	slk:lemma	nezodpovedať (niečomu)
 07319103-n	slk:lemma	zdar
 03098140-n	slk:lemma	riadiaci panel
-01755024-s	slk:lemma	večný
+01755024-a	slk:lemma	večný
 02506546-v	slk:lemma	uložiť povinnosť
-01439155-s	slk:lemma	obšírny
+01439155-a	slk:lemma	obšírny
 03413428-n	slk:lemma	herňa
 01212230-v	slk:lemma	spustiť
 00577931-n	slk:lemma	poradňa
 14956325-n	slk:lemma	blato
 15242029-n	slk:lemma	pôst
-00792202-s	slk:lemma	zvrchovaný
+00792202-a	slk:lemma	zvrchovaný
 13979173-n	slk:lemma	prevrat
 09125727-n	slk:lemma	Saratoga Springs
 13999941-n	slk:lemma	samoväzba
 07993279-n	slk:lemma	fauna
 00141396-n	slk:lemma	pitva
-01916784-s	slk:lemma	pochybný
-00194357-s	slk:lemma	zlý
+01916784-a	slk:lemma	pochybný
+00194357-a	slk:lemma	zlý
 02573275-v	slk:lemma	švindľovať
 00031820-v	slk:lemma	smiať sa
 12351975-n	slk:lemma	Musaceae
@@ -29976,7 +29976,7 @@
 00765649-v	slk:lemma	nástojiť
 00282840-n	slk:lemma	pokrok
 03825080-n	slk:lemma	oblečenie na noc
-02004685-s	slk:lemma	regulačný
+02004685-a	slk:lemma	regulačný
 10189776-n	slk:lemma	hospodárka
 01146768-n	slk:lemma	zajatie
 02701628-v	slk:lemma	uchovávať
@@ -29994,7 +29994,7 @@
 07409592-n	slk:lemma	dotýkanie
 00033922-r	slk:lemma	zanedlho
 00888786-v	slk:lemma	dohodovať sa
-00215087-s	slk:lemma	ochlpený
+00215087-a	slk:lemma	ochlpený
 05187446-n	slk:lemma	právo
 02540670-v	slk:lemma	poslúžiť niekomu
 00436879-v	slk:lemma	obohatiť
@@ -30005,15 +30005,15 @@
 01032040-n	slk:lemma	služby Božie
 03702719-n	slk:lemma	pršiplášť
 00983824-v	slk:lemma	vydať (zvuk)
-01336837-s	slk:lemma	neinteligentný
+01336837-a	slk:lemma	neinteligentný
 14009481-n	slk:lemma	chod
 09780249-n	slk:lemma	pomocník
 12901264-n	slk:lemma	Capsicum annuum
-00143854-s	slk:lemma	pokrytý oceľovými plátmi
+00143854-a	slk:lemma	pokrytý oceľovými plátmi
 13387877-n	slk:lemma	mince
 00067526-n	slk:lemma	prehra
 01577635-v	slk:lemma	ponoriť sa
-01350225-s	slk:lemma	vonkajší
+01350225-a	slk:lemma	vonkajší
 09410026-n	slk:lemma	štrbina
 08226699-n	slk:lemma	malomesto
 00029343-a	slk:lemma	nenásytný
@@ -30046,7 +30046,7 @@
 13286254-n	slk:lemma	vreckové
 10334567-n	slk:lemma	horal
 01171183-v	slk:lemma	naslopať sa
-02250430-s	slk:lemma	jediný
+02250430-a	slk:lemma	jediný
 01071632-v	slk:lemma	poslať
 05836598-n	slk:lemma	poňatie
 13144511-n	slk:lemma	Vitis
@@ -30054,17 +30054,17 @@
 14859201-n	slk:lemma	ferit
 00714884-v	slk:lemma	preberať niečo
 09448361-n	slk:lemma	vodné koryto
-01199083-s	slk:lemma	rozličný
+01199083-a	slk:lemma	rozličný
 00671190-v	slk:lemma	nespravodlivo oceňovať
 02413480-v	slk:lemma	makať
-02570643-s	slk:lemma	absurdný
+02570643-a	slk:lemma	absurdný
 00671190-v	slk:lemma	nesprávne posúdiť
 10371052-n	slk:lemma	navrhovateľ
 05247178-n	slk:lemma	nefrón
 03394649-n	slk:lemma	francúzske dvere
 01985029-v	slk:lemma	ľahnúť si
 04778630-n	slk:lemma	príjemnosť
-01385773-s	slk:lemma	sloní
+01385773-a	slk:lemma	sloní
 00248659-v	slk:lemma	rozvíjať sa
 00959376-n	slk:lemma	šarvátka
 02699141-v	slk:lemma	predstavovať
@@ -30088,7 +30088,7 @@
 00421691-v	slk:lemma	miznúť
 01350449-v	slk:lemma	nútiť
 07504111-n	slk:lemma	hnus
-00330506-s	slk:lemma	umiestený uprostred
+00330506-a	slk:lemma	umiestený uprostred
 05854150-n	slk:lemma	abstrakcia
 04277980-n	slk:lemma	chrbtica
 02898711-n	slk:lemma	nadjazd
@@ -30108,14 +30108,14 @@
 00504526-n	slk:lemma	halma
 07511626-n	slk:lemma	zlatá horúčka
 00682230-v	slk:lemma	oceniť
-00692255-s	slk:lemma	plytký
-02050841-s	slk:lemma	poľnohospodársky
+00692255-a	slk:lemma	plytký
+02050841-a	slk:lemma	poľnohospodársky
 07625493-n	slk:lemma	koláč z lístkového cesta
 00150287-v	slk:lemma	adaptovať sa
 07457126-n	slk:lemma	olympiáda
 00072012-v	slk:lemma	pocikávať sa
 10201535-n	slk:lemma	podvodník
-02456157-s	slk:lemma	nepokojný
+02456157-a	slk:lemma	nepokojný
 07974025-n	slk:lemma	sociálna vrstva
 02066510-v	slk:lemma	pohybovať sa
 14526182-n	slk:lemma	nálada
@@ -30132,31 +30132,31 @@
 04605446-n	slk:lemma	prikrývka
 00356621-n	slk:lemma	vyčerpanie
 06660520-n	slk:lemma	obchodné embargo
-00763272-s	slk:lemma	odvracajúci pozornosť
+00763272-a	slk:lemma	odvracajúci pozornosť
 01011031-v	slk:lemma	vyhlásiť
-00602563-s	slk:lemma	otázny
+00602563-a	slk:lemma	otázny
 00385266-n	slk:lemma	útek
 01762963-v	slk:lemma	otriasať (niekým)
 06413889-n	slk:lemma	knižka
 07704656-n	slk:lemma	sladká pšeničná kaša
-00521329-s	slk:lemma	ukončený
+00521329-a	slk:lemma	ukončený
 02541251-v	slk:lemma	slúžiť
 00836705-v	slk:lemma	skresľovať
 01249060-n	slk:lemma	opakovanie
-01876261-s	slk:lemma	progresívny
+01876261-a	slk:lemma	progresívny
 02500775-v	slk:lemma	trestať
 00052500-n	slk:lemma	pristátie
 10694258-n	slk:lemma	inštruktor
 06876007-n	slk:lemma	americký znakový jazyk
-01969150-s	slk:lemma	ročný
+01969150-a	slk:lemma	ročný
 02420232-v	slk:lemma	farmárčiť
 00612042-v	slk:lemma	zvečniť
 02506546-v	slk:lemma	nútiť
 09906986-n	slk:lemma	kancelár
-01216981-s	slk:lemma	napodobňujúci
+01216981-a	slk:lemma	napodobňujúci
 05243879-n	slk:lemma	kórium
 04517535-n	slk:lemma	vakcína
-01314537-s	slk:lemma	vrodený
+01314537-a	slk:lemma	vrodený
 00221819-n	slk:lemma	matkovražda
 12410381-n	slk:lemma	Liliidae
 04405907-n	slk:lemma	televízny prijímač
@@ -30168,11 +30168,11 @@
 09284015-n	slk:lemma	zalesnená krajina
 00214951-v	slk:lemma	zmáčať si
 00908621-v	slk:lemma	udržiavať v chode
-00070427-s	slk:lemma	senzuálny
+00070427-a	slk:lemma	senzuálny
 01886756-n	slk:lemma	placentovec
 03833564-n	slk:lemma	hubica
 05596651-n	slk:lemma	panva
-02218314-s	slk:lemma	početný
+02218314-a	slk:lemma	početný
 14424517-n	slk:lemma	renovácia
 01782650-v	slk:lemma	zdesiť sa
 05162985-n	slk:lemma	strata
@@ -30198,7 +30198,7 @@
 08978821-n	slk:lemma	Partská ríša
 05228020-n	slk:lemma	bradavkové teliesko
 02539334-v	slk:lemma	dominovať
-01401224-s	slk:lemma	legitímny
+01401224-a	slk:lemma	legitímny
 13969101-n	slk:lemma	pohoda
 01513430-v	slk:lemma	vyzliecť sa (z)
 14190493-n	slk:lemma	puerperálna horúčka
@@ -30228,12 +30228,12 @@
 02028366-v	slk:lemma	dopliesť sa
 05499379-n	slk:lemma	hypotalamus
 02731024-v	slk:lemma	zotrvať
-01082714-s	slk:lemma	neúspešný
+01082714-a	slk:lemma	neúspešný
 07544647-n	slk:lemma	láska
 01127795-v	slk:lemma	obraňovať sa
 07344015-n	slk:lemma	podvečer
 09931418-n	slk:lemma	súkromný tréner
-00011327-s	slk:lemma	prasačí
+00011327-a	slk:lemma	prasačí
 10253703-n	slk:lemma	legionár
 00060201-n	slk:lemma	únik
 09704509-n	slk:lemma	obyvateľ Liverpoolu
@@ -30245,7 +30245,7 @@
 10426749-n	slk:lemma	profesionálny fotograf
 13279262-n	slk:lemma	zárobok
 00242808-n	slk:lemma	prebudenie
-00967646-s	slk:lemma	fraškovitý
+00967646-a	slk:lemma	fraškovitý
 02260362-v	slk:lemma	realizovať obchodnú činnosť
 00871576-n	slk:lemma	krátenie
 04361641-n	slk:lemma	supresor
@@ -30253,21 +30253,21 @@
 02684924-v	slk:lemma	pokračovať
 13775706-n	slk:lemma	príval
 00164751-r	slk:lemma	v tom prípade
-01627315-s	slk:lemma	zavšivavený
+01627315-a	slk:lemma	zavšivavený
 00822367-v	slk:lemma	vyhlásiť (niekoho za niečo)
 05816622-n	slk:lemma	informácia
 03453696-n	slk:lemma	počítačová grafika
 09165613-n	slk:lemma	Zambijská republika
 01075164-v	slk:lemma	začať
-00127543-s	slk:lemma	za sebou
+00127543-a	slk:lemma	za sebou
 02202384-v	slk:lemma	nechávať si
-00740217-s	slk:lemma	nemenný
+00740217-a	slk:lemma	nemenný
 02633356-v	slk:lemma	pozostávať z
 03150795-n	slk:lemma	kurzor
 02498320-v	slk:lemma	rezervovať si
 00151755-r	slk:lemma	v konečnom dôsledku
 10069645-n	slk:lemma	výkonný pracovník
-01136248-s	slk:lemma	podráždený
+01136248-a	slk:lemma	podráždený
 02066939-v	slk:lemma	vlievať sa
 13477023-n	slk:lemma	evolúcia
 07059962-n	slk:lemma	pop
@@ -30285,7 +30285,7 @@
 01889610-v	slk:lemma	trepať sa
 08227214-n	slk:lemma	klub
 06155432-n	slk:lemma	anglistika
-01536276-s	slk:lemma	neo-
+01536276-a	slk:lemma	neo-
 14967478-n	slk:lemma	stály olej
 03327841-n	slk:lemma	ochranná mriežka na bicykli
 14433587-n	slk:lemma	výraznosť
@@ -30310,7 +30310,7 @@
 13397443-n	slk:lemma	dlh
 00069295-v	slk:lemma	vylúčiť
 04589593-n	slk:lemma	okenný rám
-00528761-s	slk:lemma	super
+00528761-a	slk:lemma	super
 01247807-n	slk:lemma	prepustenie na slobodu
 09845999-n	slk:lemma	kozmetička
 11551211-n	slk:lemma	Spermatophyta
@@ -30334,15 +30334,15 @@
 02387034-v	slk:lemma	pripravovať sa
 03617594-n	slk:lemma	televízna obrazovka
 00685683-v	slk:lemma	odmietnuť
-01660444-s	slk:lemma	pripravený k boju
-00927978-s	slk:lemma	nemajúci
+01660444-a	slk:lemma	pripravený k boju
+00927978-a	slk:lemma	nemajúci
 00389083-v	slk:lemma	útočiť
 00556313-n	slk:lemma	pohyb
 15268239-n	slk:lemma	pozastavenie
 00859758-v	slk:lemma	pobaviť sa
 01760944-a	slk:lemma	prípustný
 00507673-n	slk:lemma	hazardná hra
-02462375-s	slk:lemma	falošný
+02462375-a	slk:lemma	falošný
 02531625-v	slk:lemma	otestovať
 02584097-v	slk:lemma	prebiehať
 02525447-v	slk:lemma	fungovať
@@ -30352,11 +30352,11 @@
 07911371-n	slk:lemma	miešaný nápoj
 00959376-n	slk:lemma	ostrá výmena názorov
 06637350-n	slk:lemma	otvorenie procesu
-00521811-s	slk:lemma	úplný
+00521811-a	slk:lemma	úplný
 00235368-v	slk:lemma	vymedzovať
 11509377-n	slk:lemma	ľadová ihlička
 04610879-n	slk:lemma	dvorec
-01443097-s	slk:lemma	utekajúci
+01443097-a	slk:lemma	utekajúci
 13939892-n	slk:lemma	level
 13286099-n	slk:lemma	porcia
 02452885-v	slk:lemma	nedovoľovať
@@ -30379,7 +30379,7 @@
 00059854-r	slk:lemma	čím ďalej tým viac
 06876309-n	slk:lemma	gesto
 02027612-v	slk:lemma	tiesniť sa
-01143138-s	slk:lemma	postupný
+01143138-a	slk:lemma	postupný
 01071411-n	slk:lemma	milosť
 00754942-v	slk:lemma	nárokovať si
 09206693-n	slk:lemma	rieka Arno
@@ -30408,30 +30408,30 @@
 00672277-v	slk:lemma	hodnotiť
 00079617-r	slk:lemma	aktívne
 02407338-v	slk:lemma	bojovať
-01950198-s	slk:lemma	ťažký
+01950198-a	slk:lemma	ťažký
 13769123-n	slk:lemma	plná izba
 00599472-n	slk:lemma	úrad tajomníka
 00751145-n	slk:lemma	falzifikácia
 00609100-v	slk:lemma	nespomenúť si
 03138856-n	slk:lemma	koruna
-01789481-s	slk:lemma	poškvrnený
+01789481-a	slk:lemma	poškvrnený
 01044114-v	slk:lemma	zašuškať
-01050088-s	slk:lemma	hrozný
-02456157-s	slk:lemma	úzkostlivý
+01050088-a	slk:lemma	hrozný
+02456157-a	slk:lemma	úzkostlivý
 02670890-v	slk:lemma	plniť úlohu
 00455919-v	slk:lemma	doplniť
 03039711-n	slk:lemma	čistá bomba
 05549061-n	slk:lemma	plece
-01172139-s	slk:lemma	majúci zdravú farbu
+01172139-a	slk:lemma	majúci zdravú farbu
 11556187-n	slk:lemma	čeľaď jednoklíčnolistových ľaliovitých rastlín
 00329031-n	slk:lemma	pokĺznutie
 02691390-a	slk:lemma	veľkorysý
 14122235-n	slk:lemma	nákazlivá choroba
 05667404-n	slk:lemma	tradícia
 09392162-n	slk:lemma	Herkulove stĺpy
-00927978-s	slk:lemma	pustý
+00927978-a	slk:lemma	pustý
 08739512-n	slk:lemma	Panama City
-02506922-s	slk:lemma	mnohoraký
+02506922-a	slk:lemma	mnohoraký
 00780148-n	slk:lemma	podvod
 12289433-n	slk:lemma	lieskový orech
 07071942-n	slk:lemma	hudobný štýl
@@ -30441,7 +30441,7 @@
 01523823-v	slk:lemma	rozpletať
 03696301-n	slk:lemma	nosič batožín na veku batožinového priestoru
 05567217-n	slk:lemma	palec na ruke
-02083908-s	slk:lemma	suchý
+02083908-a	slk:lemma	suchý
 08179205-n	slk:lemma	chudobní
 05425910-n	slk:lemma	vlásočnica
 06655388-n	slk:lemma	princíp
@@ -30460,7 +30460,7 @@
 00868097-v	slk:lemma	vyzývať
 05767245-n	slk:lemma	zrkadlo
 03390075-n	slk:lemma	ochranný zákop
-00708738-s	slk:lemma	drobivý
+00708738-a	slk:lemma	drobivý
 13427078-n	slk:lemma	prispôsobenie
 00045907-n	slk:lemma	opätovné získanie
 05103072-n	slk:lemma	hrúbka
@@ -30480,9 +30480,9 @@
 01397210-v	slk:lemma	zbiť
 09922799-n	slk:lemma	cirkevný správca
 13705415-n	slk:lemma	srílanská rupia
-02327315-s	slk:lemma	hašterivý
+02327315-a	slk:lemma	hašterivý
 00174987-r	slk:lemma	hlava-nehlava
-02110778-s	slk:lemma	oddelený
+02110778-a	slk:lemma	oddelený
 00594337-v	slk:lemma	poznať
 07487375-n	slk:lemma	clivota
 09221571-n	slk:lemma	vtáčie hniezdo
@@ -30511,10 +30511,10 @@
 05319028-n	slk:lemma	endokranium
 02383440-v	slk:lemma	odísť
 05017909-n	slk:lemma	neviditeľnosť
-01243102-s	slk:lemma	divoký
-01601069-s	slk:lemma	severný
+01243102-a	slk:lemma	divoký
+01601069-a	slk:lemma	severný
 12992464-n	slk:lemma	Fungi
-01420337-s	slk:lemma	básnický
+01420337-a	slk:lemma	básnický
 00804502-a	slk:lemma	jednotvárny
 10123711-n	slk:lemma	podivín
 02467662-v	slk:lemma	deliť si
@@ -30528,12 +30528,12 @@
 15238169-n	slk:lemma	rastové obdobie
 07965085-n	slk:lemma	združenie
 09258715-n	slk:lemma	rozštiepenie
-00975487-s	slk:lemma	majúci šmrnc
+00975487-a	slk:lemma	majúci šmrnc
 02120997-n	slk:lemma	mačkovitá šelma
-02295098-s	slk:lemma	klasický
+02295098-a	slk:lemma	klasický
 14327266-n	slk:lemma	zle od žalúdka
 02577061-a	slk:lemma	svetský
-00481592-s	slk:lemma	merateľný
+00481592-a	slk:lemma	merateľný
 03671272-n	slk:lemma	linka
 13659943-n	slk:lemma	myriameter
 00685683-v	slk:lemma	zavrhnúť
@@ -30544,7 +30544,7 @@
 02144835-v	slk:lemma	skrývať
 00859325-v	slk:lemma	rozradostniť
 01615991-v	slk:lemma	odložiť
-02433975-s	slk:lemma	znudený
+02433975-a	slk:lemma	znudený
 02376958-v	slk:lemma	(vzájomne) ovplyvňovať
 03764276-n	slk:lemma	vojenské vozidlo
 06641524-n	slk:lemma	index zmien veľkoobchodných cien
@@ -30560,7 +30560,7 @@
 07450842-n	slk:lemma	ceremónia
 05638063-n	slk:lemma	umenie
 02309621-v	slk:lemma	podať (telo Kristovo, pomazanie)
-01262284-s	slk:lemma	ľudský
+01262284-a	slk:lemma	ľudský
 02672540-v	slk:lemma	opraviť
 14849880-n	slk:lemma	sklený papier
 01072072-n	slk:lemma	potešenie
@@ -30581,7 +30581,7 @@
 01336007-v	slk:lemma	previazať
 02130524-v	slk:lemma	kukať (pozerať)
 06345320-n	slk:lemma	podtitulok
-01536094-s	slk:lemma	súčasný
+01536094-a	slk:lemma	súčasný
 03110610-a	slk:lemma	expiratórny
 02206619-v	slk:lemma	uchvacovať
 02439929-n	slk:lemma	laba
@@ -30604,12 +30604,12 @@
 00670261-v	slk:lemma	hodnotiť
 03086974-a	slk:lemma	minerálny
 06887726-n	slk:lemma	zobrazenie
-00048858-s	slk:lemma	pomocný
+00048858-a	slk:lemma	pomocný
 00485711-a	slk:lemma	bežný
 04749991-n	slk:lemma	tolerancia
 02143539-v	slk:lemma	objaviť
 02528380-v	slk:lemma	zlyhávať
-01752953-s	slk:lemma	chybný
+01752953-a	slk:lemma	chybný
 13470491-n	slk:lemma	úbytok
 02663141-v	slk:lemma	odporovať
 03401500-n	slk:lemma	palivové potrubie
@@ -30625,15 +30625,15 @@
 08318904-n	slk:lemma	komora
 01654628-v	slk:lemma	postaviť
 09377657-n	slk:lemma	Ojos del Salado
-00425313-s	slk:lemma	odporný
+00425313-a	slk:lemma	odporný
 09906986-n	slk:lemma	premiér
 00431005-n	slk:lemma	žart
 09695514-n	slk:lemma	Brunejčan
 09320985-n	slk:lemma	James
 04548362-n	slk:lemma	peňaženka
-00792641-s	slk:lemma	zvrchovaný
+00792641-a	slk:lemma	zvrchovaný
 03079741-n	slk:lemma	oddelenie
-00602117-s	slk:lemma	sporný
+00602117-a	slk:lemma	sporný
 00025203-v	slk:lemma	znervóznieť
 00346715-r	slk:lemma	zárobkovo (činný)
 00843959-v	slk:lemma	obžalúvať
@@ -30649,7 +30649,7 @@
 00089657-n	slk:lemma	stiahnutie
 15254550-n	slk:lemma	prehistória
 01478002-v	slk:lemma	blokovať
-02340458-s	slk:lemma	pokorný
+02340458-a	slk:lemma	pokorný
 00659535-v	slk:lemma	podriadiť
 01823092-a	slk:lemma	nemožný
 02522864-v	slk:lemma	dosahovať niečo
@@ -30671,7 +30671,7 @@
 00079947-r	slk:lemma	nad
 13767822-n	slk:lemma	pohár
 09622302-n	slk:lemma	milenec
-00727113-s	slk:lemma	spoliehajúci sa na
+00727113-a	slk:lemma	spoliehajúci sa na
 01018928-v	slk:lemma	zmluvne určovať
 00074407-r	slk:lemma	dozadu
 00902932-v	slk:lemma	želať si
@@ -30702,12 +30702,12 @@
 10277638-n	slk:lemma	lutnista
 02106506-v	slk:lemma	pociťovať
 01352059-n	slk:lemma	čeľaď baktérií
-01723091-s	slk:lemma	zaujatý
+01723091-a	slk:lemma	zaujatý
 03339296-n	slk:lemma	plastická fólia
 14561618-n	slk:lemma	zhoršenie
 00141806-n	slk:lemma	kontrola
 00845909-v	slk:lemma	zneuctievať
-01625063-s	slk:lemma	hnusný
+01625063-a	slk:lemma	hnusný
 01621555-v	slk:lemma	zhotoviť
 02539101-v	slk:lemma	pliesť sa
 02085320-v	slk:lemma	rozlievať sa
@@ -30723,10 +30723,10 @@
 01449974-v	slk:lemma	viezť
 14499262-n	slk:lemma	porucha
 00462383-n	slk:lemma	kolky
-00813589-s	slk:lemma	prehistorický
+00813589-a	slk:lemma	prehistorický
 00229605-v	slk:lemma	stupňovať
 05018103-n	slk:lemma	jasnosť
-00477661-s	slk:lemma	pripomínajúci domov
+00477661-a	slk:lemma	pripomínajúci domov
 05546540-n	slk:lemma	krk
 00540235-v	slk:lemma	zväčšovať
 00140652-n	slk:lemma	manipulácia
@@ -30755,23 +30755,23 @@
 14698000-n	slk:lemma	sedimentovaná hornina
 10148165-n	slk:lemma	družba
 01568630-v	slk:lemma	premáhať
-02059811-s	slk:lemma	riskantný
+02059811-a	slk:lemma	riskantný
 09221723-n	slk:lemma	Biskajský záliv
 02434976-v	slk:lemma	pripojiť sa
 00385649-n	slk:lemma	odlúčenie
-01950198-s	slk:lemma	ťažkopádny
+01950198-a	slk:lemma	ťažkopádny
 09370383-n	slk:lemma	Newyorkský záliv
 05790242-n	slk:lemma	výber
 11485186-n	slk:lemma	hviezdna žiara
 01095218-v	slk:lemma	plniť úlohu
 00312380-v	slk:lemma	stmievať sa
-00792202-s	slk:lemma	najvyšší
+00792202-a	slk:lemma	najvyšší
 03903868-n	slk:lemma	podstavec
 02579140-v	slk:lemma	osvedčovať sa
 03899533-n	slk:lemma	cestička
 09164561-n	slk:lemma	Jemen
 02396970-n	slk:lemma	genus Phacochoerus
-00750054-s	slk:lemma	ľahký
+00750054-a	slk:lemma	ľahký
 08894456-n	slk:lemma	Wales
 08556491-n	slk:lemma	doména
 12709103-n	slk:lemma	pomelo
@@ -30782,7 +30782,7 @@
 14249512-n	slk:lemma	nezhubný nádor z priečne pruhovaného svalstva
 08524572-n	slk:lemma	stred búrky
 05532225-n	slk:lemma	tráviaca trubica
-01375831-s	slk:lemma	uznávaný
+01375831-a	slk:lemma	uznávaný
 13400798-n	slk:lemma	poplatok
 02220461-v	slk:lemma	odovzdať (majetok)
 00303940-v	slk:lemma	zväčšovať
@@ -30797,26 +30797,26 @@
 02344381-v	slk:lemma	odvďačiť sa
 00183995-n	slk:lemma	pomerné hlasovanie
 07199922-n	slk:lemma	replika
-00959244-s	slk:lemma	pevný
+00959244-a	slk:lemma	pevný
 00124008-n	slk:lemma	bočná paľba
 10086074-n	slk:lemma	zmocnenec
-01208738-s	slk:lemma	pokročilý
+01208738-a	slk:lemma	pokročilý
 05667196-n	slk:lemma	obyčaj
 07723330-n	slk:lemma	zelený šalát
 03453696-n	slk:lemma	grafika
 03546340-n	slk:lemma	bývanie
 08182716-n	slk:lemma	množstvo
-00922840-s	slk:lemma	fádny
+00922840-a	slk:lemma	fádny
 06650431-n	slk:lemma	osvedčenie
 00322847-v	slk:lemma	uvariť
-02101757-s	slk:lemma	šokujúci
+02101757-a	slk:lemma	šokujúci
 09457020-n	slk:lemma	Temža
 01556346-v	slk:lemma	odtrhávať sa
 09376979-n	slk:lemma	Odra
 04184701-n	slk:lemma	úlomok
 01888295-v	slk:lemma	potichu odísť
-02164913-s	slk:lemma	štíhly
-00930765-s	slk:lemma	neobvyklý
+02164913-a	slk:lemma	štíhly
+00930765-a	slk:lemma	neobvyklý
 10261624-n	slk:lemma	poloťažká váha
 02968074-n	slk:lemma	garážovacia plocha krytá zo strán
 00085512-r	slk:lemma	určite
@@ -30826,10 +30826,10 @@
 01976220-v	slk:lemma	hodiť do vody
 00428270-n	slk:lemma	tancovanie
 15140190-n	slk:lemma	nemocenská
-01126841-s	slk:lemma	poľutovaniahodný
-02081114-s	slk:lemma	príma
-02440617-s	slk:lemma	vyšší
-00813589-s	slk:lemma	pradávny
+01126841-a	slk:lemma	poľutovaniahodný
+02081114-a	slk:lemma	príma
+02440617-a	slk:lemma	vyšší
+00813589-a	slk:lemma	pradávny
 08513718-n	slk:lemma	nehnuteľnosť
 04931965-n	slk:lemma	zloženie
 09468604-n	slk:lemma	dolina
@@ -30847,7 +30847,7 @@
 00434374-v	slk:lemma	neuspieť
 00002684-n	slk:lemma	fyzikálny objekt
 05282247-n	slk:lemma	mliečne zuby
-01143855-s	slk:lemma	naliehavý
+01143855-a	slk:lemma	naliehavý
 00921738-v	slk:lemma	vyznačovať
 01876530-v	slk:lemma	pohybovať sa hore-dolu
 07420538-n	slk:lemma	ujma
@@ -30859,7 +30859,7 @@
 09960117-n	slk:lemma	kontakt
 02679415-n	slk:lemma	doplnok
 00520214-a	slk:lemma	úplný
-00750054-s	slk:lemma	príjemný
+00750054-a	slk:lemma	príjemný
 02586619-v	slk:lemma	nariaďovať
 06831391-n	slk:lemma	C
 06045562-n	slk:lemma	lekárska veda
@@ -30873,7 +30873,7 @@
 03453162-n	slk:lemma	hospodárstvo
 00836236-v	slk:lemma	symbolizovať
 02963942-a	slk:lemma	srbský
-00901969-s	slk:lemma	skutočný
+00901969-a	slk:lemma	skutočný
 10143725-n	slk:lemma	darca
 00004227-v	slk:lemma	vydýchnuť
 00992041-v	slk:lemma	naznačiť
@@ -30923,11 +30923,11 @@
 02249438-v	slk:lemma	nahrádzať
 08683548-n	slk:lemma	divočina
 05830059-n	slk:lemma	obťažovanie
-01827946-s	slk:lemma	bezmocný
+01827946-a	slk:lemma	bezmocný
 02651424-v	slk:lemma	ubytúvať
 05518094-n	slk:lemma	folikul
 05912814-n	slk:lemma	fond nákupu akcií
-01263013-s	slk:lemma	neľudský
+01263013-a	slk:lemma	neľudský
 04580493-n	slk:lemma	biela technika
 14180848-n	slk:lemma	otrava krvi
 13354420-n	slk:lemma	obežný kapitál
@@ -30938,7 +30938,7 @@
 00151497-n	slk:lemma	objavovanie
 01168369-n	slk:lemma	štrajk
 14330265-n	slk:lemma	bolesť v konečníku a okolo konečníka
-00803275-s	slk:lemma	ostrý
+00803275-a	slk:lemma	ostrý
 02357228-v	slk:lemma	šetriť
 10204177-n	slk:lemma	priemyselník
 00006105-r	slk:lemma	väčšinou
@@ -30946,19 +30946,19 @@
 09908678-n	slk:lemma	chapman
 05712426-n	slk:lemma	prahová hodnota
 11555413-n	slk:lemma	čeľaď jednoklíčnolistových rastlín
-02165432-s	slk:lemma	povrchný
+02165432-a	slk:lemma	povrchný
 10727256-n	slk:lemma	pokladník
 05926236-n	slk:lemma	múdrosť
 08118039-n	slk:lemma	obchodné oddelenie
-00906655-s	slk:lemma	pohŕdavý
+00906655-a	slk:lemma	pohŕdavý
 00210768-r	slk:lemma	zvyčajne
 01273406-v	slk:lemma	bodkovať
 11665372-n	slk:lemma	krytosemenné
-01046226-s	slk:lemma	vlastný
+01046226-a	slk:lemma	vlastný
 06094587-n	slk:lemma	fyzika
 00720431-n	slk:lemma	úloha
 06831605-n	slk:lemma	e
-01840880-s	slk:lemma	idiotský
+01840880-a	slk:lemma	idiotský
 00103664-r	slk:lemma	atď.
 07060976-n	slk:lemma	džez
 02821030-n	slk:lemma	posteľná bielizeň
@@ -30971,14 +30971,14 @@
 02570267-v	slk:lemma	pokaziť (dieťa)
 09255768-n	slk:lemma	Cookov prieliv
 04623113-n	slk:lemma	vlastnosti
-01085167-s	slk:lemma	preplnený
+01085167-a	slk:lemma	preplnený
 02020590-v	slk:lemma	doraziť
 12660009-n	slk:lemma	čeľaď Rubiaceae
 09342937-n	slk:lemma	rieka Loire
 06345566-n	slk:lemma	nadpis
-00246175-s	slk:lemma	uhrovitý
-01951197-s	slk:lemma	drsný
-00051373-s	slk:lemma	vhodný
+00246175-a	slk:lemma	uhrovitý
+01951197-a	slk:lemma	drsný
+00051373-a	slk:lemma	vhodný
 00267917-n	slk:lemma	údržba auta
 05163807-n	slk:lemma	daň
 01469263-v	slk:lemma	klásť na seba
@@ -31021,7 +31021,7 @@
 02172683-v	slk:lemma	zacengať
 02180898-v	slk:lemma	zvoniť
 01210737-v	slk:lemma	zaobchádzať
-01386538-s	slk:lemma	ohromný
+01386538-a	slk:lemma	ohromný
 00352826-v	slk:lemma	končiť
 13903738-n	slk:lemma	hranica
 10509810-n	slk:lemma	obchodník s nehnuteľnosťami
@@ -31030,7 +31030,7 @@
 09323470-n	slk:lemma	rieka Kansas
 03222516-n	slk:lemma	zvonček
 15246853-n	slk:lemma	moment
-00120784-s	slk:lemma	anonymný
+00120784-a	slk:lemma	anonymný
 06566077-n	slk:lemma	softvér
 04046974-n	slk:lemma	plot z horizontálnych latiek
 02759367-a	slk:lemma	materský
@@ -31095,7 +31095,7 @@
 00906735-v	slk:lemma	odsudzovať
 01641914-v	slk:lemma	uviesť
 01112420-n	slk:lemma	marketing
-01401105-s	slk:lemma	právny
+01401105-a	slk:lemma	právny
 05748054-n	slk:lemma	rozlišovanie
 02265979-v	slk:lemma	odkladať
 02629390-v	slk:lemma	vopred zabrániť
@@ -31106,14 +31106,14 @@
 09700964-n	slk:lemma	Brit
 00209943-n	slk:lemma	záver
 00928232-v	slk:lemma	odporučiť
-01977488-s	slk:lemma	pozorný
+01977488-a	slk:lemma	pozorný
 07943870-n	slk:lemma	seniori
 03600977-n	slk:lemma	spoj
 00270215-v	slk:lemma	uvádzať do vojenskej pohotovosti
 00845909-v	slk:lemma	znevažovať
 00424934-n	slk:lemma	surovosť
 01214265-v	slk:lemma	zmocňovať sa
-02477211-s	slk:lemma	spojený
+02477211-a	slk:lemma	spojený
 00029836-v	slk:lemma	rehotať sa
 07992450-n	slk:lemma	taxón
 07466557-n	slk:lemma	technická disciplína
@@ -31123,7 +31123,7 @@
 07567707-n	slk:lemma	strava
 13792579-n	slk:lemma	spojenie
 05829213-n	slk:lemma	podnet
-01159119-s	slk:lemma	jedovatý
+01159119-a	slk:lemma	jedovatý
 07193184-n	slk:lemma	dopytovanie
 01280014-v	slk:lemma	zakrivovať sa
 00021878-r	slk:lemma	občas
@@ -31137,7 +31137,7 @@
 00976531-n	slk:lemma	nájazd
 01212519-n	slk:lemma	podpora
 08992648-n	slk:lemma	Demokratická republika Svätý Tomáš a Principe
-00345694-s	slk:lemma	premenlivý
+00345694-a	slk:lemma	premenlivý
 01205696-v	slk:lemma	susediť s čím
 06410904-n	slk:lemma	knižka
 13659760-n	slk:lemma	km
@@ -31153,10 +31153,10 @@
 00419685-v	slk:lemma	relaxovať
 15238169-n	slk:lemma	doba rastu
 08085824-n	slk:lemma	kolégium kardinálov
-00325619-s	slk:lemma	ostražitý
+00325619-a	slk:lemma	ostražitý
 14438788-n	slk:lemma	meno
 08163273-n	slk:lemma	zákonodárny zbor
-01285136-s	slk:lemma	vznešený
+01285136-a	slk:lemma	vznešený
 09704876-n	slk:lemma	obyvateľ Manchesteru
 00763399-v	slk:lemma	stanovovať
 03915437-n	slk:lemma	bicí nástroj
@@ -31171,13 +31171,13 @@
 05728493-n	slk:lemma	údajová štruktúra
 05455563-n	slk:lemma	parafovea
 01280014-v	slk:lemma	zahnúť sa
-01074582-s	slk:lemma	pomerne slaný
+01074582-a	slk:lemma	pomerne slaný
 00528397-n	slk:lemma	tanečné predstavenie
 05650820-n	slk:lemma	jazyk
 01647229-v	slk:lemma	vybudovať
 13370669-n	slk:lemma	bohatstvo
 01027668-v	slk:lemma	vyjadrovať (svoj názor)
-02083908-s	slk:lemma	pedantský
+02083908-a	slk:lemma	pedantský
 03152951-n	slk:lemma	priestorové znázornenie v reze
 03145384-n	slk:lemma	obušok
 00498220-n	slk:lemma	druh pokeru
@@ -31189,7 +31189,7 @@
 07260623-n	slk:lemma	meradlo
 03365592-n	slk:lemma	dlážka
 02687916-v	slk:lemma	trvať
-01397998-s	slk:lemma	deravý
+01397998-a	slk:lemma	deravý
 02304982-v	slk:lemma	zhromažďovať
 01641914-v	slk:lemma	začať
 10738515-n	slk:lemma	odborový predák
@@ -31198,7 +31198,7 @@
 05426989-n	slk:lemma	sietnica oka
 00784342-v	slk:lemma	spýtať sa
 00892467-v	slk:lemma	ďakovať
-01808227-s	slk:lemma	rozprávkový
+01808227-a	slk:lemma	rozprávkový
 02106030-n	slk:lemma	škótsky ovčiak
 00061598-n	slk:lemma	kompletizácia
 00490035-a	slk:lemma	pozoruhodný
@@ -31210,15 +31210,15 @@
 01059400-a	slk:lemma	uchytený
 00745637-n	slk:lemma	nehanebnosť
 00024649-v	slk:lemma	oživovať
-01513050-s	slk:lemma	silný
+01513050-a	slk:lemma	silný
 01617192-v	slk:lemma	tvoriť
 05075602-n	slk:lemma	umiestnenie
-02336109-s	slk:lemma	dostatočný
+02336109-a	slk:lemma	dostatočný
 00034213-n	slk:lemma	fenomén
 08108972-n	slk:lemma	rod
 00038625-r	slk:lemma	pochopiteľne
 02046075-v	slk:lemma	zvŕtať
-01372948-s	slk:lemma	štedrý
+01372948-a	slk:lemma	štedrý
 03327234-n	slk:lemma	prekážka
 01543123-v	slk:lemma	sedieť
 07289014-n	slk:lemma	ťažkosť
@@ -31270,9 +31270,9 @@
 00382635-v	slk:lemma	premeniť
 14520278-n	slk:lemma	stav v atmosfére
 00633443-v	slk:lemma	usudzovať
-00122844-s	slk:lemma	následný
+00122844-a	slk:lemma	následný
 10224578-n	slk:lemma	novinár
-02343110-s	slk:lemma	znamenitý
+02343110-a	slk:lemma	znamenitý
 02971691-n	slk:lemma	zásobník
 04643662-n	slk:lemma	bojovnosť
 13095685-n	slk:lemma	rastlinné pletivo
@@ -31304,7 +31304,7 @@
 06802571-n	slk:lemma	predzvesť
 03403431-n	slk:lemma	lodný komín
 00850425-n	slk:lemma	miešanie
-01067415-s	slk:lemma	občasný
+01067415-a	slk:lemma	občasný
 00151755-r	slk:lemma	celkovo
 00339934-v	slk:lemma	uskutočňovať sa
 00127130-r	slk:lemma	po formálnej stránke
@@ -31316,7 +31316,7 @@
 04635104-n	slk:lemma	aktívnosť
 01762283-v	slk:lemma	vydráždiť
 02709906-v	slk:lemma	divergovať
-01933731-s	slk:lemma	faktický
+01933731-a	slk:lemma	faktický
 02734544-a	slk:lemma	génový
 00335182-r	slk:lemma	ex abrupto
 00348541-v	slk:lemma	rozkývať sa
@@ -31343,7 +31343,7 @@
 05074774-n	slk:lemma	postavenie
 02144835-v	slk:lemma	ukrývať
 04504141-n	slk:lemma	dvojdielny oblek
-01683349-s	slk:lemma	smerujúci domov
+01683349-a	slk:lemma	smerujúci domov
 04737934-n	slk:lemma	nemennosť
 00151689-v	slk:lemma	klesať
 03701391-n	slk:lemma	samopal
@@ -31361,7 +31361,7 @@
 10709435-n	slk:lemma	otrok
 03499142-n	slk:lemma	palubný prielez
 05714894-n	slk:lemma	smrad
-02165432-s	slk:lemma	triviálny
+02165432-a	slk:lemma	triviálny
 01447257-v	slk:lemma	zaťažiť
 03656484-n	slk:lemma	šošovka
 00387310-v	slk:lemma	vracať
@@ -31407,12 +31407,12 @@
 02446164-v	slk:lemma	zamerať sa na
 05199869-n	slk:lemma	účinnosť
 09340935-n	slk:lemma	Little Sioux River
-00876204-s	slk:lemma	ospalý
+00876204-a	slk:lemma	ospalý
 02179518-v	slk:lemma	vydávať zvuk
 02964107-a	slk:lemma	chorvátsky
-00068180-s	slk:lemma	zhodnotený
+00068180-a	slk:lemma	zhodnotený
 04188368-n	slk:lemma	lano
-00853473-s	slk:lemma	nevítaný
+00853473-a	slk:lemma	nevítaný
 05088804-n	slk:lemma	sústredenie
 10132887-n	slk:lemma	autor glosy
 09078231-n	slk:lemma	HI
@@ -31426,7 +31426,7 @@
 02608347-v	slk:lemma	zahájiť
 07093895-n	slk:lemma	prozódia
 03560860-n	slk:lemma	zapaľovacia cievka
-00382173-s	slk:lemma	ružovkastý
+00382173-a	slk:lemma	ružovkastý
 11429057-n	slk:lemma	väzobná energia
 04606574-n	slk:lemma	skrutkový kľúč
 00807178-v	slk:lemma	neuznávať
@@ -31470,7 +31470,7 @@
 13083586-n	slk:lemma	Tracheophyta
 00651670-n	slk:lemma	porovnanie
 07484265-n	slk:lemma	túžba
-02279723-s	slk:lemma	bujarý
+02279723-a	slk:lemma	bujarý
 13326450-n	slk:lemma	odpisová sadzba
 00698004-n	slk:lemma	púšťanie žilou
 05239808-n	slk:lemma	epitelové tkanivo
@@ -31482,7 +31482,7 @@
 06545137-n	slk:lemma	postupná listina
 05646926-n	slk:lemma	idiotstvo
 13811900-n	slk:lemma	náklonnosť
-02571277-s	slk:lemma	hlúpy
+02571277-a	slk:lemma	hlúpy
 01826498-v	slk:lemma	dávať prednosť
 01325777-a	slk:lemma	informatívny
 09225146-n	slk:lemma	vodstvo
@@ -31539,7 +31539,7 @@
 03624497-n	slk:lemma	ostrie
 00872107-n	slk:lemma	plus
 13779374-n	slk:lemma	kapacita
-02408977-s	slk:lemma	oblastný
+02408977-a	slk:lemma	oblastný
 02721220-a	slk:lemma	jazdecký
 00511676-n	slk:lemma	bakchanálie
 05392744-n	slk:lemma	komora
@@ -31553,7 +31553,7 @@
 10407954-n	slk:lemma	sponzor
 00964569-n	slk:lemma	agresia
 01796346-v	slk:lemma	chvieť sa
-00015247-s	slk:lemma	prehnaný
+00015247-a	slk:lemma	prehnaný
 09303008-n	slk:lemma	kopec
 06693502-n	slk:lemma	chvála
 06608143-n	slk:lemma	nezmysel
@@ -31582,7 +31582,7 @@
 00540235-v	slk:lemma	rozšíriť si
 00897241-v	slk:lemma	pozdravovať
 02988304-n	slk:lemma	prehrávač kompaktných diskov
-00646117-s	slk:lemma	neuveriteľný
+00646117-a	slk:lemma	neuveriteľný
 05690269-n	slk:lemma	zábrana
 11605708-n	slk:lemma	Coniferophyta
 13959818-n	slk:lemma	nebytie
@@ -31616,7 +31616,7 @@
 01679980-v	slk:lemma	dekorovať
 08367880-n	slk:lemma	forma vlády
 01761706-v	slk:lemma	otriasať
-00188917-s	slk:lemma	hypnoidný
+00188917-a	slk:lemma	hypnoidný
 06611147-n	slk:lemma	táranina
 08718391-n	slk:lemma	Falklandy
 01278427-v	slk:lemma	krčiť sa
@@ -31632,7 +31632,7 @@
 01051331-n	slk:lemma	pozícia
 02028366-v	slk:lemma	prúdiť
 00066025-v	slk:lemma	zamrnčať
-01038332-s	slk:lemma	národný
+01038332-a	slk:lemma	národný
 00050652-v	slk:lemma	vziať na seba
 14811706-n	slk:lemma	kyselina chromitá
 06641181-n	slk:lemma	úroveň cien
@@ -31643,7 +31643,7 @@
 07206096-n	slk:lemma	zrieknutie sa
 01625747-n	slk:lemma	Amphibia
 01184625-v	slk:lemma	postarať sa (o)
-01440331-s	slk:lemma	dlhodobo pôsobiaci
+01440331-a	slk:lemma	dlhodobo pôsobiaci
 13988663-n	slk:lemma	žiaľ
 05343542-n	slk:lemma	spojovacia tepna
 07553741-n	slk:lemma	ľútosť
@@ -31661,7 +31661,7 @@
 03002816-n	slk:lemma	salaš
 15255641-n	slk:lemma	úsek hry v póle
 02696669-n	slk:lemma	Alhambra
-01509066-s	slk:lemma	jemný
+01509066-a	slk:lemma	jemný
 04891184-n	slk:lemma	ostražitosť
 00046344-n	slk:lemma	kúsok
 00808182-n	slk:lemma	obmedzenie
@@ -31681,7 +31681,7 @@
 02436349-v	slk:lemma	zvládnuť
 05211044-n	slk:lemma	humornosť
 00819235-a	slk:lemma	neskorý
-02280333-s	slk:lemma	čulý
+02280333-a	slk:lemma	čulý
 01219603-a	slk:lemma	nížinatý
 01100145-v	slk:lemma	zvíťaziť
 02631349-v	slk:lemma	hrať
@@ -31707,13 +31707,13 @@
 08892971-n	slk:lemma	Glasgow
 06181584-n	slk:lemma	deskriptívna lingvistika
 01767949-v	slk:lemma	dojímať
-00282675-s	slk:lemma	nežný
+00282675-a	slk:lemma	nežný
 02215355-v	slk:lemma	zmocňovať sa (územia)
 05523269-n	slk:lemma	toporivý orgán
 02743261-a	slk:lemma	humánny
 01545649-v	slk:lemma	kľačať
 00046522-n	slk:lemma	spojenie
-01079052-s	slk:lemma	obklopený ľadom
+01079052-a	slk:lemma	obklopený ľadom
 09832321-n	slk:lemma	stará baba
 08751317-n	slk:lemma	Hayti
 08553535-n	slk:lemma	obývané pásmo
@@ -31740,10 +31740,10 @@
 00123170-v	slk:lemma	meniť si
 00197772-n	slk:lemma	substitúcia
 01018352-v	slk:lemma	nárokovať si
-01539444-s	slk:lemma	nenáročný
+01539444-a	slk:lemma	nenáročný
 02424652-v	slk:lemma	utláčať
 02496816-v	slk:lemma	držať na uzde
-01968352-s	slk:lemma	nočný
+01968352-a	slk:lemma	nočný
 03961250-n	slk:lemma	plát železa
 01020356-v	slk:lemma	zapísať
 02731024-v	slk:lemma	ostať
@@ -31756,8 +31756,8 @@
 06591442-n	slk:lemma	súhrn
 03567066-n	slk:lemma	liaheň
 13387877-n	slk:lemma	kovové peniaze
-00028471-s	slk:lemma	údajný
-01977488-s	slk:lemma	opatrný
+00028471-a	slk:lemma	údajný
+01977488-a	slk:lemma	opatrný
 07907943-n	slk:lemma	likér
 02157731-v	slk:lemma	zatemniť sa
 07356676-n	slk:lemma	zvýšenie
@@ -31776,7 +31776,7 @@
 05593318-n	slk:lemma	vretenná kosť
 05785508-n	slk:lemma	zahĺbenie
 05943300-n	slk:lemma	škola myslenia
-00150505-s	slk:lemma	výrečný
+00150505-a	slk:lemma	výrečný
 05561507-n	slk:lemma	noha
 02841315-n	slk:lemma	divadelný ďalekohľad
 04507609-n	slk:lemma	nedostatočné množstvo streliva
@@ -31786,7 +31786,7 @@
 08672073-n	slk:lemma	mestečko
 00223854-n	slk:lemma	porážka
 02848523-n	slk:lemma	list vrtule
-00631798-s	slk:lemma	akurátny
+00631798-a	slk:lemma	akurátny
 02400760-v	slk:lemma	zvoliť
 05059830-n	slk:lemma	pohotovosť
 00820352-v	slk:lemma	overovať
@@ -31800,15 +31800,15 @@
 05752544-n	slk:lemma	nadobúdanie
 01053617-n	slk:lemma	pobyt
 01130905-n	slk:lemma	dôkazné bremeno
-01903160-s	slk:lemma	odvetný
+01903160-a	slk:lemma	odvetný
 09009174-n	slk:lemma	Novgorod
 01772498-v	slk:lemma	chváliť sa
 14931879-n	slk:lemma	vyvretá hornina
 01742726-v	slk:lemma	kultivovať
-02467559-s	slk:lemma	hore nohami
+02467559-a	slk:lemma	hore nohami
 02375131-v	slk:lemma	zúčastniť sa (niečoho)
 08891889-n	slk:lemma	Škótska nížina
-00326608-s	slk:lemma	prudký
+00326608-a	slk:lemma	prudký
 00964343-n	slk:lemma	bitka
 03231024-n	slk:lemma	podklad na kreslenie
 00117959-n	slk:lemma	žmurk
@@ -31824,7 +31824,7 @@
 13352138-n	slk:lemma	hypotekárne záložné právo
 00719734-v	slk:lemma	očakávať
 00009147-v	slk:lemma	pĺznuť
-02413851-s	slk:lemma	podobný vláknu
+02413851-a	slk:lemma	podobný vláknu
 02738701-v	slk:lemma	stočiť sa
 02419773-v	slk:lemma	odmakať
 00646833-n	slk:lemma	chemická analýza
@@ -31834,12 +31834,12 @@
 01209220-n	slk:lemma	pomoc
 13324297-n	slk:lemma	príplatok k úradnému devízovému kurzu
 00173338-v	slk:lemma	dávať preč
-01440574-s	slk:lemma	pozdĺžny
+01440574-a	slk:lemma	pozdĺžny
 01101913-v	slk:lemma	poraziť
 02956247-n	slk:lemma	koruna piliera
 03876519-n	slk:lemma	maľba
 07294907-n	slk:lemma	spravodlivosť
-02344070-s	slk:lemma	kvalitný
+02344070-a	slk:lemma	kvalitný
 01604226-a	slk:lemma	severský
 00504209-n	slk:lemma	šípky
 02539101-v	slk:lemma	zapliesť sa
@@ -31866,12 +31866,12 @@
 00628491-v	slk:lemma	uvažovať
 04884627-n	slk:lemma	benevolencia
 02541509-v	slk:lemma	zastupovať
-01936528-s	slk:lemma	domnelý
+01936528-a	slk:lemma	domnelý
 06134271-n	slk:lemma	priemyselné inžinierstvo
 02443609-v	slk:lemma	riadiť
 02898584-a	slk:lemma	kognitívny
 14500567-n	slk:lemma	neporiadok
-00685113-s	slk:lemma	osudný
+00685113-a	slk:lemma	osudný
 02959007-a	slk:lemma	portugálsky
 04241573-n	slk:lemma	komutátor
 10753546-n	slk:lemma	zlosyn
@@ -31894,7 +31894,7 @@
 04933363-n	slk:lemma	štruktúra
 09851465-n	slk:lemma	ženíchov svedok
 02176178-a	slk:lemma	komplexný
-02578894-s	slk:lemma	kláštorný
+02578894-a	slk:lemma	kláštorný
 08948346-n	slk:lemma	Britská Guiana
 01770263-n	slk:lemma	šťúry
 00125436-n	slk:lemma	poklep
@@ -31940,7 +31940,7 @@
 09298410-n	slk:lemma	Guinejský záliv
 01613615-n	slk:lemma	vtáča
 06636524-n	slk:lemma	záznam
-00770993-s	slk:lemma	nepriamy
+00770993-a	slk:lemma	nepriamy
 02412210-n	slk:lemma	škop
 00356412-r	slk:lemma	nato
 03743902-n	slk:lemma	pamätník
@@ -31950,7 +31950,7 @@
 09334396-n	slk:lemma	zem
 10032342-n	slk:lemma	adresát zmenky
 05712076-n	slk:lemma	zmyslová skúsenosť
-01950198-s	slk:lemma	hrubý
+01950198-a	slk:lemma	hrubý
 03098140-n	slk:lemma	ovládacia doska
 00721889-v	slk:lemma	ohodnotiť
 00782057-v	slk:lemma	naliehať
@@ -31961,7 +31961,7 @@
 00964911-v	slk:lemma	iniciovať
 08226699-n	slk:lemma	mestečko
 01158181-v	slk:lemma	plytvať
-00195383-s	slk:lemma	impozantný
+00195383-a	slk:lemma	impozantný
 06734823-n	slk:lemma	corpus delicti
 03238131-n	slk:lemma	šatňa na obliekanie
 05627785-n	slk:lemma	nebesia
@@ -31985,13 +31985,13 @@
 04592962-n	slk:lemma	zákulisie
 09299397-n	slk:lemma	záliv St. Lawrence
 04078747-n	slk:lemma	vodná nádrž
-00011327-s	slk:lemma	svinský
+00011327-a	slk:lemma	svinský
 03322570-n	slk:lemma	hospodárska budova
 04340231-n	slk:lemma	lom
 01480186-a	slk:lemma	označený
 08305568-n	slk:lemma	hospodárska únia
 04081844-n	slk:lemma	zábrana
-01074335-s	slk:lemma	soľotvorný
+01074335-a	slk:lemma	soľotvorný
 03744276-n	slk:lemma	počítačová pamäť
 05596442-n	slk:lemma	ľadvinová panvička
 08464601-n	slk:lemma	hnutie
@@ -32020,14 +32020,14 @@
 04695963-n	slk:lemma	strata lesku
 04392764-n	slk:lemma	pásková jednotka
 00248659-v	slk:lemma	postupovať
-01610261-s	slk:lemma	nepozorovaný
+01610261-a	slk:lemma	nepozorovaný
 11667562-n	slk:lemma	trieda Monocotyledonae
 10092098-n	slk:lemma	lesný správca
 10143172-n	slk:lemma	starý rodič
 00419950-v	slk:lemma	napínať sa
 13286099-n	slk:lemma	prídel
 00851100-v	slk:lemma	žartovať
-01322323-s	slk:lemma	zločinný
+01322323-a	slk:lemma	zločinný
 01355326-n	slk:lemma	pravé baktérie
 07503987-n	slk:lemma	odpor
 00104868-v	slk:lemma	odsávať
@@ -32044,7 +32044,7 @@
 12410381-n	slk:lemma	podtrieda Liliidae
 01212024-v	slk:lemma	používať násilie
 00975781-n	slk:lemma	prudký útok
-00837977-s	slk:lemma	namáhavý
+00837977-a	slk:lemma	namáhavý
 04983122-n	slk:lemma	kvalita zvuku
 05277532-n	slk:lemma	nosná kosť
 00136991-v	slk:lemma	nechať
@@ -32053,22 +32053,22 @@
 00788973-n	slk:lemma	snaha
 00008007-r	slk:lemma	celkovo
 00518395-v	slk:lemma	uľahčiť
-00904745-s	slk:lemma	podlý
+00904745-a	slk:lemma	podlý
 01340439-v	slk:lemma	fixovať
 00524682-v	slk:lemma	osvojovať si
 11682512-n	slk:lemma	endosperm
 01282545-v	slk:lemma	vyhĺbiť
 13729428-n	slk:lemma	imaginárne číslo
 15046900-n	slk:lemma	tuhá hmota
-01993693-s	slk:lemma	slušný
+01993693-a	slk:lemma	slušný
 00754767-n	slk:lemma	prelud
 00361781-r	slk:lemma	lenivo
 09721883-n	slk:lemma	Malajzijčan
 01975880-n	slk:lemma	rad Decapoda
-01898722-s	slk:lemma	súdny
+01898722-a	slk:lemma	súdny
 00087988-v	slk:lemma	chytať
 00661713-v	slk:lemma	kolacionovať
-01677200-s	slk:lemma	príšerný
+01677200-a	slk:lemma	príšerný
 09196611-n	slk:lemma	Andy
 00512843-n	slk:lemma	pochabosť
 02614023-v	slk:lemma	ulievať sa
@@ -32095,10 +32095,10 @@
 00999330-a	slk:lemma	neoperený
 04019101-n	slk:lemma	verejná doprava
 01835496-v	slk:lemma	pohýnať
-01441000-s	slk:lemma	dlhodobý
+01441000-a	slk:lemma	dlhodobý
 04219424-n	slk:lemma	hodváb
 02249147-v	slk:lemma	prihlasovať sa
-00590163-s	slk:lemma	nespokojný
+00590163-a	slk:lemma	nespokojný
 14967730-n	slk:lemma	plynový olej
 07516997-n	slk:lemma	hnev
 00405360-n	slk:lemma	ohyb
@@ -32115,7 +32115,7 @@
 01859221-v	slk:lemma	zadržať
 13962048-n	slk:lemma	koža
 06074507-n	slk:lemma	fykológia
-01477077-s	slk:lemma	mužský
+01477077-a	slk:lemma	mužský
 02705428-v	slk:lemma	predĺžiť sa
 00876737-n	slk:lemma	vnímanie
 07429976-n	slk:lemma	invázia
@@ -32137,12 +32137,12 @@
 09849598-n	slk:lemma	milovaný
 04236377-n	slk:lemma	rukáv
 07392783-n	slk:lemma	šum
-00167829-s	slk:lemma	pútavý
+00167829-a	slk:lemma	pútavý
 06681177-n	slk:lemma	správy
 15196186-n	slk:lemma	Vianoce
 01154957-v	slk:lemma	hrať lepšie
 15246353-n	slk:lemma	chvíľa
-01645678-s	slk:lemma	šedovlasý
+01645678-a	slk:lemma	šedovlasý
 02387486-v	slk:lemma	vychovávať si
 03168774-n	slk:lemma	okraj ručného papiera
 00301662-v	slk:lemma	zamerať na
@@ -32160,10 +32160,10 @@
 01022483-n	slk:lemma	diskontinuita
 09475925-n	slk:lemma	breh
 10522324-n	slk:lemma	lotor
-00927832-s	slk:lemma	chýbajúci
+00927832-a	slk:lemma	chýbajúci
 05599501-n	slk:lemma	orlí nos
 03025746-a	slk:lemma	alpský
-01611973-s	slk:lemma	neškodný
+01611973-a	slk:lemma	neškodný
 00229568-r	slk:lemma	ticho
 03253398-n	slk:lemma	kanál
 02134084-n	slk:lemma	polárny medveď (Ursus maritimus)
@@ -32171,12 +32171,12 @@
 13144794-n	slk:lemma	réva vínna
 04335435-n	slk:lemma	trolejbus
 05338025-n	slk:lemma	sluchová tepna
-00993885-s	slk:lemma	osudný
+00993885-a	slk:lemma	osudný
 01547390-v	slk:lemma	odpočívať
 03082979-n	slk:lemma	počítacie zariadenie
 02153709-v	slk:lemma	vyhľadať
 00729285-n	slk:lemma	cvičenie
-01778935-s	slk:lemma	telesný
+01778935-a	slk:lemma	telesný
 09408977-n	slk:lemma	Rhone
 14526182-n	slk:lemma	duch
 09928451-n	slk:lemma	účtovník
@@ -32203,7 +32203,7 @@
 04743605-n	slk:lemma	podoba
 07566340-n	slk:lemma	potravinársky výrobok
 00534849-n	slk:lemma	tancovanie v tanečnej sále
-00529191-s	slk:lemma	limitovaný
+00529191-a	slk:lemma	limitovaný
 00358431-v	slk:lemma	zahynúť
 01230710-v	slk:lemma	podnietiť
 02464583-v	slk:lemma	chrániť
@@ -32213,28 +32213,28 @@
 00648790-n	slk:lemma	rozbor nákladov
 10386312-n	slk:lemma	vyhnanec
 00791078-n	slk:lemma	pokus
-00412788-s	slk:lemma	primitívny
+00412788-a	slk:lemma	primitívny
 02640440-v	slk:lemma	robiť okolky
 05048301-n	slk:lemma	koexistencia
 00376106-v	slk:lemma	rozpustiť sa
-02508514-s	slk:lemma	prezradený
+02508514-a	slk:lemma	prezradený
 00746587-n	slk:lemma	znesvätenie
 03010337-a	slk:lemma	pokrytý bradavicami
 05716577-n	slk:lemma	sladkavosť
 02629256-v	slk:lemma	odstrániť
 00272844-r	slk:lemma	šikmo
-01136248-s	slk:lemma	nervózny
+01136248-a	slk:lemma	nervózny
 07135080-n	slk:lemma	klebetenie
 05217168-n	slk:lemma	ľudské telo
-01141595-s	slk:lemma	neprirodzený
+01141595-a	slk:lemma	neprirodzený
 09879744-n	slk:lemma	fušer
-01789481-s	slk:lemma	strakatý
+01789481-a	slk:lemma	strakatý
 01114646-n	slk:lemma	veľkoobchod
 10059162-n	slk:lemma	účastník kurzu
 07134850-n	slk:lemma	táranie
 04447443-n	slk:lemma	toaletné potreby
 02076676-v	slk:lemma	opustiť
-01287808-s	slk:lemma	výrazný
+01287808-a	slk:lemma	výrazný
 01874875-v	slk:lemma	preplaviť
 01252730-v	slk:lemma	zamazať blatom
 02295842-v	slk:lemma	dávať do spoločného fondu
@@ -32256,7 +32256,7 @@
 02431320-v	slk:lemma	rozdeliť sa
 14936226-n	slk:lemma	mramor
 05541872-n	slk:lemma	záhlavná kosť
-01704420-s	slk:lemma	pyskovitý
+01704420-a	slk:lemma	pyskovitý
 11480698-n	slk:lemma	mechanický fenomén
 01798936-v	slk:lemma	rozčarovať
 12630999-n	slk:lemma	jahoda
@@ -32265,12 +32265,12 @@
 00121286-r	slk:lemma	čiste teoreticky
 13440063-n	slk:lemma	telesná aktivita
 09010300-n	slk:lemma	Novosibirsk
-01079052-s	slk:lemma	uzavretý ľadom
+01079052-a	slk:lemma	uzavretý ľadom
 13374597-n	slk:lemma	bankový úver
-01443097-s	slk:lemma	okamžitý
+01443097-a	slk:lemma	okamžitý
 02130524-v	slk:lemma	pozerať
 02436349-v	slk:lemma	mať na starosti
-00579498-s	slk:lemma	nápadný
+00579498-a	slk:lemma	nápadný
 00028270-n	slk:lemma	čas
 07481375-n	slk:lemma	nadšenie
 13686660-n	slk:lemma	libra
@@ -32286,16 +32286,16 @@
 02631163-v	slk:lemma	spájať
 03930630-n	slk:lemma	pickup
 07891726-n	slk:lemma	víno
-01119661-s	slk:lemma	glazovaný
+01119661-a	slk:lemma	glazovaný
 08760393-n	slk:lemma	severná Európa
 06312966-n	slk:lemma	komponent
 05682950-n	slk:lemma	záujem
 03014288-a	slk:lemma	akcieschopný
 13275495-n	slk:lemma	náklady
 03320262-n	slk:lemma	klinový remeň
-02160135-s	slk:lemma	slepý
+02160135-a	slk:lemma	slepý
 00419375-v	slk:lemma	zmierniť
-00853473-s	slk:lemma	nežiadúci
+00853473-a	slk:lemma	nežiadúci
 08415469-n	slk:lemma	osobitná porota
 05784242-n	slk:lemma	premýšľanie
 02068735-n	slk:lemma	delfínovité
@@ -32313,7 +32313,7 @@
 08759420-n	slk:lemma	Benin
 02524171-v	slk:lemma	dariť sa
 06353445-n	slk:lemma	pravopis
-00048858-s	slk:lemma	dodatočný
+00048858-a	slk:lemma	dodatočný
 00894552-n	slk:lemma	výcvik
 02486693-v	slk:lemma	zvať von
 00321993-r	slk:lemma	rýchlejšie
@@ -32324,16 +32324,16 @@
 02294056-v	slk:lemma	predávať pod cenu
 01229938-n	slk:lemma	stretnutie
 05141683-n	slk:lemma	hodnota
-01712753-s	slk:lemma	bolestivý
+01712753-a	slk:lemma	bolestivý
 07987380-n	slk:lemma	štvorka
 08739047-n	slk:lemma	Managua
-01874331-s	slk:lemma	neodborný
+01874331-a	slk:lemma	neodborný
 06390962-n	slk:lemma	návrh
 01325417-n	slk:lemma	paroh
 09968259-n	slk:lemma	výrobca kostýmov
 15281329-n	slk:lemma	výnos z investície
 00632627-v	slk:lemma	zdôvodniť
-01574259-s	slk:lemma	fyzický
+01574259-a	slk:lemma	fyzický
 02541509-v	slk:lemma	zastúpiť
 10640620-n	slk:lemma	manžel
 00363493-v	slk:lemma	zadržiavať (peniaze, majetok)
@@ -32357,11 +32357,11 @@
 02802721-n	slk:lemma	basketbalové vybavenie
 02620466-v	slk:lemma	podriadiť sa
 06650701-n	slk:lemma	vedenie
-01450178-s	slk:lemma	chýbajúci
+01450178-a	slk:lemma	chýbajúci
 00358431-v	slk:lemma	zanikať
 02387034-v	slk:lemma	cvičiť sa
 02817031-n	slk:lemma	ložisko
-02346878-s	slk:lemma	obchodný
+02346878-a	slk:lemma	obchodný
 03504420-n	slk:lemma	ústredie
 00665886-v	slk:lemma	podporovať
 06379439-n	slk:lemma	pastierska báseň
@@ -32400,19 +32400,19 @@
 08701942-n	slk:lemma	Anatólia
 03562739-n	slk:lemma	imunogén
 02775934-a	slk:lemma	finančný
-01046553-s	slk:lemma	epištolárny
+01046553-a	slk:lemma	epištolárny
 13757724-n	slk:lemma	veľké množstvo
 02561332-v	slk:lemma	uplatniť
 00227323-r	slk:lemma	zlostne
 02791385-n	slk:lemma	obrnená plošina dela
-02571277-s	slk:lemma	stupídny
+02571277-a	slk:lemma	stupídny
 00119940-r	slk:lemma	úspešne
 03772077-n	slk:lemma	kláštorný kostol
 01556921-v	slk:lemma	separovať sa
 03829340-n	slk:lemma	záložná pamäť
 01807882-v	slk:lemma	oslovovať
-00012071-s	slk:lemma	myslený
-00848375-s	slk:lemma	záväzný
+00012071-a	slk:lemma	myslený
+00848375-a	slk:lemma	záväzný
 10150940-n	slk:lemma	hosť
 00779248-n	slk:lemma	švindeľ
 07409255-n	slk:lemma	inflácia
@@ -32423,11 +32423,11 @@
 00406243-v	slk:lemma	pripraviť
 06664051-n	slk:lemma	smernica
 04297476-n	slk:lemma	kulisy
-00168910-s	slk:lemma	okúzľujúci
+00168910-a	slk:lemma	okúzľujúci
 03825080-n	slk:lemma	veci na spanie
 07421316-n	slk:lemma	porucha
 04176528-n	slk:lemma	rádio
-01050088-s	slk:lemma	nešťastný
+01050088-a	slk:lemma	nešťastný
 13681661-n	slk:lemma	koruna
 00947077-v	slk:lemma	presne určiť
 07567707-n	slk:lemma	múčka
@@ -32444,15 +32444,15 @@
 04760024-n	slk:lemma	hmotnosť
 08199025-n	slk:lemma	armáda
 01785748-v	slk:lemma	odrádzať
-00852754-s	slk:lemma	legálny
+00852754-a	slk:lemma	legálny
 08968677-n	slk:lemma	Mongolsko
 02423762-v	slk:lemma	zdusiť
 01579813-v	slk:lemma	roztvárať (náruč)
 04531098-n	slk:lemma	nádrž
 11872850-n	slk:lemma	Armoracia
-00335768-s	slk:lemma	definitívny
+00335768-a	slk:lemma	definitívny
 01060745-n	slk:lemma	tylové zaistenie
-01395821-s	slk:lemma	umiernený
+01395821-a	slk:lemma	umiernený
 00371264-v	slk:lemma	rozžeraviť
 14189837-n	slk:lemma	septikémia
 03365991-n	slk:lemma	poschodie
@@ -32460,7 +32460,7 @@
 00918872-v	slk:lemma	určiť
 08408900-n	slk:lemma	pracovná skupina
 02284951-v	slk:lemma	vrátiť
-01042703-s	slk:lemma	klasický
+01042703-a	slk:lemma	klasický
 13836371-n	slk:lemma	uhlová poloha
 04615866-n	slk:lemma	ľudská povaha
 07504111-n	slk:lemma	odpor
@@ -32478,7 +32478,7 @@
 15056938-n	slk:lemma	kyselina stearová
 03838298-n	slk:lemma	objektív
 01051331-n	slk:lemma	lokalizácia
-02052603-s	slk:lemma	mestský
+02052603-a	slk:lemma	mestský
 08745407-n	slk:lemma	San Luis Potosi
 00260470-v	slk:lemma	uškodiť
 02725460-v	slk:lemma	hodiť sa
@@ -32492,20 +32492,20 @@
 07964144-n	slk:lemma	farebná tonalita
 03582658-n	slk:lemma	inovácia
 03653583-n	slk:lemma	stojan
-01894196-s	slk:lemma	odskúšaný
+01894196-a	slk:lemma	odskúšaný
 02323715-n	slk:lemma	Leporidae
-00425313-s	slk:lemma	vulgárny
+00425313-a	slk:lemma	vulgárny
 14474052-n	slk:lemma	úspešnosť
 00512877-v	slk:lemma	sprístupňovať
-00768397-s	slk:lemma	odbiehajúci od témy
+00768397-a	slk:lemma	odbiehajúci od témy
 02399000-n	slk:lemma	prežúvavec
 01439190-v	slk:lemma	zachytiť
-01937390-s	slk:lemma	iluzórny
+01937390-a	slk:lemma	iluzórny
 05151088-n	slk:lemma	pragmatickosť
-02565425-s	slk:lemma	pohotový
+02565425-a	slk:lemma	pohotový
 14033802-n	slk:lemma	teplota vzplanutia
 13129165-n	slk:lemma	stonka
-01392249-s	slk:lemma	malinký
+01392249-a	slk:lemma	malinký
 04846770-n	slk:lemma	morálka
 10127273-n	slk:lemma	džentlmen
 08559155-n	slk:lemma	trvalé bydlisko
@@ -32572,7 +32572,7 @@
 05564590-n	slk:lemma	laba
 00140967-v	slk:lemma	deformovať
 04695605-n	slk:lemma	krvavá škvrna
-01509367-s	slk:lemma	striedmy
+01509367-a	slk:lemma	striedmy
 02322230-v	slk:lemma	ukradnúť
 14288235-n	slk:lemma	krvácanie
 08521623-n	slk:lemma	pohrebisko
@@ -32586,7 +32586,7 @@
 01947352-v	slk:lemma	veslovať
 13408361-n	slk:lemma	mimoriadna dividenda
 15278825-n	slk:lemma	tempo rastu
-00669942-s	slk:lemma	potvorský
+00669942-a	slk:lemma	potvorský
 00202445-v	slk:lemma	potrestať
 00829107-v	slk:lemma	naučiť
 05814291-n	slk:lemma	otázka
@@ -32596,7 +32596,7 @@
 05361123-n	slk:lemma	hlavová žila
 01807770-v	slk:lemma	zlákať
 01655505-v	slk:lemma	ustanoviť
-00922051-s	slk:lemma	čarovný
+00922051-a	slk:lemma	čarovný
 09954879-n	slk:lemma	podrazník
 15249547-n	slk:lemma	rok 2000
 01899708-v	slk:lemma	vymrštiť sa
@@ -32605,9 +32605,9 @@
 13796779-n	slk:lemma	gramatický vzťah
 01335804-v	slk:lemma	lemovať
 01782650-v	slk:lemma	vyľakať sa
-00218950-s	slk:lemma	pekne vyzerajúci
+00218950-a	slk:lemma	pekne vyzerajúci
 08436562-n	slk:lemma	cech
-01941814-s	slk:lemma	faktický
+01941814-a	slk:lemma	faktický
 00229605-v	slk:lemma	prehlbovať
 00719494-n	slk:lemma	úloha
 00061014-n	slk:lemma	únik o vlások
@@ -32653,14 +32653,14 @@
 00831782-n	slk:lemma	respirácia
 07214994-n	slk:lemma	informovanie
 05695002-n	slk:lemma	zakázané ovocie
-01731786-s	slk:lemma	terajší
+01731786-a	slk:lemma	terajší
 01848718-v	slk:lemma	odísť
 01280014-v	slk:lemma	zakrivovať
 01108402-n	slk:lemma	prevod vlastníckych práv
 09339512-n	slk:lemma	Krokodília rieka
 08838556-n	slk:lemma	ostrov Wake
 02692624-a	slk:lemma	chemický
-01632066-s	slk:lemma	obraňujúci
+01632066-a	slk:lemma	obraňujúci
 13283764-n	slk:lemma	odmena
 02351010-v	slk:lemma	určovať cenu
 00859325-v	slk:lemma	rozptýliť sa
@@ -32689,7 +32689,7 @@
 07296428-n	slk:lemma	modifikácia
 04151940-n	slk:lemma	úkryt
 00948071-v	slk:lemma	spočítať
-01153595-s	slk:lemma	podobný bavlne
+01153595-a	slk:lemma	podobný bavlne
 01029852-v	slk:lemma	označovať
 07314427-n	slk:lemma	nehoda
 01044114-v	slk:lemma	šepkať
@@ -32725,7 +32725,7 @@
 00466053-v	slk:lemma	usporadovať
 10200365-n	slk:lemma	imitátor
 02251743-v	slk:lemma	doplatiť
-00310433-s	slk:lemma	detailný
+00310433-a	slk:lemma	detailný
 07818277-n	slk:lemma	cesnak
 02350175-v	slk:lemma	oslobodzovať
 08195797-n	slk:lemma	letecká jednotka
@@ -32766,9 +32766,9 @@
 06877008-n	slk:lemma	znamenie
 07460546-n	slk:lemma	maratón
 14984973-n	slk:lemma	farba
-00900071-s	slk:lemma	tajomný
+00900071-a	slk:lemma	tajomný
 03550289-n	slk:lemma	koterec
-01950198-s	slk:lemma	nemotorný
+01950198-a	slk:lemma	nemotorný
 14687633-n	slk:lemma	karosén
 00948071-v	slk:lemma	počítať
 01635432-v	slk:lemma	pomyslieť
@@ -32777,7 +32777,7 @@
 01126360-v	slk:lemma	obsadzovať
 07233996-n	slk:lemma	kliatba
 08240169-n	slk:lemma	krúžok
-00477284-s	slk:lemma	príjemný
+00477284-a	slk:lemma	príjemný
 02131279-v	slk:lemma	prehľadávať
 01461328-v	slk:lemma	zlúčiť
 02693088-v	slk:lemma	byť základom
@@ -32785,7 +32785,7 @@
 00907147-v	slk:lemma	bedákať
 00066025-v	slk:lemma	fikať
 00417787-r	slk:lemma	okolo
-02512641-s	slk:lemma	násilný
+02512641-a	slk:lemma	násilný
 10129825-n	slk:lemma	dievčina
 03694098-n	slk:lemma	spodná paluba
 14500047-n	slk:lemma	špina
@@ -32796,17 +32796,17 @@
 06489659-n	slk:lemma	adresár
 02024508-v	slk:lemma	zasadať
 06440663-n	slk:lemma	Sofoniáš
-02123007-s	slk:lemma	podobný mačiatku
+02123007-a	slk:lemma	podobný mačiatku
 00267217-n	slk:lemma	látanie
 02598211-a	slk:lemma	rastlinný
 02902535-n	slk:lemma	štetina
-02368247-s	slk:lemma	suchý
+02368247-a	slk:lemma	suchý
 05774614-n	slk:lemma	dedukcia
 01435380-v	slk:lemma	doručovať
 04744814-n	slk:lemma	podobnosť
 06877078-n	slk:lemma	výraz tváre
 02265979-v	slk:lemma	ušetriť
-00049016-s	slk:lemma	doplnkový
+00049016-a	slk:lemma	doplnkový
 01642924-v	slk:lemma	previesť
 03057021-n	slk:lemma	kabát
 04880273-n	slk:lemma	zbehlosť
@@ -32841,7 +32841,7 @@
 12205694-n	slk:lemma	bylina
 15171857-n	slk:lemma	prístupový čas
 01062255-n	slk:lemma	odčerpávanie
-00011327-s	slk:lemma	chamtivý
+00011327-a	slk:lemma	chamtivý
 02528380-v	slk:lemma	neuspievať
 07159791-n	slk:lemma	čaro
 09261138-n	slk:lemma	rieka Cumberland
@@ -32863,11 +32863,11 @@
 14812566-n	slk:lemma	cigaretový papier
 08223802-n	slk:lemma	obec
 01118081-v	slk:lemma	predložiť
-00792075-s	slk:lemma	riadiaci
-00685113-s	slk:lemma	osudový
+00792075-a	slk:lemma	riadiaci
+00685113-a	slk:lemma	osudový
 08621598-n	slk:lemma	poloha
 04269944-n	slk:lemma	špachtľa
-01084297-s	slk:lemma	nabitý
+01084297-a	slk:lemma	nabitý
 02058994-v	slk:lemma	uháňať
 05721180-n	slk:lemma	telový vnem
 01115585-v	slk:lemma	podľahnúť
@@ -32879,7 +32879,7 @@
 04295081-n	slk:lemma	postroj
 00397576-v	slk:lemma	rozdrobiť
 00607780-v	slk:lemma	pomyslieť si
-00816839-s	slk:lemma	zrelý
+00816839-a	slk:lemma	zrelý
 05053215-n	slk:lemma	stálosť
 01581217-v	slk:lemma	zavaľovať
 09143973-n	slk:lemma	Del Rio
@@ -32896,15 +32896,15 @@
 08553535-n	slk:lemma	obytná oblasť
 00293171-r	slk:lemma	naprieč
 05675905-n	slk:lemma	vedomosť
-00301951-s	slk:lemma	nespočetný
+00301951-a	slk:lemma	nespočetný
 00799798-v	slk:lemma	zriekať sa
 06832140-n	slk:lemma	jéčko
 05951566-n	slk:lemma	obava
-01383394-s	slk:lemma	dosť veľký
+01383394-a	slk:lemma	dosť veľký
 02329093-n	slk:lemma	rad hlodavce
 08979054-n	slk:lemma	Peruánska republika
 03179701-n	slk:lemma	pult
-01881478-s	slk:lemma	nekorektný
+01881478-a	slk:lemma	nekorektný
 00827010-n	slk:lemma	izolácia
 00654625-v	slk:lemma	zoradiť
 00908351-v	slk:lemma	podporiť
@@ -32916,7 +32916,7 @@
 01976220-v	slk:lemma	hádzať do vody
 00211110-n	slk:lemma	dovŕšenie
 00969873-v	slk:lemma	rozšíriť sa
-01898722-s	slk:lemma	rozumný
+01898722-a	slk:lemma	rozumný
 03538634-n	slk:lemma	vozidlo ťahané koňmi
 07368256-n	slk:lemma	pokles
 04686003-n	slk:lemma	príťažlivosť
@@ -32927,8 +32927,8 @@
 02005948-v	slk:lemma	dochádzať
 07332956-n	slk:lemma	osudná náhoda
 01992503-v	slk:lemma	posunúť sa
-01413763-s	slk:lemma	vierohodný
-02090228-s	slk:lemma	podozrivý
+01413763-a	slk:lemma	vierohodný
+02090228-a	slk:lemma	podozrivý
 02098550-n	slk:lemma	poľovnícky pes
 04402746-n	slk:lemma	telefónny systém
 09851165-n	slk:lemma	naj
@@ -32945,7 +32945,7 @@
 00016756-a	slk:lemma	skromný
 00115554-r	slk:lemma	pokiaľ možno
 06551627-n	slk:lemma	patent
-01593079-s	slk:lemma	primitívny
+01593079-a	slk:lemma	primitívny
 02117534-v	slk:lemma	povzbudiť
 04840011-n	slk:lemma	láskavosť
 15133621-n	slk:lemma	doba
@@ -32958,7 +32958,7 @@
 01129920-n	slk:lemma	záväzok
 02697120-v	slk:lemma	ohroziť
 00130432-r	slk:lemma	profesionálne
-00724397-s	slk:lemma	bezpečný
+00724397-a	slk:lemma	bezpečný
 06943771-n	slk:lemma	slovanský jazyk
 06667317-n	slk:lemma	ustanovenie
 00250181-v	slk:lemma	nechať dorásť
@@ -32966,7 +32966,7 @@
 13910019-n	slk:lemma	farebný bod
 14520518-n	slk:lemma	hmotnosť vzduchu
 13261107-n	slk:lemma	čisté tržby
-01372948-s	slk:lemma	súcitný
+01372948-a	slk:lemma	súcitný
 01176219-n	slk:lemma	zdolanie
 00216723-n	slk:lemma	odstránenie
 05892880-n	slk:lemma	predbežná podmienka
@@ -33015,9 +33015,9 @@
 02116118-v	slk:lemma	rozochvievať (citovo)
 05204982-n	slk:lemma	bezmocnosť
 01150981-v	slk:lemma	obrátiť sa
-00014490-s	slk:lemma	bohatý
+00014490-a	slk:lemma	bohatý
 01447868-v	slk:lemma	zovrieť
-02316992-s	slk:lemma	krivoľaký
+02316992-a	slk:lemma	krivoľaký
 00915830-v	slk:lemma	hovoriť šeptom
 08395298-n	slk:lemma	jazdná polícia USA
 02871695-a	slk:lemma	farský
@@ -33040,18 +33040,18 @@
 00434374-v	slk:lemma	pokaziť sa
 01780434-v	slk:lemma	mať strach
 00490304-r	slk:lemma	ležiaci uprostred krajiny
-01868578-s	slk:lemma	jedinečný
+01868578-a	slk:lemma	jedinečný
 01899262-v	slk:lemma	sácať
 02933112-n	slk:lemma	skriňa
 15229677-n	slk:lemma	ranná modlitba
-00975487-s	slk:lemma	exkluzívny
+00975487-a	slk:lemma	exkluzívny
 00873682-v	slk:lemma	oznámiť
 00527872-n	slk:lemma	step
 08273167-n	slk:lemma	posádka
 00771961-v	slk:lemma	inšpirovať
 00020280-r	slk:lemma	neprestajne
 00321731-n	slk:lemma	nakvapkanie
-00373493-s	slk:lemma	medený
+00373493-a	slk:lemma	medený
 10503247-n	slk:lemma	priekupník
 04694809-n	slk:lemma	opar
 01628946-a	slk:lemma	ofenzívny
@@ -33060,7 +33060,7 @@
 00146856-n	slk:lemma	zlúčenie
 04112430-n	slk:lemma	hlavný rotor
 15264607-n	slk:lemma	v rytme
-02242798-s	slk:lemma	chrastavý
+02242798-a	slk:lemma	chrastavý
 00039941-r	slk:lemma	zdanlivo
 00675701-a	slk:lemma	cyklický
 00869931-v	slk:lemma	podať žalobu
@@ -33074,33 +33074,33 @@
 00786816-v	slk:lemma	vyšetriť
 00464478-n	slk:lemma	vodné pólo
 09187743-n	slk:lemma	rieka Adige
-01025212-s	slk:lemma	zarytý
+01025212-a	slk:lemma	zarytý
 01392237-v	slk:lemma	zotierať
 03911658-n	slk:lemma	vreckový nôž
 04358874-n	slk:lemma	nadstavba
-00808822-s	slk:lemma	meniaci sa
+00808822-a	slk:lemma	meniaci sa
 09623038-n	slk:lemma	vodca
 01250826-n	slk:lemma	transmutácia
 02150948-v	slk:lemma	pozrieť
 00671335-v	slk:lemma	nedoceňovať
 05261566-n	slk:lemma	brada
 09762509-n	slk:lemma	odborník
-01466775-s	slk:lemma	studený
+01466775-a	slk:lemma	studený
 00278040-n	slk:lemma	navlhčovanie
 00098083-v	slk:lemma	oživovať
 02872066-a	slk:lemma	manželský
 00215314-n	slk:lemma	rozchod
 13347065-n	slk:lemma	zákonné poistenie zodpovednosti
-01280908-s	slk:lemma	triviálny
-00138782-s	slk:lemma	neprimeraný
+01280908-a	slk:lemma	triviálny
+00138782-a	slk:lemma	neprimeraný
 02167052-v	slk:lemma	hľadieť
 10004804-n	slk:lemma	závislá osoba
 01843055-v	slk:lemma	potúlať sa
 00847478-v	slk:lemma	pochovávať (prenesene, expresívne)
 00898019-v	slk:lemma	potriasť si rukou
-00574884-s	slk:lemma	konzervatívny
+00574884-a	slk:lemma	konzervatívny
 06263369-n	slk:lemma	tlač
-02180277-s	slk:lemma	úprimný
+02180277-a	slk:lemma	úprimný
 03296478-n	slk:lemma	štít
 04967801-n	slk:lemma	šedozelená farba
 11410625-n	slk:lemma	efekt
@@ -33122,21 +33122,21 @@
 09105821-n	slk:lemma	MO
 02725829-a	slk:lemma	federálny
 10625860-n	slk:lemma	čarodejník
-02333976-s	slk:lemma	frustrovaný
+02333976-a	slk:lemma	frustrovaný
 08663860-n	slk:lemma	vrch
 05814291-n	slk:lemma	námet
 00099439-n	slk:lemma	prídavok
 13288337-n	slk:lemma	nerozdelené právo
 01817130-v	slk:lemma	znepáčiť sa
 00013328-v	slk:lemma	hrať sa
-00925287-s	slk:lemma	rekriminačný
+00925287-a	slk:lemma	rekriminačný
 00797878-n	slk:lemma	pokus
 02771004-n	slk:lemma	kláves backspace
 03089014-n	slk:lemma	potrubie
 00157624-r	slk:lemma	kompletne
 13926451-n	slk:lemma	štátnosť
 01095218-v	slk:lemma	odslúžiť
-00032733-s	slk:lemma	bystrý
+00032733-a	slk:lemma	bystrý
 00511041-n	slk:lemma	lumpačka
 00268112-n	slk:lemma	generálna oprava
 00912048-v	slk:lemma	zakričať
@@ -33180,7 +33180,7 @@
 00622384-v	slk:lemma	týrať
 00494269-v	slk:lemma	oddeľovať
 00240184-n	slk:lemma	zriadenie
-01854129-s	slk:lemma	pomocný
+01854129-a	slk:lemma	pomocný
 12706644-n	slk:lemma	čeľaď Rutaceae
 03177349-n	slk:lemma	depozitár
 02898121-a	slk:lemma	stavebný
@@ -33195,7 +33195,7 @@
 00123170-v	slk:lemma	meniť sa
 05685538-n	slk:lemma	záhada
 13379413-n	slk:lemma	úverový limit
-00412788-s	slk:lemma	nekultúrny
+00412788-a	slk:lemma	nekultúrny
 00503164-v	slk:lemma	dráždiť
 00242003-n	slk:lemma	pokračovanie
 09247942-n	slk:lemma	Clyde
@@ -33207,13 +33207,13 @@
 01479940-a	slk:lemma	bez posádky
 08414807-n	slk:lemma	porota
 13493998-n	slk:lemma	ľudská činnosť
-00579622-s	slk:lemma	významný
+00579622-a	slk:lemma	významný
 01573515-v	slk:lemma	rozodrať
 02111838-v	slk:lemma	lomiť sa
 10089484-n	slk:lemma	filmová hviezda
 05430628-n	slk:lemma	vegetatívna bunka
 01017643-v	slk:lemma	brániť
-01234527-s	slk:lemma	naklonený
+01234527-a	slk:lemma	naklonený
 10470779-n	slk:lemma	kňaz
 00732746-n	slk:lemma	porušenie zákona
 00282050-n	slk:lemma	pohyb vpred, pohyb dopredu
@@ -33223,12 +33223,12 @@
 06870576-n	slk:lemma	nota
 01811736-v	slk:lemma	vzpruhovať
 00437487-n	slk:lemma	premet
-01079052-s	slk:lemma	zamrznutý
+01079052-a	slk:lemma	zamrznutý
 00178102-v	slk:lemma	oberať
-00048858-s	slk:lemma	ďalší
+00048858-a	slk:lemma	ďalší
 04288784-n	slk:lemma	pätka klenby
 02871957-a	slk:lemma	susedný
-00329034-s	slk:lemma	rozdelený na úseky
+00329034-a	slk:lemma	rozdelený na úseky
 00035058-r	slk:lemma	častokrát
 02774630-n	slk:lemma	batožina
 00681429-v	slk:lemma	hodnotiť
@@ -33241,18 +33241,18 @@
 00067274-v	slk:lemma	fňukať
 05790758-n	slk:lemma	favorit
 08948346-n	slk:lemma	Guyana
-02215087-s	slk:lemma	neobyčajný
+02215087-a	slk:lemma	neobyčajný
 11537327-n	slk:lemma	mach
 01974062-v	slk:lemma	dvíhať
 04731925-n	slk:lemma	vrchol
-01935744-s	slk:lemma	povestný
+01935744-a	slk:lemma	povestný
 01548193-a	slk:lemma	morálny
 00803617-n	slk:lemma	riadenie
 14612764-n	slk:lemma	azoimid
 01235137-n	slk:lemma	odplata
 00112601-r	slk:lemma	nedávno
 13791389-n	slk:lemma	spojenie
-00405879-s	slk:lemma	poblednutý
+00405879-a	slk:lemma	poblednutý
 03002816-n	slk:lemma	chalet
 01163847-v	slk:lemma	vyťažiť
 01404389-v	slk:lemma	odraziť
@@ -33270,14 +33270,14 @@
 14360320-n	slk:lemma	mdlosť
 00090253-n	slk:lemma	prijatie
 04332243-n	slk:lemma	filter
-01419784-s	slk:lemma	obrazný
+01419784-a	slk:lemma	obrazný
 09289331-n	slk:lemma	ľadovec
-02327315-s	slk:lemma	neústupčivý
-00844719-s	slk:lemma	ohybný
+02327315-a	slk:lemma	neústupčivý
+00844719-a	slk:lemma	ohybný
 04830102-n	slk:lemma	bezcitnosť
 06831177-n	slk:lemma	a
-00421875-s	slk:lemma	nechutný
-02101757-s	slk:lemma	do očí bijúci
+00421875-a	slk:lemma	nechutný
+02101757-a	slk:lemma	do očí bijúci
 07361128-n	slk:lemma	zrútenie sa
 08479095-n	slk:lemma	Židia
 10455447-n	slk:lemma	nosič batožiny
@@ -33286,7 +33286,7 @@
 00039211-n	slk:lemma	ovplyvňovanie
 04830689-n	slk:lemma	krutosť
 00713167-v	slk:lemma	uviesť do vzťahu
-00521976-s	slk:lemma	celkový
+00521976-a	slk:lemma	celkový
 02141973-v	slk:lemma	predvádzať
 05491154-n	slk:lemma	vonkajšia kôra obličky
 03197201-n	slk:lemma	číslicový voltmeter
@@ -33295,11 +33295,11 @@
 00550777-a	slk:lemma	nepreukázateľný
 06379439-n	slk:lemma	eklóga
 00054950-r	slk:lemma	príšerne
-01443842-s	slk:lemma	krátkodobý
+01443842-a	slk:lemma	krátkodobý
 00214951-v	slk:lemma	zmáčať sa
 01199751-a	slk:lemma	homogénny
 04395875-n	slk:lemma	hostinec
-02160622-s	slk:lemma	celkom slepý
+02160622-a	slk:lemma	celkom slepý
 00231557-v	slk:lemma	dorásť
 04686003-n	slk:lemma	atraktivita
 10411867-n	slk:lemma	pederast
@@ -33307,7 +33307,7 @@
 08791167-n	slk:lemma	Stredný východ
 01146918-v	slk:lemma	šermovať
 06620579-n	slk:lemma	TV šou
-00493012-s	slk:lemma	spoločný
+00493012-a	slk:lemma	spoločný
 04726724-n	slk:lemma	povahové črty
 00079947-r	slk:lemma	vyššie (spomenuté)
 03462747-n	slk:lemma	uzemnenie
@@ -33317,7 +33317,7 @@
 11427619-n	slk:lemma	severná žiara
 07152259-n	slk:lemma	reklamné heslo
 09633969-n	slk:lemma	delikvent
-01499269-s	slk:lemma	nezmerný
+01499269-a	slk:lemma	nezmerný
 10207169-n	slk:lemma	príbuzenstvo
 00069173-n	slk:lemma	nedodržanie zmluvy
 10541229-n	slk:lemma	panovník
@@ -33336,7 +33336,7 @@
 00699815-v	slk:lemma	určiť si
 02238770-v	slk:lemma	zaobstarávať si
 11552386-n	slk:lemma	Spermatophyta
-00657473-s	slk:lemma	hranatý
+00657473-a	slk:lemma	hranatý
 09441107-n	slk:lemma	Juhočínske more
 02489916-v	slk:lemma	ženiť sa
 07466832-n	slk:lemma	záverečná súťaž
@@ -33351,13 +33351,13 @@
 08519916-n	slk:lemma	Transkaukazsko
 00928542-n	slk:lemma	výstavba miest
 00258175-r	slk:lemma	bez poplatku
-00348018-s	slk:lemma	nemenný
+00348018-a	slk:lemma	nemenný
 13163803-n	slk:lemma	vetva
 07989373-n	slk:lemma	muž a žena
 10271677-n	slk:lemma	lord
 02788378-a	slk:lemma	republikánsky
 05128870-n	slk:lemma	výmera pôdy
-01385663-s	slk:lemma	kozmický
+01385663-a	slk:lemma	kozmický
 01411085-v	slk:lemma	vybiť
 06300193-n	slk:lemma	koreň slova
 08514034-n	slk:lemma	stredisko
@@ -33382,7 +33382,7 @@
 00854420-v	slk:lemma	oklamať
 02022659-v	slk:lemma	nestihnúť
 02452637-n	slk:lemma	rypák
-00195684-s	slk:lemma	hrozivý
+00195684-a	slk:lemma	hrozivý
 14633781-n	slk:lemma	atóm uhlíka
 01845720-v	slk:lemma	cestovať
 02061069-v	slk:lemma	mykať sa
@@ -33398,7 +33398,7 @@
 04339291-n	slk:lemma	pruh
 08954443-n	slk:lemma	Thule
 00326291-n	slk:lemma	vzostup
-00209916-s	slk:lemma	podobný tráve
+00209916-a	slk:lemma	podobný tráve
 00111609-r	slk:lemma	naj
 05098311-n	slk:lemma	maximálna hodnota
 15202806-n	slk:lemma	slnečný rok
@@ -33408,14 +33408,14 @@
 01061017-v	slk:lemma	niesť v sebe
 00271263-n	slk:lemma	degradácia
 04066270-n	slk:lemma	červený koberec
-02418692-s	slk:lemma	nepredstaviteľný
+02418692-a	slk:lemma	nepredstaviteľný
 05118437-n	slk:lemma	výstrednosť
 03416094-n	slk:lemma	portál
 01951480-v	slk:lemma	posielať (niekam)
 00786816-v	slk:lemma	preskúšať
 00586598-v	slk:lemma	potlačiť
 06292000-n	slk:lemma	záhlavie
-02515001-s	slk:lemma	lotrovský
+02515001-a	slk:lemma	lotrovský
 13956488-n	slk:lemma	pravdivosť
 10014939-n	slk:lemma	generálny riaditeľ
 02967407-n	slk:lemma	klepačka na koberce
@@ -33425,7 +33425,7 @@
 01638368-v	slk:lemma	navrhnúť
 01534147-v	slk:lemma	blatiť
 10150940-n	slk:lemma	návštevník
-02433975-s	slk:lemma	vyčerpaný
+02433975-a	slk:lemma	vyčerpaný
 00443984-v	slk:lemma	roztaviť
 02351467-v	slk:lemma	predať pod cenu
 13380667-n	slk:lemma	dividendový kupón
@@ -33433,8 +33433,8 @@
 02295842-v	slk:lemma	deliť
 08337108-n	slk:lemma	zastupiteľstvo, zastupiteľský úrad
 00659112-v	slk:lemma	preskupiť
-00751099-s	slk:lemma	zrozumiteľný
-01357027-s	slk:lemma	osviežujúci
+00751099-a	slk:lemma	zrozumiteľný
+01357027-a	slk:lemma	osviežujúci
 13998576-n	slk:lemma	zadržanie v trestnom konaní
 01814074-v	slk:lemma	udržať v dobrej nálade
 02863750-n	slk:lemma	bojler
@@ -33451,17 +33451,17 @@
 05596651-n	slk:lemma	panvový pletenec
 00885925-v	slk:lemma	preukázať láskavosť
 02531625-v	slk:lemma	preveriť
-01031602-s	slk:lemma	rýchlonohý
+01031602-a	slk:lemma	rýchlonohý
 02349477-a	slk:lemma	ležiaci nižšie
 05298729-n	slk:lemma	orgán
 08563627-n	slk:lemma	americký Juhozápad, juhozápad Spojených štátov
 05158431-n	slk:lemma	osobný prospech
-01709437-s	slk:lemma	zaplatený vopred
+01709437-a	slk:lemma	zaplatený vopred
 00044150-n	slk:lemma	implementácia
 06374587-n	slk:lemma	literárna kritika
 00971075-a	slk:lemma	moderný
 12212810-n	slk:lemma	podtrieda Rosidae
-02070342-s	slk:lemma	odlišný
+02070342-a	slk:lemma	odlišný
 00793785-v	slk:lemma	pritiahnuť
 00034288-v	slk:lemma	robiť grimasy
 00882961-n	slk:lemma	vôňa
@@ -33484,7 +33484,7 @@
 00047392-r	slk:lemma	neprimerane
 13419032-n	slk:lemma	podielnické osvedčenie
 05656537-n	slk:lemma	videnie
-00119006-s	slk:lemma	plný života
+00119006-a	slk:lemma	plný života
 00286957-n	slk:lemma	krok
 04289195-n	slk:lemma	protipožiarne sprchovacie zariadenie
 05310790-n	slk:lemma	plodová membrána
@@ -33514,11 +33514,11 @@
 05579944-n	slk:lemma	lakťový kĺb
 13265904-n	slk:lemma	príspevok
 00087736-v	slk:lemma	chytiť (chorobu)
-01176973-s	slk:lemma	postihnutý sneťou
+01176973-a	slk:lemma	postihnutý sneťou
 09209263-n	slk:lemma	Atlantik
 02904372-a	slk:lemma	kontrolný
 00548326-n	slk:lemma	herectvo
-01722846-s	slk:lemma	dcérsky
+01722846-a	slk:lemma	dcérsky
 04171831-n	slk:lemma	polovodičový prvok
 02333368-n	slk:lemma	rod Rattus
 00268557-n	slk:lemma	zreštaurovanie
@@ -33546,22 +33546,22 @@
 02540347-v	slk:lemma	dospievať
 00040325-a	slk:lemma	aktívny
 02000868-v	slk:lemma	sledovať
-01024228-s	slk:lemma	prispôsobivý
+01024228-a	slk:lemma	prispôsobivý
 14120767-n	slk:lemma	tyreotoxikóza
 01068773-n	slk:lemma	zdržanlivosť
 08891415-n	slk:lemma	Kaledónia
 01577093-v	slk:lemma	ponoriť sa
 09832538-n	slk:lemma	nosič batožiny
-01961205-s	slk:lemma	príležitostný
+01961205-a	slk:lemma	príležitostný
 06433249-n	slk:lemma	Kniha Numeri
 00441824-n	slk:lemma	vodné športy
-00305700-s	slk:lemma	prudký
+00305700-a	slk:lemma	prudký
 03424103-n	slk:lemma	plynovod
 08459252-n	slk:lemma	sekvencia
-01368464-s	slk:lemma	ponurý
+01368464-a	slk:lemma	ponurý
 07963208-n	slk:lemma	kopa sena
 10121144-n	slk:lemma	podlžník skonfiškovanej pohľadávky
-02322512-s	slk:lemma	krutý
+02322512-a	slk:lemma	krutý
 00996485-v	slk:lemma	podpísať sa
 10113583-n	slk:lemma	nastrčená osoba
 06725067-n	slk:lemma	technické podmienky
@@ -33585,30 +33585,30 @@
 06719299-n	slk:lemma	kyslé hrozno
 00510364-v	slk:lemma	robiť škvrny
 03956331-n	slk:lemma	pohon s planétovými kolesami
-00554098-s	slk:lemma	v rozpore (s)
-01287808-s	slk:lemma	zreteľný
+00554098-a	slk:lemma	v rozpore (s)
+01287808-a	slk:lemma	zreteľný
 04548280-n	slk:lemma	nástenné hodiny
 06832896-n	slk:lemma	q
 00442569-n	slk:lemma	kúpanie v mori
 12583401-n	slk:lemma	palmeto
 01552885-a	slk:lemma	zopár
 01133281-n	slk:lemma	manažment
-00566835-s	slk:lemma	spriaznený
+00566835-a	slk:lemma	spriaznený
 02143539-v	slk:lemma	vykopať
 01435380-v	slk:lemma	preniesť
 00755745-v	slk:lemma	žiadať si
 15155220-n	slk:lemma	deň
 00956687-v	slk:lemma	posudzovať
-00372111-s	slk:lemma	hnedý
+00372111-a	slk:lemma	hnedý
 03814112-n	slk:lemma	výstrih
 00393369-n	slk:lemma	ostránenie
-00823556-s	slk:lemma	smerom k východu
-02372434-s	slk:lemma	krížový
-00890351-s	slk:lemma	ekvivalentný
+00823556-a	slk:lemma	smerom k východu
+02372434-a	slk:lemma	krížový
+00890351-a	slk:lemma	ekvivalentný
 00466053-v	slk:lemma	zladiť
 00072012-v	slk:lemma	pomočiť sa
 06205018-n	slk:lemma	nezáujem
-02528566-s	slk:lemma	vyhnaný
+02528566-a	slk:lemma	vyhnaný
 08300641-n	slk:lemma	Medzinárodná agentúra pre atómovú energiu
 06650070-n	slk:lemma	konfirmácia
 02555126-a	slk:lemma	vlhký
@@ -33623,7 +33623,7 @@
 02563327-v	slk:lemma	spustiť
 08510666-n	slk:lemma	povrch
 10629449-n	slk:lemma	novinár platený od riadka
-00440292-s	slk:lemma	hlúpy
+00440292-a	slk:lemma	hlúpy
 00621058-v	slk:lemma	objasniť
 00806049-v	slk:lemma	poskytnúť
 03842012-n	slk:lemma	administratívna budova
@@ -33632,8 +33632,8 @@
 13728499-n	slk:lemma	celé číslo
 01105639-v	slk:lemma	vynikať nad
 01006056-v	slk:lemma	zapísať si
-02337188-s	slk:lemma	chudý
-00746047-s	slk:lemma	nepríjemný
+02337188-a	slk:lemma	chudý
+00746047-a	slk:lemma	nepríjemný
 09826204-n	slk:lemma	letec
 00871405-v	slk:lemma	vyhrážať
 00054628-v	slk:lemma	počať
@@ -33641,11 +33641,11 @@
 01404389-v	slk:lemma	odbíjať
 13615557-n	slk:lemma	imperiálna jednotka objemu
 00048828-n	slk:lemma	príchod
-01350225-s	slk:lemma	externý
+01350225-a	slk:lemma	externý
 01664172-v	slk:lemma	uvariť
 00193130-v	slk:lemma	dodávať mysli
-02090228-s	slk:lemma	ukrývaný
-00028867-s	slk:lemma	nedocenený
+02090228-a	slk:lemma	ukrývaný
+00028867-a	slk:lemma	nedocenený
 05979909-n	slk:lemma	nevera
 01188725-v	slk:lemma	vyžadovať
 05481095-n	slk:lemma	mozog
@@ -33667,12 +33667,12 @@
 04631700-n	slk:lemma	živosť
 01091556-a	slk:lemma	fungujúci
 00066025-v	slk:lemma	zaplakať
-00666610-s	slk:lemma	súčasný
+00666610-a	slk:lemma	súčasný
 01129920-n	slk:lemma	povinnosť
 02821943-n	slk:lemma	spálňový nábytok
 07007684-n	slk:lemma	dráma
 00393161-n	slk:lemma	mlátenie
-02508514-s	slk:lemma	odhalený
+02508514-a	slk:lemma	odhalený
 02742482-v	slk:lemma	mať význam
 13969854-n	slk:lemma	uznanie
 01732172-v	slk:lemma	interpretovať
@@ -33693,18 +33693,18 @@
 01780434-v	slk:lemma	desiť sa
 00828704-n	slk:lemma	oblečenie
 00282613-n	slk:lemma	kariéra
-00068180-s	slk:lemma	zvážený
+00068180-a	slk:lemma	zvážený
 00885925-v	slk:lemma	robiť láskavosť
 04264914-n	slk:lemma	balistická strela
 07152752-n	slk:lemma	bojový pokrik
 08065093-n	slk:lemma	komerčný podnik
-01086453-s	slk:lemma	napchatý
+01086453-a	slk:lemma	napchatý
 00452152-n	slk:lemma	kohútie zápasy
 08375154-n	slk:lemma	zväz
 01127795-v	slk:lemma	ubrániť sa
 13352138-n	slk:lemma	hypotéka
 00641252-v	slk:lemma	odpočítať
-00487198-s	slk:lemma	všeobecný
+00487198-a	slk:lemma	všeobecný
 09382990-n	slk:lemma	Tichý oceán
 05750163-n	slk:lemma	móda
 04867871-n	slk:lemma	nepravdivosť
@@ -33741,7 +33741,7 @@
 00164444-v	slk:lemma	občerstviť sa
 00087188-r	slk:lemma	bezvýhradne
 00314835-r	slk:lemma	aby som pravdu povedal
-01178134-s	slk:lemma	bledý
+01178134-a	slk:lemma	bledý
 05547508-n	slk:lemma	hrdlo
 03711897-n	slk:lemma	dopravná línia
 00304422-v	slk:lemma	zovrieť
@@ -33750,7 +33750,7 @@
 15271008-n	slk:lemma	prerušenie
 09815790-n	slk:lemma	asistentka
 01724459-v	slk:lemma	hrať
-01952643-s	slk:lemma	surový
+01952643-a	slk:lemma	surový
 03612378-n	slk:lemma	Torodal
 01365131-v	slk:lemma	pokrývať laminátom
 05779568-n	slk:lemma	ideológia
@@ -33760,7 +33760,7 @@
 08322981-n	slk:lemma	výbor
 05954481-n	slk:lemma	myšlienka
 01034457-a	slk:lemma	cudzí
-01573238-s	slk:lemma	nepravý
+01573238-a	slk:lemma	nepravý
 08303692-n	slk:lemma	národ
 04675777-n	slk:lemma	imidž
 04344873-n	slk:lemma	pohovka
@@ -33778,7 +33778,7 @@
 02368336-a	slk:lemma	sladký
 01186958-v	slk:lemma	odstaviť
 07953827-n	slk:lemma	skupina
-02279723-s	slk:lemma	nadšený
+02279723-a	slk:lemma	nadšený
 01447257-v	slk:lemma	pritláčať
 14687633-n	slk:lemma	kerozín
 10271216-n	slk:lemma	pozorovateľ
@@ -33793,7 +33793,7 @@
 00030142-v	slk:lemma	chichotať sa
 00582071-n	slk:lemma	administratívna práca
 07325190-n	slk:lemma	štart
-01840880-s	slk:lemma	imbecilný
+01840880-a	slk:lemma	imbecilný
 00467451-v	slk:lemma	začleňovať sa
 00217152-v	slk:lemma	zaplavovať
 13908021-n	slk:lemma	zúbkovanie
@@ -33837,7 +33837,7 @@
 00514041-n	slk:lemma	svinstvo
 03409591-n	slk:lemma	štítová strecha
 01695681-n	slk:lemma	archosaurus
-01968811-s	slk:lemma	hodinový
+01968811-a	slk:lemma	hodinový
 07199565-n	slk:lemma	reakcia
 06820212-n	slk:lemma	dolný index
 00292448-a	slk:lemma	identický
@@ -33857,7 +33857,7 @@
 00619869-v	slk:lemma	nechápať
 15058310-n	slk:lemma	sterol
 00339934-v	slk:lemma	diať sa
-00194357-s	slk:lemma	hroziaci
+00194357-a	slk:lemma	hroziaci
 00392588-v	slk:lemma	zlepšovať
 09189157-n	slk:lemma	orlie hniezdo
 02681795-v	slk:lemma	udržať
@@ -33881,13 +33881,13 @@
 00415226-n	slk:lemma	spôsob
 01615602-v	slk:lemma	pokryť kovom
 15112239-n	slk:lemma	látka pľuzgierotvorná
-01750386-s	slk:lemma	absolútny
+01750386-a	slk:lemma	absolútny
 07515790-n	slk:lemma	pohoda
 10667187-n	slk:lemma	sprosták
 02344381-v	slk:lemma	odplatiť
 09296121-n	slk:lemma	záliv
 06253690-n	slk:lemma	správa
-01757211-s	slk:lemma	núdzový
+01757211-a	slk:lemma	núdzový
 08121394-n	slk:lemma	požiarna poisťovňa
 03653583-n	slk:lemma	pult
 00099721-v	slk:lemma	športovať
@@ -33904,7 +33904,7 @@
 00513089-n	slk:lemma	hra
 09541919-n	slk:lemma	zlý duch
 15278281-n	slk:lemma	častosť
-01804422-s	slk:lemma	odpudzujúci
+01804422-a	slk:lemma	odpudzujúci
 00377351-v	slk:lemma	celkom zhorieť
 00759501-v	slk:lemma	naliehať
 09010085-n	slk:lemma	Volgograd, Stalingrad, Tsaritsyn
@@ -33914,7 +33914,7 @@
 07509572-n	slk:lemma	úžas
 00099089-v	slk:lemma	zaceliť sa
 02367032-v	slk:lemma	odstupovať
-00915141-s	slk:lemma	matematický
+00915141-a	slk:lemma	matematický
 09089139-n	slk:lemma	Kentucky
 00164444-v	slk:lemma	občerstviť
 01062136-n	slk:lemma	poistná škoda
@@ -33933,9 +33933,9 @@
 01122630-v	slk:lemma	predbiehať
 07123552-n	slk:lemma	vresk
 04453910-n	slk:lemma	pokrievka
-01893510-s	slk:lemma	pokorný
+01893510-a	slk:lemma	pokorný
 02457825-v	slk:lemma	nevážiť si
-01223271-s	slk:lemma	ľstivý
+01223271-a	slk:lemma	ľstivý
 00348541-v	slk:lemma	rozbehnúť sa
 01818235-v	slk:lemma	posmeľovať
 01819554-v	slk:lemma	vydierať
@@ -33943,7 +33943,7 @@
 00939857-v	slk:lemma	ozrejmiť
 00748282-v	slk:lemma	potrestať
 08213424-n	slk:lemma	Zvláštne oddiely americkej armády
-00704360-s	slk:lemma	opustený
+00704360-a	slk:lemma	opustený
 08168978-n	slk:lemma	štát
 00354183-n	slk:lemma	devitalizácia
 01012360-n	slk:lemma	zoskupovanie
@@ -33961,7 +33961,7 @@
 02061069-v	slk:lemma	strhnúť sa
 01022292-n	slk:lemma	pamiatka
 09923673-n	slk:lemma	občan
-01674242-s	slk:lemma	normálny
+01674242-a	slk:lemma	normálny
 01580467-v	slk:lemma	zabaliť
 00720063-v	slk:lemma	očakávať
 01329239-v	slk:lemma	prišívať
@@ -33995,7 +33995,7 @@
 02351467-v	slk:lemma	predávať pod cenu
 01898731-n	slk:lemma	srsť
 00074407-r	slk:lemma	nazad
-00179815-s	slk:lemma	neakreditovaný
+00179815-a	slk:lemma	neakreditovaný
 02267012-a	slk:lemma	vyriešený
 08997487-n	slk:lemma	Singapur
 02007422-n	slk:lemma	Phoenicopteridae
@@ -34022,8 +34022,8 @@
 02345048-v	slk:lemma	vylúpiť
 02976641-n	slk:lemma	kartáč
 03860404-n	slk:lemma	vonkajší záchod
-01744515-s	slk:lemma	bystrý
-00440579-s	slk:lemma	nudný
+01744515-a	slk:lemma	bystrý
+00440579-a	slk:lemma	nudný
 02838005-a	slk:lemma	polárny
 02319824-v	slk:lemma	zdražovať
 09943239-n	slk:lemma	poverený vojenský úradník
@@ -34036,12 +34036,12 @@
 00780731-n	slk:lemma	škrupinky
 09018030-n	slk:lemma	Jerevan
 13949802-n	slk:lemma	prednostné právo
-02499148-s	slk:lemma	právoplatný
+02499148-a	slk:lemma	právoplatný
 04395024-n	slk:lemma	plachta na nákladný automobil
 13536794-n	slk:lemma	fotografovanie
-00729439-s	slk:lemma	nezávislý
+00729439-a	slk:lemma	nezávislý
 00974367-v	slk:lemma	oznámiť
-01687167-s	slk:lemma	nový
+01687167-a	slk:lemma	nový
 01753788-v	slk:lemma	zriadiť
 14236226-n	slk:lemma	nezhubný nádor
 02933112-n	slk:lemma	skrinka
@@ -34049,13 +34049,13 @@
 14613643-n	slk:lemma	kyanovodík
 07204401-n	slk:lemma	odmietnutie
 02694776-n	slk:lemma	aljašský ropovod
-01523567-s	slk:lemma	schopný samovoľného pohybu
+01523567-a	slk:lemma	schopný samovoľného pohybu
 00172980-r	slk:lemma	odvážne
 01114303-v	slk:lemma	zmocniť sa
 09994943-n	slk:lemma	zosnulý
 05547396-n	slk:lemma	zátylok
 03843438-n	slk:lemma	voskové plátno
-02000968-s	slk:lemma	extravagantný
+02000968-a	slk:lemma	extravagantný
 01534147-v	slk:lemma	okydať
 01955984-v	slk:lemma	plaviť sa
 09362316-n	slk:lemma	ústie
@@ -34067,15 +34067,15 @@
 04446521-n	slk:lemma	záchod
 01080062-n	slk:lemma	námietka proti zaujatosti sudcu
 03488438-n	slk:lemma	telefón
-01940472-s	slk:lemma	každodenný
+01940472-a	slk:lemma	každodenný
 02499312-v	slk:lemma	poslať do vyhnanstva
 00440747-n	slk:lemma	lyžiarstvo
 10801697-n	slk:lemma	hráč na xylofón
 01034312-v	slk:lemma	prediskutovať
-02132224-s	slk:lemma	obscénny
+02132224-a	slk:lemma	obscénny
 15224486-n	slk:lemma	obdobie
 08749312-n	slk:lemma	Svätý Eustatius
-01413501-s	slk:lemma	rovnako pravdepodobný
+01413501-a	slk:lemma	rovnako pravdepodobný
 06207437-n	slk:lemma	nezdvorilosť
 00974173-v	slk:lemma	ohlasovať
 02564674-v	slk:lemma	ušetriť (od niečoho)
@@ -34095,7 +34095,7 @@
 06761099-n	slk:lemma	vytáčka
 01925469-n	slk:lemma	motolice
 00806075-n	slk:lemma	interná kontrola
-01439496-s	slk:lemma	dlhodobý
+01439496-a	slk:lemma	dlhodobý
 09075842-n	slk:lemma	Georgia
 05372290-n	slk:lemma	vnútorná sluchová žila
 02587375-v	slk:lemma	panovať
@@ -34105,21 +34105,21 @@
 04359589-n	slk:lemma	opora
 14929662-n	slk:lemma	listová zmes
 03484487-n	slk:lemma	krém na ruky
-00656132-s	slk:lemma	rozhodujúci
+00656132-a	slk:lemma	rozhodujúci
 04259771-n	slk:lemma	ozvenový hĺbkomer
 00365471-n	slk:lemma	zmenšovanie
 14796073-n	slk:lemma	benzenol
 00030647-v	slk:lemma	zvaliť sa (o človeku)
 00923444-n	slk:lemma	priemysel
-02403505-s	slk:lemma	napätý
+02403505-a	slk:lemma	napätý
 00877345-a	slk:lemma	výskumný
 00298041-a	slk:lemma	socialistický
-02327315-s	slk:lemma	zanovitý
+02327315-a	slk:lemma	zanovitý
 05901410-n	slk:lemma	daňová politika
 02513989-v	slk:lemma	krivdiť niekomu
 00419644-n	slk:lemma	týranie
 01113068-n	slk:lemma	predávanie
-00936523-s	slk:lemma	starý
+00936523-a	slk:lemma	starý
 00394562-a	slk:lemma	farebný
 15063493-n	slk:lemma	kyselina sírová
 03446528-n	slk:lemma	golfové ihrisko
@@ -34127,8 +34127,8 @@
 01419473-v	slk:lemma	zmiešať
 07313636-n	slk:lemma	úraz
 02296153-v	slk:lemma	zanechávať
-01676026-s	slk:lemma	nesmierny
-01439496-s	slk:lemma	trvanlivý
+01676026-a	slk:lemma	nesmierny
+01439496-a	slk:lemma	trvanlivý
 00926472-v	slk:lemma	odhadnúť
 06888944-n	slk:lemma	atrakcia
 01742726-v	slk:lemma	skultivovať
@@ -34167,7 +34167,7 @@
 03291819-n	slk:lemma	obálka
 07971449-n	slk:lemma	rod
 02292125-v	slk:lemma	čerpať
-02002470-s	slk:lemma	obmedzený
+02002470-a	slk:lemma	obmedzený
 00181781-n	slk:lemma	voľby
 01541467-v	slk:lemma	primiešať
 01034457-a	slk:lemma	zahraničný
@@ -34183,10 +34183,10 @@
 00199130-n	slk:lemma	zmena stavu
 10259094-n	slk:lemma	zvrchovaný panovník
 03219135-n	slk:lemma	bábika
-01154030-s	slk:lemma	nadýchaný
-00848679-s	slk:lemma	podľa etikety
+01154030-a	slk:lemma	nadýchaný
+00848679-a	slk:lemma	podľa etikety
 02513269-a	slk:lemma	bezúhonný
-00929815-s	slk:lemma	predvídaný
+00929815-a	slk:lemma	predvídaný
 12434775-n	slk:lemma	cesnak
 00146572-n	slk:lemma	konvergencia
 13555915-n	slk:lemma	odvádzač
@@ -34196,15 +34196,15 @@
 03154073-n	slk:lemma	príbor
 12318378-n	slk:lemma	vlašský orech
 09195372-n	slk:lemma	rieka Amazon
-01741669-s	slk:lemma	mierny
-00326608-s	slk:lemma	prenáhlený
+01741669-a	slk:lemma	mierny
+00326608-a	slk:lemma	prenáhlený
 01106670-v	slk:lemma	predbiehať
 07134850-n	slk:lemma	reči
 08189659-n	slk:lemma	skupina
 02763306-n	slk:lemma	vonkajšia pamäť
 00799383-v	slk:lemma	upúšťať (od)
 13725457-n	slk:lemma	metrický cent
-01621424-s	slk:lemma	uviaznutý na mŕtvom bode
+01621424-a	slk:lemma	uviaznutý na mŕtvom bode
 08420278-n	slk:lemma	banková spoločnosť
 05230357-n	slk:lemma	orientačný bod
 00607114-v	slk:lemma	študovať
@@ -34246,42 +34246,42 @@
 00833199-v	slk:lemma	informovať
 02881757-n	slk:lemma	cylinder
 10418101-n	slk:lemma	personifikácia
-01265308-s	slk:lemma	podivný
-01676517-s	slk:lemma	náramný
+01265308-a	slk:lemma	podivný
+01676517-a	slk:lemma	náramný
 01247240-a	slk:lemma	horúci
 00668099-v	slk:lemma	trpieť
 00146572-n	slk:lemma	zbližovanie
 07720442-n	slk:lemma	paprika
 13623636-n	slk:lemma	cm³
 09173023-n	slk:lemma	Sýrska púšť
-01415219-s	slk:lemma	malý
+01415219-a	slk:lemma	malý
 00032613-n	slk:lemma	vlastníctvo
 14567281-n	slk:lemma	rinosporidióza
 08153337-n	slk:lemma	Pantheon
-01984252-s	slk:lemma	poškodený
+01984252-a	slk:lemma	poškodený
 08722645-n	slk:lemma	Cape Horn
 02066510-v	slk:lemma	prevaliť sa
 01893601-v	slk:lemma	šklbať
 02632353-v	slk:lemma	chýbať
 13723712-n	slk:lemma	gram
 09795556-n	slk:lemma	osoba oprávnená na anuitu
-00653617-s	slk:lemma	škuľavý
+00653617-a	slk:lemma	škuľavý
 05586111-n	slk:lemma	hrudný pletenec
 06593296-n	slk:lemma	periodikum
 13841863-n	slk:lemma	vzájomnosť
 00470988-r	slk:lemma	krátko a stručne
 00874067-n	slk:lemma	mienka
-00927978-s	slk:lemma	prázdny
+00927978-a	slk:lemma	prázdny
 00581241-n	slk:lemma	pracovná záťaž
 07154046-n	slk:lemma	otrepaná fráza
 01237872-n	slk:lemma	centralizácia
-01968165-s	slk:lemma	každodenný
+01968165-a	slk:lemma	každodenný
 00770270-n	slk:lemma	delikt
-00011327-s	slk:lemma	zanovitý
+00011327-a	slk:lemma	zanovitý
 01857392-v	slk:lemma	ostávať
 01807170-v	slk:lemma	získať si (niekoho)
 00177483-r	slk:lemma	jemne
-00014490-s	slk:lemma	štedrý
+00014490-a	slk:lemma	štedrý
 01854132-v	slk:lemma	čerpať
 01993926-v	slk:lemma	posúvať dopredu
 06523132-n	slk:lemma	nájomné
@@ -34293,13 +34293,13 @@
 00223500-v	slk:lemma	ochabovať
 05635841-n	slk:lemma	hodinárstvo
 01278817-v	slk:lemma	krčiť sa
-00491511-s	slk:lemma	mimoriadny
+00491511-a	slk:lemma	mimoriadny
 00697589-v	slk:lemma	rozhodnúť
 02151966-v	slk:lemma	dať pozor
 01158872-v	slk:lemma	používať
 01461328-v	slk:lemma	zostaviť sa
 06208751-n	slk:lemma	pespektíva
-00977699-s	slk:lemma	rýchlikový
+00977699-a	slk:lemma	rýchlikový
 02731024-v	slk:lemma	zostať
 10042845-n	slk:lemma	čudák
 01082606-v	slk:lemma	stať sa účastníkom (niečoho)
@@ -34309,9 +34309,9 @@
 13356985-n	slk:lemma	peňažný majetok
 00301662-v	slk:lemma	zameriavať sa na
 00466053-v	slk:lemma	koordinovať
-00746451-s	slk:lemma	problematický
+00746451-a	slk:lemma	problematický
 04268565-n	slk:lemma	indukčná cievka
-01827161-s	slk:lemma	silný
+01827161-a	slk:lemma	silný
 00927430-v	slk:lemma	podotknúť
 02641463-v	slk:lemma	odložiť
 04618070-n	slk:lemma	identita
@@ -34319,7 +34319,7 @@
 00387666-r	slk:lemma	vľavo
 04605726-n	slk:lemma	obal
 02345048-v	slk:lemma	plieniť
-00412788-s	slk:lemma	divoký
+00412788-a	slk:lemma	divoký
 03357376-n	slk:lemma	fazóna (na oblečení)
 10450303-n	slk:lemma	člen politickej strany
 06560254-n	slk:lemma	obhajoba
@@ -34344,7 +34344,7 @@
 01166093-v	slk:lemma	uplatňovať
 07323231-n	slk:lemma	prejav
 14580752-n	slk:lemma	chemické zloženie
-02119716-s	slk:lemma	reálny
+02119716-a	slk:lemma	reálny
 10255096-n	slk:lemma	prenajímateľ
 02479323-v	slk:lemma	dodávať
 00314835-r	slk:lemma	aby som povedal pravdu
@@ -34366,7 +34366,7 @@
 00717358-v	slk:lemma	dať odozvu
 06072145-n	slk:lemma	pestovanie lesov
 10557854-n	slk:lemma	učenec
-01423851-s	slk:lemma	obytný
+01423851-a	slk:lemma	obytný
 00504620-r	slk:lemma	úplne
 04008634-n	slk:lemma	riadená strela
 00233203-v	slk:lemma	obmedziť
@@ -34386,16 +34386,16 @@
 09738400-n	slk:lemma	Američan
 05302499-n	slk:lemma	ústa
 15239579-n	slk:lemma	doba
-01762065-s	slk:lemma	prípustný
+01762065-a	slk:lemma	prípustný
 00791134-v	slk:lemma	povolávať
 00890100-v	slk:lemma	ručiť
 00511555-n	slk:lemma	festival
-01763159-s	slk:lemma	zhovievavý
+01763159-a	slk:lemma	zhovievavý
 05491154-n	slk:lemma	vonkajší obal obličky
-01814252-s	slk:lemma	nerozumný
+01814252-a	slk:lemma	nerozumný
 01199755-v	slk:lemma	vdychovať
-01177899-s	slk:lemma	duševný
-00557108-s	slk:lemma	absolútny
+01177899-a	slk:lemma	duševný
+00557108-a	slk:lemma	absolútny
 00199707-n	slk:lemma	premena
 06904171-n	slk:lemma	prirodzený jazyk
 03505504-n	slk:lemma	šatka na hlavu
@@ -34406,17 +34406,17 @@
 10801697-n	slk:lemma	xylofonista
 06761798-n	slk:lemma	námietka, slovná
 14428160-n	slk:lemma	niveau
-01243102-s	slk:lemma	Bohom zabudnutý
+01243102-a	slk:lemma	Bohom zabudnutý
 00755745-v	slk:lemma	požiadať si
 13910384-n	slk:lemma	medzera
-01300661-s	slk:lemma	poriadkový
+01300661-a	slk:lemma	poriadkový
 08208016-n	slk:lemma	osadenstvo
-00301589-s	slk:lemma	početný
+00301589-a	slk:lemma	početný
 06771653-n	slk:lemma	písomná dohoda
 00851744-a	slk:lemma	oprávnený
 08120384-n	slk:lemma	obecný úrad
 02440020-v	slk:lemma	riadiť
-02144436-s	slk:lemma	formovateľný
+02144436-a	slk:lemma	formovateľný
 00706693-v	slk:lemma	predložiť
 06053439-n	slk:lemma	štúdium pôrodníctva
 08388636-n	slk:lemma	aristokracia
@@ -34427,7 +34427,7 @@
 01205696-v	slk:lemma	približovať sa
 02295979-v	slk:lemma	podriadiť záujmom obce
 00035385-r	slk:lemma	nie často
-00167829-s	slk:lemma	vábny
+00167829-a	slk:lemma	vábny
 05457973-n	slk:lemma	ženská pohlavná bunka
 09024668-n	slk:lemma	Baleáry
 04171831-n	slk:lemma	polovodičová súčiastka
@@ -34439,7 +34439,7 @@
 02556720-a	slk:lemma	robotnícky
 01534147-v	slk:lemma	mazať
 05514081-n	slk:lemma	genitálie
-02229961-s	slk:lemma	podradný
+02229961-a	slk:lemma	podradný
 07506569-n	slk:lemma	potupa
 05689909-n	slk:lemma	prekážka pre uzavretie manželstva
 10180178-n	slk:lemma	vlastník
@@ -34454,15 +34454,15 @@
 06362953-n	slk:lemma	písomná práca
 07531105-n	slk:lemma	uspokojenie
 05058025-n	slk:lemma	pásmo milimetrových vĺn
-01035007-s	slk:lemma	exotický
+01035007-a	slk:lemma	exotický
 07357388-n	slk:lemma	zdokonalenie
 01807882-v	slk:lemma	priťahovať
 00260622-n	slk:lemma	reforma
 00684645-v	slk:lemma	pochybovať
 14052046-n	slk:lemma	zdravotný problém
 04656748-n	slk:lemma	nespoločenskosť
-00733297-s	slk:lemma	očakávaný
-01898722-s	slk:lemma	bystrý
+00733297-a	slk:lemma	očakávaný
+01898722-a	slk:lemma	bystrý
 03442756-n	slk:lemma	bránka
 02157731-v	slk:lemma	zakaliť sa
 09290777-n	slk:lemma	zrnko
@@ -34481,7 +34481,7 @@
 00859325-v	slk:lemma	rozradosťovať
 02237338-v	slk:lemma	odoprieť
 00160659-r	slk:lemma	blízko
-00974697-s	slk:lemma	spiatočnícky
+00974697-a	slk:lemma	spiatočnícky
 00868591-v	slk:lemma	vyzývať (na sútaž, na súboj)
 03604629-n	slk:lemma	prepojka
 04891683-n	slk:lemma	absurdnosť
@@ -34493,8 +34493,8 @@
 06459450-n	slk:lemma	Jeremiášov list
 00098083-v	slk:lemma	preberať (k životu)
 01705494-v	slk:lemma	skladať
-01172139-s	slk:lemma	zdravo vyzerajúci
-00927832-s	slk:lemma	neprítomný
+01172139-a	slk:lemma	zdravo vyzerajúci
+00927832-a	slk:lemma	neprítomný
 01165043-v	slk:lemma	užívať
 08997801-n	slk:lemma	Singapur
 00589309-v	slk:lemma	vycítiť
@@ -34503,8 +34503,8 @@
 07180787-n	slk:lemma	nesúhlas
 00502415-n	slk:lemma	stolná hra
 00057388-r	slk:lemma	úplne
-01945350-s	slk:lemma	nespravodlivý
-00821603-s	slk:lemma	dosiahnutý
+01945350-a	slk:lemma	nespravodlivý
+00821603-a	slk:lemma	dosiahnutý
 00210935-r	slk:lemma	zvyčajne
 05643491-n	slk:lemma	štetcové podanie
 02015571-a	slk:lemma	vďačný (práca)
@@ -34522,12 +34522,12 @@
 01471002-a	slk:lemma	väčší
 00057257-r	slk:lemma	poriadne
 01892104-v	slk:lemma	odskočiť
-00951003-s	slk:lemma	vonkajší
+00951003-a	slk:lemma	vonkajší
 03660664-n	slk:lemma	depozitár
 00422090-v	slk:lemma	objaviť sa
 00430606-n	slk:lemma	hra
 01809064-v	slk:lemma	zaraziť
-01440159-s	slk:lemma	celoživotný
+01440159-a	slk:lemma	celoživotný
 01496021-a	slk:lemma	najmenší
 01783022-v	slk:lemma	ochromovať
 09379705-n	slk:lemma	Orange
@@ -34535,31 +34535,31 @@
 03641706-n	slk:lemma	presah
 09774266-n	slk:lemma	školiteľ
 05888929-n	slk:lemma	hypotéza
-00115777-s	slk:lemma	iritujúci
+00115777-a	slk:lemma	iritujúci
 04433077-n	slk:lemma	škatuľka na šitie
 13085113-n	slk:lemma	burina
 06877849-n	slk:lemma	vyjadrebie mračením
 00854717-n	slk:lemma	úchylka
 01062817-n	slk:lemma	prestávka
 07560193-n	slk:lemma	rýchle občerstvenie
-02250430-s	slk:lemma	osamelý
+02250430-a	slk:lemma	osamelý
 00729378-v	slk:lemma	dumať
 06514093-n	slk:lemma	história
 00378479-n	slk:lemma	zapálenie
 00272844-r	slk:lemma	naprieč
 13874384-n	slk:lemma	arkus
 13997253-n	slk:lemma	poddanstvo
-02280333-s	slk:lemma	svojrázny
-00848983-s	slk:lemma	povinný
+02280333-a	slk:lemma	svojrázny
+00848983-a	slk:lemma	povinný
 06013741-n	slk:lemma	infinitezimálny počet
-02456157-s	slk:lemma	znepokojujúci
+02456157-a	slk:lemma	znepokojujúci
 01111028-v	slk:lemma	postúpiť
 00696852-v	slk:lemma	prejsť si
 07200290-n	slk:lemma	echo
 00705227-v	slk:lemma	plánovať
 05587288-n	slk:lemma	osová kostra
-01080900-s	slk:lemma	bohatý
-01389170-s	slk:lemma	masívny
+01080900-a	slk:lemma	bohatý
+01389170-a	slk:lemma	masívny
 02637202-v	slk:lemma	zdržať sa
 14580752-n	slk:lemma	chemické vlastnosti
 02815753-a	slk:lemma	plechový
@@ -34576,7 +34576,7 @@
 01621555-v	slk:lemma	vyhotovovať
 03427202-n	slk:lemma	pištoľ
 00610861-a	slk:lemma	bežný
-01145151-s	slk:lemma	strmý
+01145151-a	slk:lemma	strmý
 00467913-a	slk:lemma	distribučný
 06769670-n	slk:lemma	chybná tlač
 07229530-n	slk:lemma	samochvála
@@ -34589,7 +34589,7 @@
 10388924-n	slk:lemma	držiteľ
 05015117-n	slk:lemma	mrazivosť
 01809321-v	slk:lemma	prekonať
-02218314-s	slk:lemma	mnohonásobný
+02218314-a	slk:lemma	mnohonásobný
 00102463-r	slk:lemma	skvele
 15292617-n	slk:lemma	večerná služba
 00067545-v	slk:lemma	potiť
@@ -34607,17 +34607,17 @@
 00873682-v	slk:lemma	vyrozumieť
 00304422-v	slk:lemma	stiahnuť sa
 07507098-n	slk:lemma	ťažkosti
-00696996-s	slk:lemma	ako baránok
+00696996-a	slk:lemma	ako baránok
 03592773-n	slk:lemma	vejár
 07338552-n	slk:lemma	úder
 06845599-n	slk:lemma	značka
 15295778-n	slk:lemma	premietacia doba
 10757193-n	slk:lemma	návštevník
-00453053-s	slk:lemma	dôverne známy
+00453053-a	slk:lemma	dôverne známy
 14102075-n	slk:lemma	trombóza
-00126497-s	slk:lemma	precedentný
+00126497-a	slk:lemma	precedentný
 00409597-r	slk:lemma	už nikdy
-02130821-s	slk:lemma	neuzavretý
+02130821-a	slk:lemma	neuzavretý
 06530789-n	slk:lemma	písomná plná moc zástupcu
 05289861-n	slk:lemma	priečne pruhovaný sval
 00120316-v	slk:lemma	spraviť
@@ -34629,7 +34629,7 @@
 09383793-n	slk:lemma	pobrežie Pacifiku
 02439281-v	slk:lemma	dať sa (do niečoho)
 03544360-n	slk:lemma	dom
-02365900-s	slk:lemma	imúnny
+02365900-a	slk:lemma	imúnny
 00168564-r	slk:lemma	zúrivo
 02027612-v	slk:lemma	preplniť
 11428379-n	slk:lemma	elektrónový zväzok
@@ -34640,10 +34640,10 @@
 00005041-v	slk:lemma	nadýchnuť sa
 02535457-v	slk:lemma	odtrhnúť sa
 13440935-n	slk:lemma	booleovská operácia
-00193480-s	slk:lemma	desný
+00193480-a	slk:lemma	desný
 02738031-n	slk:lemma	vojenská výzbroj
 01195536-a	slk:lemma	prospešný
-01931926-s	slk:lemma	v pohotovosti
+01931926-a	slk:lemma	v pohotovosti
 01686956-v	slk:lemma	znázorniť
 00169659-r	slk:lemma	priemerne
 00368302-n	slk:lemma	rozširovanie
@@ -34653,7 +34653,7 @@
 00428000-n	slk:lemma	veselie
 14612764-n	slk:lemma	kyselina azidovodíková
 13363056-n	slk:lemma	poručnícky fond v prospech ekonomicky nezodpovednej osoby
-00138782-s	slk:lemma	nevhodný
+00138782-a	slk:lemma	nevhodný
 00075021-v	slk:lemma	unaviť sa
 00811171-v	slk:lemma	vyhýbať sa
 04898437-n	slk:lemma	adekvátnosť
@@ -34661,12 +34661,12 @@
 00169651-v	slk:lemma	meniť (veľkosť, rozsah, hodnotu)
 00061595-v	slk:lemma	zbavovať pohlavných žliaz
 09676746-n	slk:lemma	Slovania
-01581305-s	slk:lemma	prebytočný
+01581305-a	slk:lemma	prebytočný
 05470189-n	slk:lemma	prívesok
 05093890-n	slk:lemma	úroveň
 06018465-n	slk:lemma	štatistika
 02351010-v	slk:lemma	stanovovať cenu
-01255022-s	slk:lemma	letný
+01255022-a	slk:lemma	letný
 08180190-n	slk:lemma	masy
 00090253-n	slk:lemma	príjem
 04857490-n	slk:lemma	temperament
@@ -34676,20 +34676,20 @@
 06832788-n	slk:lemma	péčko
 09348055-n	slk:lemma	masa
 06706676-n	slk:lemma	medaila
-01346978-s	slk:lemma	vnútorný
+01346978-a	slk:lemma	vnútorný
 09302804-n	slk:lemma	oceán
 06532330-n	slk:lemma	zákon
 01458842-n	slk:lemma	zárodok
 05570129-n	slk:lemma	zadok
 00770270-n	slk:lemma	prehmat
 07085375-n	slk:lemma	prízvuk
-01728614-s	slk:lemma	antický
+01728614-a	slk:lemma	antický
 01963942-v	slk:lemma	vyskočiť
 05938795-n	slk:lemma	vzor
 13359690-n	slk:lemma	bankový účet
 05436080-n	slk:lemma	chromatín
 03796605-n	slk:lemma	blatník
-00711308-s	slk:lemma	ostrý
+00711308-a	slk:lemma	ostrý
 04198797-n	slk:lemma	tlmič
 10245639-n	slk:lemma	statkár
 14237561-n	slk:lemma	zhubnosť
@@ -34700,13 +34700,13 @@
 02767701-a	slk:lemma	námornícky
 04849759-n	slk:lemma	cudnosť
 09330604-n	slk:lemma	jazero Champlain
-00969556-s	slk:lemma	zvláštny
+00969556-a	slk:lemma	zvláštny
 13240203-n	slk:lemma	mladý porast
-00997036-s	slk:lemma	nešťastný
+00997036-a	slk:lemma	nešťastný
 01319874-a	slk:lemma	poctivý
 02526085-v	slk:lemma	dosahovať
 01230350-v	slk:lemma	prebodávať
-02074929-s	slk:lemma	trafený
+02074929-a	slk:lemma	trafený
 00192659-v	slk:lemma	dať viac šťavy
 03526805-n	slk:lemma	golfová jamka
 01973125-v	slk:lemma	znižovať
@@ -34730,12 +34730,12 @@
 00031181-v	slk:lemma	prekaziť
 06473837-n	slk:lemma	prihláška
 00854904-v	slk:lemma	dobehnúť (niekoho)
-02282651-s	slk:lemma	spontánny
-01259123-s	slk:lemma	antropomorfný
+02282651-a	slk:lemma	spontánny
+01259123-a	slk:lemma	antropomorfný
 00214951-v	slk:lemma	namočiť sa
 03135152-n	slk:lemma	kríž
 02027612-v	slk:lemma	natlačiť sa
-01258264-s	slk:lemma	ľadový
+01258264-a	slk:lemma	ľadový
 10569411-n	slk:lemma	pracovník rozviedky
 00272123-n	slk:lemma	zhrubnutie
 00745005-n	slk:lemma	previnenie
@@ -34744,10 +34744,10 @@
 09984659-n	slk:lemma	odberateľ
 00227969-n	slk:lemma	rituálne obetovanie
 11426125-n	slk:lemma	jadrová energia
-02035086-s	slk:lemma	čestný
+02035086-a	slk:lemma	čestný
 07941945-n	slk:lemma	bióm
 01128193-v	slk:lemma	ochraňovať
-02400628-s	slk:lemma	podliehajúci clu
+02400628-a	slk:lemma	podliehajúci clu
 02775934-a	slk:lemma	peňažný
 00796976-v	slk:lemma	opovrhovať
 05047059-n	slk:lemma	oneskorenie
@@ -34760,9 +34760,9 @@
 03708425-n	slk:lemma	induktor
 01642924-v	slk:lemma	predviesť
 02988281-a	slk:lemma	národnostný
-01344171-s	slk:lemma	strhujúci
+01344171-a	slk:lemma	strhujúci
 04588986-n	slk:lemma	oblok
-00850648-s	slk:lemma	čistý
+00850648-a	slk:lemma	čistý
 00215800-v	slk:lemma	vlhčiť
 11642622-n	slk:lemma	Ahuehuete
 00512267-n	slk:lemma	poskok
@@ -34771,15 +34771,15 @@
 01478002-v	slk:lemma	zabarikádovať
 05549830-n	slk:lemma	torzo
 09308572-n	slk:lemma	ľadovcová kryha
-02024928-s	slk:lemma	prepychový
+02024928-a	slk:lemma	prepychový
 05549061-n	slk:lemma	ramenný kĺb
 01272798-v	slk:lemma	periť sa
 03041810-n	slk:lemma	lucerna
 15202806-n	slk:lemma	tropický rok
 05417975-n	slk:lemma	krvná cieva
-00552089-s	slk:lemma	naplnený
+00552089-a	slk:lemma	naplnený
 00008007-r	slk:lemma	všetko
-00816160-s	slk:lemma	uplynulý
+00816160-a	slk:lemma	uplynulý
 13724582-n	slk:lemma	kg
 03379719-n	slk:lemma	brzdový pedál
 02768874-v	slk:lemma	horieť
@@ -34803,7 +34803,7 @@
 07476623-n	slk:lemma	bitka
 00262881-v	slk:lemma	poškodzovať
 06551339-n	slk:lemma	povolenie na sobáš
-02003023-s	slk:lemma	vždy použiteľný
+02003023-a	slk:lemma	vždy použiteľný
 08121117-n	slk:lemma	požiarne oddelenie
 01791756-v	slk:lemma	odvádzať
 04655929-n	slk:lemma	srdečný vzťah
@@ -34818,12 +34818,12 @@
 05622456-n	slk:lemma	schopnosť
 08472335-n	slk:lemma	politické hnutie
 08847268-n	slk:lemma	Bahamy
-00599005-s	slk:lemma	pod kontrolou
+00599005-a	slk:lemma	pod kontrolou
 15258091-n	slk:lemma	prvý polčas
 07013549-n	slk:lemma	reťazec
 06713512-n	slk:lemma	výčitka
 09397391-n	slk:lemma	jazero
-00764484-s	slk:lemma	otvorený
+00764484-a	slk:lemma	otvorený
 03526198-n	slk:lemma	diera
 01873294-v	slk:lemma	odsúvať
 09535809-n	slk:lemma	bohyňa zeme
@@ -34833,13 +34833,13 @@
 00112393-r	slk:lemma	nutne
 14997529-n	slk:lemma	konzervant
 13372403-n	slk:lemma	perla
-00590163-s	slk:lemma	otrávený
+00590163-a	slk:lemma	otrávený
 09337686-n	slk:lemma	rieka Lena
 08163792-n	slk:lemma	zraz
 05951323-n	slk:lemma	očakávanie
 01754421-a	slk:lemma	stály
 01871680-v	slk:lemma	tisnúť sa
-01499269-s	slk:lemma	nesmierny
+01499269-a	slk:lemma	nesmierny
 02765924-v	slk:lemma	odrážať sa
 02446164-v	slk:lemma	špecializovať sa na
 02972182-n	slk:lemma	zásobník
@@ -34847,8 +34847,8 @@
 14804797-n	slk:lemma	železobetón
 05031012-n	slk:lemma	pevnosť
 10294602-n	slk:lemma	morský vlk
-01856419-s	slk:lemma	podstatný
-02077904-s	slk:lemma	šibnutý
+01856419-a	slk:lemma	podstatný
+02077904-a	slk:lemma	šibnutý
 00931467-v	slk:lemma	značiť
 09241712-n	slk:lemma	Chao Phraya
 11418460-n	slk:lemma	osud
@@ -34859,17 +34859,17 @@
 02609764-v	slk:lemma	končiť
 07270179-n	slk:lemma	označenie
 02921753-a	slk:lemma	rímsky
-01865807-s	slk:lemma	schopný obrábania
+01865807-a	slk:lemma	schopný obrábania
 05196582-n	slk:lemma	právo rozhodovať
 01352574-n	slk:lemma	rod baktérií
 02974003-n	slk:lemma	koleso osobného automobilu
 03875218-n	slk:lemma	farbivo
-00792075-s	slk:lemma	vládnuci
+00792075-a	slk:lemma	vládnuci
 09966255-n	slk:lemma	riadiaci obchodný pracovník
 01774136-v	slk:lemma	nenávidieť
 02434976-v	slk:lemma	pridávať sa k/ku
 03222959-n	slk:lemma	kľučka
-02291336-s	slk:lemma	stály
+02291336-a	slk:lemma	stály
 07358576-n	slk:lemma	zmena
 01245325-v	slk:lemma	vystaviť účinkom pary
 10013614-n	slk:lemma	obsluha
@@ -34883,7 +34883,7 @@
 09220046-n	slk:lemma	rieka Bighorn
 08593262-n	slk:lemma	línia
 08223802-n	slk:lemma	spoločenstvo
-00611281-s	slk:lemma	tradičný
+00611281-a	slk:lemma	tradičný
 00786816-v	slk:lemma	preveriť
 06598915-n	slk:lemma	téma
 04294426-n	slk:lemma	stabilizátor
@@ -34891,7 +34891,7 @@
 02334756-v	slk:lemma	zásobiť zbraňami
 00363218-r	slk:lemma	legitímne
 02140033-v	slk:lemma	odhaliť
-01320705-s	slk:lemma	cnostný
+01320705-a	slk:lemma	cnostný
 00652900-v	slk:lemma	porovnať si
 10231515-n	slk:lemma	panovník
 04119360-n	slk:lemma	veľký pohár
@@ -34913,7 +34913,7 @@
 12713063-n	slk:lemma	trpasličí pomaranč
 00834198-a	slk:lemma	efektívny
 00617748-v	slk:lemma	pliesť si
-02161982-s	slk:lemma	veľmi dôležitý
+02161982-a	slk:lemma	veľmi dôležitý
 08627919-n	slk:lemma	štvrť (mestská)
 06458836-n	slk:lemma	Modlitba Azariášova
 09850121-n	slk:lemma	osoba, ktorej bolo zverené oprávnenie
@@ -34925,7 +34925,7 @@
 06468951-n	slk:lemma	zhrnutie
 12432808-n	slk:lemma	cibuľa kuchynská
 11426530-n	slk:lemma	príťažlivosť
-00750296-s	slk:lemma	jednoduchý
+00750296-a	slk:lemma	jednoduchý
 03000110-a	slk:lemma	kapitalistický
 00614057-v	slk:lemma	opúšťať
 01597096-v	slk:lemma	ťažiť
@@ -34950,31 +34950,31 @@
 00872886-v	slk:lemma	radiť
 09280380-n	slk:lemma	fjord
 04395024-n	slk:lemma	nepremokavá plachtovina
-02110447-s	slk:lemma	izolovaný
+02110447-a	slk:lemma	izolovaný
 04074482-n	slk:lemma	kúra
 04701460-n	slk:lemma	priezračnosť
 02601456-v	slk:lemma	osloviť
 00752431-n	slk:lemma	podvod
-00529191-s	slk:lemma	obmedzený
+00529191-a	slk:lemma	obmedzený
 09297584-n	slk:lemma	Kalifornský záliv
 03475823-n	slk:lemma	vlasový prípravok
 01535246-v	slk:lemma	prať
 05245906-n	slk:lemma	pór
-00602117-s	slk:lemma	diskusný
+00602117-a	slk:lemma	diskusný
 11522325-n	slk:lemma	ultrafialové spektrum
 00100543-n	slk:lemma	interpretácia
 06485800-n	slk:lemma	denný plán
 03641706-n	slk:lemma	prekrytie
 02940706-n	slk:lemma	varhany s parnými píšťalami
 00528339-v	slk:lemma	postaviť na nohy
-01868578-s	slk:lemma	neopakovateľný
+01868578-a	slk:lemma	neopakovateľný
 00978173-n	slk:lemma	protiťah
 07297927-n	slk:lemma	premena
-01991166-s	slk:lemma	odhodlaný
+01991166-a	slk:lemma	odhodlaný
 02001428-n	slk:lemma	rad brodivce
 07959016-n	slk:lemma	celkový počet
 02637202-v	slk:lemma	pobudnúť
-01076145-s	slk:lemma	neformálny
+01076145-a	slk:lemma	neformálny
 13872211-n	slk:lemma	jamka
 08064130-n	slk:lemma	obrana
 04304375-n	slk:lemma	spúšťač
@@ -34993,7 +34993,7 @@
 01036996-n	slk:lemma	sobáš
 14993378-n	slk:lemma	jedovatý plyn
 03418242-n	slk:lemma	záhradné náradie
-01443097-s	slk:lemma	chvíľkový
+01443097-a	slk:lemma	chvíľkový
 00260088-r	slk:lemma	nevyhnutne
 03046257-n	slk:lemma	hodiny
 02035919-v	slk:lemma	ohnúť
@@ -35007,7 +35007,7 @@
 00348541-v	slk:lemma	rozhýbať sa
 01556346-v	slk:lemma	odtrhnúť sa
 01168569-n	slk:lemma	rivalita
-00542359-s	slk:lemma	roztrúsený
+00542359-a	slk:lemma	roztrúsený
 00710005-v	slk:lemma	pripraviť
 08953829-n	slk:lemma	Orkneje
 05243879-n	slk:lemma	dermis
@@ -35029,9 +35029,9 @@
 00798539-v	slk:lemma	zamietnuť
 09457020-n	slk:lemma	rieka Temža
 06431740-n	slk:lemma	Biblia
-02368566-s	slk:lemma	presladený
+02368566-a	slk:lemma	presladený
 14779550-n	slk:lemma	chemický pôvodca
-00414919-s	slk:lemma	spojený
+00414919-a	slk:lemma	spojený
 02128653-v	slk:lemma	pozerať sa
 00063652-n	slk:lemma	úspech
 01873294-v	slk:lemma	odťahovať
@@ -35057,13 +35057,13 @@
 00416737-n	slk:lemma	cesta najmenšieho odporu
 00813044-v	slk:lemma	rozmyslieť si
 08736107-n	slk:lemma	Kostarická republika
-00224515-s	slk:lemma	zlý
+00224515-a	slk:lemma	zlý
 15185007-n	slk:lemma	prikázaný sviatok
 07184545-n	slk:lemma	prudká hádka
 02563327-v	slk:lemma	zrealizovať
-02387413-s	slk:lemma	zavalitý
+02387413-a	slk:lemma	zavalitý
 01523520-v	slk:lemma	odviť sa
-00746047-s	slk:lemma	trápny
+00746047-a	slk:lemma	trápny
 02308741-v	slk:lemma	venovať
 06617413-n	slk:lemma	pornofilm
 04708113-n	slk:lemma	jednoduchosť
@@ -35083,11 +35083,11 @@
 04643662-n	slk:lemma	agresivita
 01947352-v	slk:lemma	priplávať na chrbáte
 07177437-n	slk:lemma	dohovor
-02523092-s	slk:lemma	vegetatívny
+02523092-a	slk:lemma	vegetatívny
 00085512-r	slk:lemma	výslovne
 07317144-n	slk:lemma	náhoda
-01649031-s	slk:lemma	malý
-00488998-s	slk:lemma	neobyčajný
+01649031-a	slk:lemma	malý
+00488998-a	slk:lemma	neobyčajný
 15280497-n	slk:lemma	rýchlosť chôdze
 09363970-n	slk:lemma	potrebná vec
 02201644-v	slk:lemma	rozdeľovať
@@ -35102,10 +35102,10 @@
 02471327-v	slk:lemma	odviesť do armády
 08600760-n	slk:lemma	záhlavník
 10098245-n	slk:lemma	flautista
-01558641-s	slk:lemma	podnietený
+01558641-a	slk:lemma	podnietený
 13344071-n	slk:lemma	finančné krytie
 09505418-n	slk:lemma	božská bytosť
-01385255-s	slk:lemma	ohromný
+01385255-a	slk:lemma	ohromný
 00031899-r	slk:lemma	veľmi
 02920259-n	slk:lemma	postele nad sebou
 06206800-n	slk:lemma	úcta
@@ -35115,14 +35115,14 @@
 00088725-n	slk:lemma	zatknutie
 07834507-n	slk:lemma	pokrm s majonézou
 13732871-n	slk:lemma	čitateľ
-01780343-s	slk:lemma	rozumový
+01780343-a	slk:lemma	rozumový
 02058794-a	slk:lemma	nebezpečný
 05476094-n	slk:lemma	komisúra
 00770543-n	slk:lemma	nedodržanie
 01646528-v	slk:lemma	vyvolať
 00356954-v	slk:lemma	skriviť sa
 00666058-a	slk:lemma	súčasný
-00763272-s	slk:lemma	na odvrátenie pozornosti
+00763272-a	slk:lemma	na odvrátenie pozornosti
 00089351-n	slk:lemma	obnovenie
 06776138-n	slk:lemma	vtip
 00552006-v	slk:lemma	konkretizovať sa
@@ -35145,7 +35145,7 @@
 07721456-n	slk:lemma	čili
 00007549-v	slk:lemma	poťahovať
 13696402-n	slk:lemma	juhoafrická menová jednotka
-00712877-s	slk:lemma	súrny
+00712877-a	slk:lemma	súrny
 01818235-v	slk:lemma	stimulovať
 02188065-n	slk:lemma	dvojkrídlovce
 09417560-n	slk:lemma	rieka Ruhr
@@ -35165,7 +35165,7 @@
 00205079-n	slk:lemma	zrieknutie sa
 00657260-v	slk:lemma	roztriediť
 10437852-n	slk:lemma	navrhovateľ
-00250739-s	slk:lemma	prudký
+00250739-a	slk:lemma	prudký
 02346724-v	slk:lemma	preberať
 01378556-v	slk:lemma	šíriť
 00401783-n	slk:lemma	zotavenie
@@ -35194,7 +35194,7 @@
 02066939-v	slk:lemma	natiecť
 03934042-n	slk:lemma	pilier
 14436769-n	slk:lemma	zabudnutie
-01496311-s	slk:lemma	okrajový
+01496311-a	slk:lemma	okrajový
 01053920-n	slk:lemma	bývanie
 02927303-a	slk:lemma	americký
 05313115-n	slk:lemma	cievovka
@@ -35202,13 +35202,13 @@
 02565491-v	slk:lemma	predvídať
 10410815-n	slk:lemma	divoch
 08173165-n	slk:lemma	Stredná Amerika
-01723091-s	slk:lemma	predpojatý
+01723091-a	slk:lemma	predpojatý
 05035353-n	slk:lemma	energickosť
 13725457-n	slk:lemma	cent
 09024972-n	slk:lemma	Kanárske ostrovy
 03976657-n	slk:lemma	tyč
 02338975-v	slk:lemma	zásobovať
-00493012-s	slk:lemma	obecný
+00493012-a	slk:lemma	obecný
 03378915-n	slk:lemma	futbalové ihrisko
 01944976-v	slk:lemma	premávať
 04309049-n	slk:lemma	parný stroj
@@ -35236,7 +35236,7 @@
 13318147-n	slk:lemma	fixné výdavky
 06601327-n	slk:lemma	význam
 00794981-v	slk:lemma	rozvrhnúť
-00828661-s	slk:lemma	atletický
+00828661-a	slk:lemma	atletický
 00080304-r	slk:lemma	naviac
 03401500-n	slk:lemma	vedenie benzínu
 00872886-v	slk:lemma	poradiť sa
@@ -35252,11 +35252,11 @@
 11536778-n	slk:lemma	kmeň Bryophyta
 07205439-n	slk:lemma	dvojitý zápor
 02760344-v	slk:lemma	zapáliť
-01740358-s	slk:lemma	šovinistický
+01740358-a	slk:lemma	šovinistický
 00351000-n	slk:lemma	vpravo
 00180228-n	slk:lemma	rozhodnutie
-01177435-s	slk:lemma	rastúci dovnútra
-00219389-s	slk:lemma	nádherný
+01177435-a	slk:lemma	rastúci dovnútra
+00219389-a	slk:lemma	nádherný
 06468403-n	slk:lemma	životopis
 01996377-a	slk:lemma	zodpovedný
 02293321-v	slk:lemma	odovzdať
@@ -35273,10 +35273,10 @@
 00107468-v	slk:lemma	predstierať
 13904011-n	slk:lemma	dolná hranica
 06875697-n	slk:lemma	posunková reč
-02279723-s	slk:lemma	kypiaci nadšením
+02279723-a	slk:lemma	kypiaci nadšením
 12589286-n	slk:lemma	Corypha
 00151040-r	slk:lemma	ako-tak
-00526062-s	slk:lemma	celoplošný
+00526062-a	slk:lemma	celoplošný
 09984298-n	slk:lemma	kustód
 01523520-v	slk:lemma	odmotávať sa
 09759501-n	slk:lemma	akademik
@@ -35286,7 +35286,7 @@
 03024333-n	slk:lemma	sýtič
 07427728-n	slk:lemma	zánik
 14333645-n	slk:lemma	bolestivé močenie
-01259391-s	slk:lemma	krehký
+01259391-a	slk:lemma	krehký
 00393369-n	slk:lemma	odňatie
 04377057-n	slk:lemma	systém
 08791978-n	slk:lemma	Mashriq
@@ -35307,7 +35307,7 @@
 15252907-n	slk:lemma	kapitola v živote
 01695681-n	slk:lemma	plaz podtriedy Archosauria
 07702796-n	slk:lemma	cereálie
-02226979-s	slk:lemma	virtuózny
+02226979-a	slk:lemma	virtuózny
 02066939-v	slk:lemma	rozlievať sa
 00490304-r	slk:lemma	vo vnútrozemí
 14257377-n	slk:lemma	trachóm
@@ -35319,7 +35319,7 @@
 11421401-n	slk:lemma	aktinické žiarenie
 01048912-n	slk:lemma	skrývanie
 12202936-n	slk:lemma	lipa
-02314070-s	slk:lemma	zvlnený
+02314070-a	slk:lemma	zvlnený
 14435445-n	slk:lemma	výnimočnosť
 02396667-n	slk:lemma	rod babirussa
 00333203-n	slk:lemma	addukcia
@@ -35344,7 +35344,7 @@
 04522421-n	slk:lemma	látka vyvolávajúca zmrštenie cievy
 00459498-v	slk:lemma	pohnúť si
 00018813-v	slk:lemma	prebúdzať sa
-00714585-s	slk:lemma	petičný
+00714585-a	slk:lemma	petičný
 04486445-n	slk:lemma	triviálnosť
 00631737-v	slk:lemma	predpokladať
 00541178-n	slk:lemma	tanec swing
@@ -35381,25 +35381,25 @@
 08713772-n	slk:lemma	Balkán
 02733453-v	slk:lemma	žiariť
 00305683-r	slk:lemma	hlboko
-01569166-s	slk:lemma	mnohonárodný
+01569166-a	slk:lemma	mnohonárodný
 03496749-n	slk:lemma	Harvardova univerzita
 09048880-n	slk:lemma	Nové Anglicko
 02061495-v	slk:lemma	vyrútiť sa
-00473243-s	slk:lemma	horľavý
-01401224-s	slk:lemma	zákonodarný
+00473243-a	slk:lemma	horľavý
+01401224-a	slk:lemma	zákonodarný
 07959269-n	slk:lemma	hromadenie
 02005496-v	slk:lemma	vracať sa domov
 08066491-n	slk:lemma	peňažníctvo
 00759944-v	slk:lemma	modliť sa
-00238310-s	slk:lemma	rozdelený do niekoľkých častí
+00238310-a	slk:lemma	rozdelený do niekoľkých častí
 07372779-n	slk:lemma	pokrok
 12685214-n	slk:lemma	čeľaď Geraniaceae
 13299248-n	slk:lemma	paušálna čiasta
 00531489-v	slk:lemma	znížiť sa
 08180190-n	slk:lemma	ľudia
 06393253-n	slk:lemma	rozhodcovská doložka
-01313649-s	slk:lemma	osamelý
-00583842-s	slk:lemma	neutíchajúci
+01313649-a	slk:lemma	osamelý
+00583842-a	slk:lemma	neutíchajúci
 01214265-v	slk:lemma	uchopiť
 02152740-n	slk:lemma	predátor
 01573515-v	slk:lemma	drať
@@ -35408,12 +35408,12 @@
 00564695-v	slk:lemma	zavinúť
 01970272-v	slk:lemma	vyparovať
 07012534-n	slk:lemma	linka
-00135092-s	slk:lemma	vhodný
+00135092-a	slk:lemma	vhodný
 10157744-n	slk:lemma	somár
 09449773-n	slk:lemma	rieka Styx
 02859500-a	slk:lemma	apoštolský
 00945255-v	slk:lemma	prednášať
-00116245-s	slk:lemma	nahnevaný
+00116245-a	slk:lemma	nahnevaný
 00990655-v	slk:lemma	nadväzovať hovor
 09328311-n	slk:lemma	Polostrov Labrador-Ungava
 00487072-n	slk:lemma	schovávačka
@@ -35424,7 +35424,7 @@
 02490877-v	slk:lemma	sláviť
 09042675-n	slk:lemma	Sardis
 00651531-n	slk:lemma	porovnávanie
-00115777-s	slk:lemma	rozzúrený
+00115777-a	slk:lemma	rozzúrený
 03712729-n	slk:lemma	hlavná ulica
 04118021-n	slk:lemma	koberček
 07355887-n	slk:lemma	zníženie
@@ -35473,7 +35473,7 @@
 00040928-v	slk:lemma	nalíčiť
 00230444-r	slk:lemma	priaznivo
 14801921-n	slk:lemma	liatina železa
-02466566-s	slk:lemma	pochybný
+02466566-a	slk:lemma	pochybný
 00512186-v	slk:lemma	vypínať
 03258730-n	slk:lemma	halena
 04874672-n	slk:lemma	nečestnosť
@@ -35483,13 +35483,13 @@
 08968879-n	slk:lemma	Mongolsko
 04831031-n	slk:lemma	nemilosť
 09627906-n	slk:lemma	adresát
-01762257-s	slk:lemma	dovolený
+01762257-a	slk:lemma	dovolený
 00686447-v	slk:lemma	uznať
 01219004-v	slk:lemma	opierať
 04959230-n	slk:lemma	farba
 13260936-n	slk:lemma	hrubá tržba
 01564144-v	slk:lemma	nivočiť
-01754873-s	slk:lemma	trvalý
+01754873-a	slk:lemma	trvalý
 06547059-n	slk:lemma	oprávnenie
 02461314-v	slk:lemma	hlasovať
 05025935-n	slk:lemma	atómová hmotnosť
@@ -35510,7 +35510,7 @@
 04591713-n	slk:lemma	vínový sud
 09080989-n	slk:lemma	Midway Islands
 06766190-n	slk:lemma	narážka
-00807399-s	slk:lemma	šedivý
+00807399-a	slk:lemma	šedivý
 03045750-a	slk:lemma	austrálsky
 08197895-n	slk:lemma	partizáni
 01088437-n	slk:lemma	podpora v nezamestnanosti
@@ -35539,10 +35539,10 @@
 01930117-v	slk:lemma	jazdiť autom
 08672738-n	slk:lemma	obec
 01424456-v	slk:lemma	vyobjímať
-02271052-s	slk:lemma	vzdelaný
+02271052-a	slk:lemma	vzdelaný
 00256746-n	slk:lemma	česanie
 00197772-n	slk:lemma	premiestnenie
-01969150-s	slk:lemma	jednoročný
+01969150-a	slk:lemma	jednoročný
 04048568-n	slk:lemma	železničná spoločnosť
 10305802-n	slk:lemma	medik
 00419685-v	slk:lemma	uvoľniť sa
@@ -35560,7 +35560,7 @@
 06537951-n	slk:lemma	štatút
 10316013-n	slk:lemma	vojnový štváč
 05981230-n	slk:lemma	cieľ
-00803432-s	slk:lemma	pichľavý
+00803432-a	slk:lemma	pichľavý
 01638368-v	slk:lemma	zosnovať
 01821884-v	slk:lemma	nudiť (niekoho)
 01186397-n	slk:lemma	bankrot
@@ -35578,7 +35578,7 @@
 01202728-v	slk:lemma	živiť
 09482330-n	slk:lemma	rieka Jenisej
 03404251-n	slk:lemma	kožuch
-01623744-s	slk:lemma	naplnený
+01623744-a	slk:lemma	naplnený
 00591115-v	slk:lemma	chápať
 01640855-v	slk:lemma	vykonávať
 05402091-n	slk:lemma	koagulát
@@ -35593,15 +35593,15 @@
 02483224-n	slk:lemma	Hylobates
 04896724-n	slk:lemma	nečistotnosť
 00908621-v	slk:lemma	podporovať
-01139832-s	slk:lemma	ladný (pohyb)
+01139832-a	slk:lemma	ladný (pohyb)
 01155090-v	slk:lemma	stihnúť
 01105840-a	slk:lemma	národný
-01723091-s	slk:lemma	skreslený
+01723091-a	slk:lemma	skreslený
 00215314-n	slk:lemma	rozdelenie
 09283623-n	slk:lemma	brod
 00593363-v	slk:lemma	odpisovať
 07996689-n	slk:lemma	set
-02314451-s	slk:lemma	kľukatý
+02314451-a	slk:lemma	kľukatý
 00709379-v	slk:lemma	mať v úmysle
 06689297-n	slk:lemma	súhlas
 02380571-v	slk:lemma	posielať na dôchodok
@@ -35614,7 +35614,7 @@
 03509025-n	slk:lemma	kúrenie
 09632274-n	slk:lemma	nekvalifikovaná osoba
 01668603-v	slk:lemma	spracúvať
-00213610-s	slk:lemma	hebký (listy rastliny)
+00213610-a	slk:lemma	hebký (listy rastliny)
 00406243-v	slk:lemma	prichystať si
 05690916-n	slk:lemma	bariéra
 00847478-v	slk:lemma	poškodiť povesť
@@ -35628,7 +35628,7 @@
 02108377-v	slk:lemma	prekonávať
 00104003-r	slk:lemma	vonku
 00150287-v	slk:lemma	podriadiť sa
-01751609-s	slk:lemma	v perfektnom stave
+01751609-a	slk:lemma	v perfektnom stave
 02129165-n	slk:lemma	lev púšťový (Panthera leo)
 00352826-v	slk:lemma	dokončiť
 03473465-n	slk:lemma	gyroskopický stabilizátor
@@ -35655,7 +35655,7 @@
 12433081-n	slk:lemma	cibuľa
 00156601-v	slk:lemma	zvýšiť
 01346003-v	slk:lemma	otvoriť
-02390724-s	slk:lemma	nadšený
+02390724-a	slk:lemma	nadšený
 02322712-n	slk:lemma	mliečie
 04668819-n	slk:lemma	dôveryhodnosť
 10516016-n	slk:lemma	emigrant
@@ -35683,7 +35683,7 @@
 00670261-v	slk:lemma	posúdiť
 06444711-n	slk:lemma	List Kolosanom
 05926358-n	slk:lemma	nepochopiteľnosť
-02074929-s	slk:lemma	zblbnutý
+02074929-a	slk:lemma	zblbnutý
 02111626-n	slk:lemma	špic
 00622384-v	slk:lemma	znepokojiť
 04982207-n	slk:lemma	ticho
@@ -35701,7 +35701,7 @@
 01767949-v	slk:lemma	dojať
 00644583-v	slk:lemma	preberať
 00622384-v	slk:lemma	sužovať
-01764895-s	slk:lemma	bezpečnostný
+01764895-a	slk:lemma	bezpečnostný
 00463234-v	slk:lemma	premôcť
 03009794-n	slk:lemma	kostnica
 02255268-v	slk:lemma	dovoliť
@@ -35713,7 +35713,7 @@
 14520278-n	slk:lemma	atmosféra
 10189975-n	slk:lemma	demoličný pracovník
 05939432-n	slk:lemma	výzor
-01131454-s	slk:lemma	ohavný
+01131454-a	slk:lemma	ohavný
 08070465-n	slk:lemma	poisťovacia spoločnosť
 14439294-n	slk:lemma	povesť
 04539876-n	slk:lemma	nestála pamäť
@@ -35726,13 +35726,13 @@
 00628491-v	slk:lemma	premýšľať
 07434102-n	slk:lemma	porucha
 01237167-n	slk:lemma	agresia
-01876261-s	slk:lemma	inovatívny
+01876261-a	slk:lemma	inovatívny
 10245156-n	slk:lemma	pani domu
 02005948-v	slk:lemma	prichádzať
 07412092-n	slk:lemma	iskra
 01577635-v	slk:lemma	ponárať sa
 01814815-v	slk:lemma	utešovať
-01532586-s	slk:lemma	limitovaný
+01532586-a	slk:lemma	limitovaný
 07393161-n	slk:lemma	jačanie
 06505799-n	slk:lemma	záznam
 04681621-n	slk:lemma	škvrna v tvare oka
@@ -35751,15 +35751,15 @@
 03814112-n	slk:lemma	golier
 00031899-r	slk:lemma	naozaj
 00121166-n	slk:lemma	odoslanie
-00545746-s	slk:lemma	nedbalý
+00545746-a	slk:lemma	nedbalý
 06832140-n	slk:lemma	J
 07234230-n	slk:lemma	žaloba
-02248693-s	slk:lemma	etnický
+02248693-a	slk:lemma	etnický
 00868591-v	slk:lemma	vyzvať (na sútaž, na súboj)
 01550949-v	slk:lemma	preťať
 04338143-n	slk:lemma	struna
 13287414-n	slk:lemma	rozhodujúci podiel akcií
-01710809-s	slk:lemma	oslobodený od nájomného
+01710809-a	slk:lemma	oslobodený od nájomného
 06441195-n	slk:lemma	Kniha proroka Zachariáša
 01072262-v	slk:lemma	pretekať sa
 15201505-n	slk:lemma	rok
@@ -35771,11 +35771,11 @@
 07511080-n	slk:lemma	anticipácia
 02163301-v	slk:lemma	monitorovať
 07970406-n	slk:lemma	rodina
-02526611-s	slk:lemma	krytý
+02526611-a	slk:lemma	krytý
 02110927-v	slk:lemma	podrobiť sa
 09557387-n	slk:lemma	Aténa
 00743344-v	slk:lemma	skontaktovať sa (s)
-02114746-s	slk:lemma	nákazlivý
+02114746-a	slk:lemma	nákazlivý
 07548567-n	slk:lemma	agresívnosť
 14477667-n	slk:lemma	kríž
 00071803-v	slk:lemma	natiahnuť
@@ -35803,7 +35803,7 @@
 02441022-v	slk:lemma	disponovať
 02363358-a	slk:lemma	neovplyvniteľný
 02921753-a	slk:lemma	rímskokatolícky
-02499148-s	slk:lemma	legálny
+02499148-a	slk:lemma	legálny
 02962061-n	slk:lemma	demižón
 10000945-n	slk:lemma	mladistvý páchateľ
 03258730-n	slk:lemma	plášť proti prachu
@@ -35827,10 +35827,10 @@
 03427656-n	slk:lemma	hradlo
 02870092-n	slk:lemma	kniha
 02141973-v	slk:lemma	vyzdvihnúť
-02241988-s	slk:lemma	kamenný
+02241988-a	slk:lemma	kamenný
 02719930-v	slk:lemma	náležať
 13358360-n	slk:lemma	pokladňa kráľovstva
-01172139-s	slk:lemma	rumenný
+01172139-a	slk:lemma	rumenný
 05747582-n	slk:lemma	opätovné ohodnotenie
 10036266-n	slk:lemma	narkoman
 01136614-v	slk:lemma	streliť
@@ -35839,7 +35839,7 @@
 06440489-n	slk:lemma	Habakuk
 13745086-n	slk:lemma	osem
 01219111-a	slk:lemma	vrchovitý
-01754873-s	slk:lemma	stály
+01754873-a	slk:lemma	stály
 00868910-n	slk:lemma	kalkulácia
 00807461-v	slk:lemma	namietať
 01809321-v	slk:lemma	zdrviť
@@ -35857,7 +35857,7 @@
 02788689-n	slk:lemma	závora
 02208903-v	slk:lemma	prenajímať si
 00398704-n	slk:lemma	zmena
-00608791-s	slk:lemma	bizarný
+00608791-a	slk:lemma	bizarný
 01686956-v	slk:lemma	znázorňovať
 06442616-n	slk:lemma	List
 09266052-n	slk:lemma	Detroit
@@ -35880,9 +35880,9 @@
 05013204-n	slk:lemma	absolútna nula
 00296178-v	slk:lemma	nastaviť
 02579447-v	slk:lemma	znemravniť
-01484651-s	slk:lemma	cudný
-00473243-s	slk:lemma	vznetlivý
-02405805-s	slk:lemma	napätý
+01484651-a	slk:lemma	cudný
+00473243-a	slk:lemma	vznetlivý
+02405805-a	slk:lemma	napätý
 07800740-n	slk:lemma	krmivo
 08060694-n	slk:lemma	partnerstvo
 02612762-v	slk:lemma	navštevovať
@@ -35890,7 +35890,7 @@
 02620587-v	slk:lemma	predstavovať
 01850315-v	slk:lemma	pohnúť
 03082979-n	slk:lemma	systém spracovania informácií
-00633581-s	slk:lemma	spravodlivý
+00633581-a	slk:lemma	spravodlivý
 01021420-v	slk:lemma	usúdiť
 00339463-n	slk:lemma	preskupenie
 06805297-n	slk:lemma	prezrádzanie
@@ -35931,11 +35931,11 @@
 14493145-n	slk:lemma	nemajetnosť
 08709704-n	slk:lemma	Antigua a Barbuda
 03594277-n	slk:lemma	zverák
-01046553-s	slk:lemma	listový
-01276150-s	slk:lemma	kľúčový
+01046553-a	slk:lemma	listový
+01276150-a	slk:lemma	kľúčový
 01675963-v	slk:lemma	krášliť
 02489916-v	slk:lemma	oženiť sa
-02521183-s	slk:lemma	dobrovoľný
+02521183-a	slk:lemma	dobrovoľný
 15209413-n	slk:lemma	mesiac
 05945642-n	slk:lemma	pohľad
 14242337-n	slk:lemma	karcinóm
@@ -35960,9 +35960,9 @@
 05836598-n	slk:lemma	pojem
 00249987-n	slk:lemma	pokrok
 06452363-n	slk:lemma	židovská Biblia
-00286837-s	slk:lemma	tolerantný
+00286837-a	slk:lemma	tolerantný
 01342224-v	slk:lemma	rozopínať
-00195383-s	slk:lemma	strašný
+00195383-a	slk:lemma	strašný
 01344293-v	slk:lemma	rozviazať
 01651293-v	slk:lemma	ujímať sa
 00353469-n	slk:lemma	zníženie
@@ -35972,8 +35972,8 @@
 13333833-n	slk:lemma	akcie
 00932367-a	slk:lemma	nevýhodný
 00242003-n	slk:lemma	znovu obsadenie
-02318728-s	slk:lemma	riadny
-00431004-s	slk:lemma	hmlistý
+02318728-a	slk:lemma	riadny
+00431004-a	slk:lemma	hmlistý
 07229530-n	slk:lemma	chvastanie sa
 01021420-v	slk:lemma	vyvodiť (záver)
 03895585-n	slk:lemma	cestička
@@ -35991,11 +35991,11 @@
 07616590-n	slk:lemma	zmrzlinový pohár s ovocím
 02380335-n	slk:lemma	poník
 05057593-n	slk:lemma	HF
-01136248-s	slk:lemma	v zlej nálade
+01136248-a	slk:lemma	v zlej nálade
 00621058-v	slk:lemma	objasňovať
 00015303-v	slk:lemma	zdriemnuť si
 08301709-n	slk:lemma	Medzinárodná námorná organizácia
-00122844-s	slk:lemma	nasledujúci
+00122844-a	slk:lemma	nasledujúci
 07205718-n	slk:lemma	odmietnutie
 04388743-n	slk:lemma	cisterna
 00628491-v	slk:lemma	premyslieť (niečo)
@@ -36012,7 +36012,7 @@
 06442616-n	slk:lemma	apoštolský list
 04464615-n	slk:lemma	trackball
 07289481-n	slk:lemma	zázrak
-02367319-s	slk:lemma	mimoriadny
+02367319-a	slk:lemma	mimoriadny
 02644234-v	slk:lemma	dominovať
 03559841-n	slk:lemma	Iditarodský pás
 02467662-v	slk:lemma	pokrájať
@@ -36021,23 +36021,23 @@
 01335804-v	slk:lemma	spútať
 00699815-v	slk:lemma	vymedzovať sa
 00049220-r	slk:lemma	momentálne
-01185916-s	slk:lemma	masívny
+01185916-a	slk:lemma	masívny
 01079295-n	slk:lemma	profylaxia
 04841358-n	slk:lemma	pozornosť
 08737521-n	slk:lemma	Belize
-02002470-s	slk:lemma	ohraničený
+02002470-a	slk:lemma	ohraničený
 00369802-n	slk:lemma	svalová kontrakcia
 01501113-a	slk:lemma	muzikálny
 00047903-r	slk:lemma	konečne
 00061595-v	slk:lemma	sterilizovať
 06833663-n	slk:lemma	X
-00792202-s	slk:lemma	najdôležitejší
+00792202-a	slk:lemma	najdôležitejší
 08748499-n	slk:lemma	Holandské Antily
 02201644-v	slk:lemma	deliť
 00588888-v	slk:lemma	byť informovaný
 01759326-v	slk:lemma	vyvolať
-01987646-s	slk:lemma	povznesený
-00505086-s	slk:lemma	rekordný
+01987646-a	slk:lemma	povznesený
+00505086-a	slk:lemma	rekordný
 09196103-n	slk:lemma	Heilong Jiang, Heilong
 08301155-n	slk:lemma	Medzinárodné združenie pre rozvoj
 00159620-n	slk:lemma	zvádzanie
@@ -36049,24 +36049,24 @@
 01200440-v	slk:lemma	drogovať
 13780719-n	slk:lemma	medziľudský vzťah
 01348530-n	slk:lemma	baktéria
-01990653-s	slk:lemma	neoblomný
+01990653-a	slk:lemma	neoblomný
 00240293-v	slk:lemma	zväčšovať
 13137409-n	slk:lemma	bobuľovina
 15152817-n	slk:lemma	dospelosť
 02494538-n	slk:lemma	Scandentia
 05349659-n	slk:lemma	slzná artéria
 01012073-v	slk:lemma	posilňovať
-01729819-s	slk:lemma	predchádzajúci
+01729819-a	slk:lemma	predchádzajúci
 05108947-n	slk:lemma	vzostup
 09165613-n	slk:lemma	Zambia
 00039941-r	slk:lemma	na prvý pohľad
 06265815-n	slk:lemma	kuriérna pošta
 00475819-v	slk:lemma	očistiť (od hriechu)
 00963570-v	slk:lemma	prehovoriť
-02565425-s	slk:lemma	pripravený
+02565425-a	slk:lemma	pripravený
 08723006-n	slk:lemma	PRC
 02762468-v	slk:lemma	páliť
-00476663-s	slk:lemma	obmedzený
+00476663-a	slk:lemma	obmedzený
 11571907-n	slk:lemma	rod magnóliových dvojklíčnolistových rastlín
 08792083-n	slk:lemma	Úrodný Polmesiac
 06833776-n	slk:lemma	Y
@@ -36074,7 +36074,7 @@
 14190132-n	slk:lemma	saprémia
 00752764-v	slk:lemma	požadovať
 00081737-r	slk:lemma	ročne
-00714763-s	slk:lemma	prosebný
+00714763-a	slk:lemma	prosebný
 00189511-v	slk:lemma	zásobovať
 00356954-v	slk:lemma	zdeformovať sa
 12144313-n	slk:lemma	kukuričný klas
@@ -36102,8 +36102,8 @@
 00927711-v	slk:lemma	naznačovať
 12892226-n	slk:lemma	čeľaď zemiakovité
 03172211-n	slk:lemma	odmrazovač okenného skla
-00475308-s	slk:lemma	v ohni
-01894196-s	slk:lemma	vyskúšaný
+00475308-a	slk:lemma	v ohni
+01894196-a	slk:lemma	vyskúšaný
 10132145-n	slk:lemma	pracovník so sklom
 15238472-n	slk:lemma	dovolenkové obdobie
 14514039-n	slk:lemma	oblasť
@@ -36122,11 +36122,11 @@
 06528557-n	slk:lemma	súdna dražba
 00778405-n	slk:lemma	podvod právny
 05513020-n	slk:lemma	močovod
-02528566-s	slk:lemma	odvrhnutý
+02528566-a	slk:lemma	odvrhnutý
 07295629-n	slk:lemma	odplata
 02970849-n	slk:lemma	voz
 09740954-n	slk:lemma	Aljašťan
-00814902-s	slk:lemma	pomerne skorý
+00814902-a	slk:lemma	pomerne skorý
 01115585-v	slk:lemma	vzdávať sa
 06205018-n	slk:lemma	neutralita
 09235053-n	slk:lemma	mys Trafalgar
@@ -36145,7 +36145,7 @@
 01504437-n	slk:lemma	čeľaď vtákov
 06900282-n	slk:lemma	viacrozmerný programovací jazyk
 02898584-a	slk:lemma	poznávací
-00567860-s	slk:lemma	vzdialený
+00567860-a	slk:lemma	vzdialený
 06308765-n	slk:lemma	koncovka
 09174015-n	slk:lemma	Volcan de Colima
 02572119-v	slk:lemma	obrať o niečo
@@ -36155,7 +36155,7 @@
 00461402-n	slk:lemma	vojnová hra
 00205885-v	slk:lemma	zlepšiť
 00614829-v	slk:lemma	zabúdať
-00837977-s	slk:lemma	náročný
+00837977-a	slk:lemma	náročný
 02208903-v	slk:lemma	požičiavať si
 14440875-n	slk:lemma	dekadencia
 01814266-v	slk:lemma	deprimovať
@@ -36175,13 +36175,13 @@
 14696793-n	slk:lemma	skala
 07313636-n	slk:lemma	poškodenie
 13262913-n	slk:lemma	pozostalosť
-02336904-s	slk:lemma	nedostatočný
+02336904-a	slk:lemma	nedostatočný
 05146178-n	slk:lemma	daňové ohodnotenie
 00304422-v	slk:lemma	zovierať
-00343226-s	slk:lemma	osudový
+00343226-a	slk:lemma	osudový
 04151940-n	slk:lemma	kryt
 08687345-n	slk:lemma	Škorpión
-01419784-s	slk:lemma	metaforický
+01419784-a	slk:lemma	metaforický
 03835853-n	slk:lemma	ženský kláštor
 02765924-v	slk:lemma	lesknúť sa
 01044114-v	slk:lemma	mumlať
@@ -36190,7 +36190,7 @@
 02757462-n	slk:lemma	zvukový systém
 15203120-n	slk:lemma	rozpočtový rok
 15246683-n	slk:lemma	studené obdobie
-01212095-s	slk:lemma	najvyšší možný
+01212095-a	slk:lemma	najvyšší možný
 06833004-n	slk:lemma	R
 00870213-v	slk:lemma	varovať
 05203397-n	slk:lemma	spôsobilosť
@@ -36207,15 +36207,15 @@
 09285254-n	slk:lemma	kúsok
 03315644-n	slk:lemma	plátovací
 04197391-n	slk:lemma	košeľa
-00965176-s	slk:lemma	spoľahlivý
+00965176-a	slk:lemma	spoľahlivý
 01671039-v	slk:lemma	napliesť
-01175741-s	slk:lemma	kolikový
+01175741-a	slk:lemma	kolikový
 00601043-v	slk:lemma	pohltiť
 01810447-v	slk:lemma	rozhorčovať sa
 01534147-v	slk:lemma	znečisťovať
 00076193-r	slk:lemma	sem a tam
 00698609-n	slk:lemma	venesekcia
-01876261-s	slk:lemma	moderný
+01876261-a	slk:lemma	moderný
 00011516-r	slk:lemma	slabo
 08793746-n	slk:lemma	Nablus
 00669243-v	slk:lemma	odolať
@@ -36245,7 +36245,7 @@
 00700708-v	slk:lemma	ohraničiť
 04111668-n	slk:lemma	rotor
 12301180-n	slk:lemma	Olivovník európsky
-00929815-s	slk:lemma	predpokladaný
+00929815-a	slk:lemma	predpokladaný
 08342039-n	slk:lemma	medzinárodná spravodajská agentúra
 05706629-n	slk:lemma	bezočivosť
 15037877-n	slk:lemma	rhesus faktor
@@ -36254,14 +36254,14 @@
 01199755-v	slk:lemma	inhalovať
 08682819-n	slk:lemma	západ Spojených štátov
 10755080-n	slk:lemma	hráč na violu
-00349894-s	slk:lemma	konečný
+00349894-a	slk:lemma	konečný
 14563784-n	slk:lemma	záblesk svetla
 01675963-v	slk:lemma	dekorovať
 05057485-n	slk:lemma	MF
 00921738-v	slk:lemma	vyznačiť
 11529603-n	slk:lemma	rastlinná ríša
 01768402-n	slk:lemma	Chelicerata
-00144510-s	slk:lemma	obrnený
+00144510-a	slk:lemma	obrnený
 02549392-v	slk:lemma	preukázať pozornosť
 03104594-n	slk:lemma	druhopis
 01857392-v	slk:lemma	ostať
@@ -36299,7 +36299,7 @@
 02734423-n	slk:lemma	architektonický ornament
 06427831-n	slk:lemma	edícia
 09398217-n	slk:lemma	rieka Potomac
-01706465-s	slk:lemma	tajný
+01706465-a	slk:lemma	tajný
 07679356-n	slk:lemma	chleboviny
 13250542-n	slk:lemma	bohatstvo
 03745146-n	slk:lemma	zoologická záhrada
@@ -36317,18 +36317,18 @@
 01108148-v	slk:lemma	prekonávať
 01018352-v	slk:lemma	domôcť sa
 02470451-n	slk:lemma	podrad vyššie primáty
-01372948-s	slk:lemma	dobročinný
+01372948-a	slk:lemma	dobročinný
 06687358-n	slk:lemma	plná moc
 09229409-n	slk:lemma	potôčik
 02637202-v	slk:lemma	pobývať
 03294048-n	slk:lemma	výbava
-02249183-s	slk:lemma	medziľudský
+02249183-a	slk:lemma	medziľudský
 03951971-n	slk:lemma	os ramena nápravy
 09441725-n	slk:lemma	rieka South Platte
 01686132-v	slk:lemma	stvárniť
 02348459-v	slk:lemma	posielať
 00416135-v	slk:lemma	vysťahovať sa
-00919919-s	slk:lemma	dychtivý
+00919919-a	slk:lemma	dychtivý
 07250034-n	slk:lemma	reklama
 02108377-v	slk:lemma	podstúpiť (niečo)
 00915787-a	slk:lemma	nepresný
@@ -36341,7 +36341,7 @@
 09481036-n	slk:lemma	poškodenie hmyzom
 01774426-v	slk:lemma	zhnusiť sa
 00618642-n	slk:lemma	dámske krajčírstvo
-00179035-s	slk:lemma	schválený
+00179035-a	slk:lemma	schválený
 14417551-n	slk:lemma	diskontinuita
 01336007-v	slk:lemma	opraviť väzbu
 01122754-n	slk:lemma	deficitné financovanie
@@ -36349,7 +36349,7 @@
 02459173-v	slk:lemma	usadiť
 03574816-n	slk:lemma	prístroj
 02515194-v	slk:lemma	ošetrovať
-00764484-s	slk:lemma	hovoriaci od srdca
+00764484-a	slk:lemma	hovoriaci od srdca
 00859325-v	slk:lemma	potešovať
 00230058-r	slk:lemma	zvonku
 00889555-v	slk:lemma	poskytovať záruku
@@ -36364,10 +36364,10 @@
 04695176-n	slk:lemma	fľak
 01510082-v	slk:lemma	vyhodiť
 07510495-n	slk:lemma	omámenie
-01276482-s	slk:lemma	hlavný
+01276482-a	slk:lemma	hlavný
 00030358-n	slk:lemma	čin
 01041061-v	slk:lemma	sklapnúť
-00901547-s	slk:lemma	nevyhnutný
+00901547-a	slk:lemma	nevyhnutný
 02284951-v	slk:lemma	refundovať
 00359903-n	slk:lemma	vystrihovanie
 02153445-n	slk:lemma	labka
@@ -36387,9 +36387,9 @@
 08721145-n	slk:lemma	Antofagasta
 14751417-n	slk:lemma	kortikosteroid
 06460295-n	slk:lemma	Kniha Sirachovcova
-02318728-s	slk:lemma	úprimný
+02318728-a	slk:lemma	úprimný
 00575365-n	slk:lemma	detská hra
-01081340-s	slk:lemma	produktívny
+01081340-a	slk:lemma	produktívny
 00209943-n	slk:lemma	výsledok
 00259303-r	slk:lemma	(ležiaci presne) uprostred
 03548086-n	slk:lemma	veko náboja kolesa
@@ -36399,10 +36399,10 @@
 10107303-n	slk:lemma	otec
 01230710-v	slk:lemma	pobádať
 00453935-n	slk:lemma	rybárčenie
-01796977-s	slk:lemma	červivý
+01796977-a	slk:lemma	červivý
 04306080-n	slk:lemma	stanica
 01814074-v	slk:lemma	udržiavať sa v dobrej nálade
-01987646-s	slk:lemma	vzdialený
+01987646-a	slk:lemma	vzdialený
 05910940-n	slk:lemma	časový plán
 01717117-a	slk:lemma	hmatateľný
 07355887-n	slk:lemma	zmiernenie
@@ -36412,7 +36412,7 @@
 06195839-n	slk:lemma	spôsob myslenia
 04256993-n	slk:lemma	mäkká droga
 00589769-n	slk:lemma	hodnosť kapitána
-01499269-s	slk:lemma	bezhraničný
+01499269-a	slk:lemma	bezhraničný
 13393762-n	slk:lemma	papierový peniaz
 04620216-n	slk:lemma	povaha
 01761706-v	slk:lemma	triasť sa
@@ -36423,7 +36423,7 @@
 02304507-v	slk:lemma	byť zajatý
 01812337-n	slk:lemma	hrdlička
 06125041-n	slk:lemma	technika
-01126291-s	slk:lemma	odporný
+01126291-a	slk:lemma	odporný
 02762468-v	slk:lemma	zhorieť
 00060939-r	slk:lemma	pred
 09420030-n	slk:lemma	Saint Lawrence
@@ -36436,11 +36436,11 @@
 00933420-n	slk:lemma	umenie
 04230707-n	slk:lemma	držiak lyží
 02174115-v	slk:lemma	zaštrngať
-01358534-s	slk:lemma	pozývajúci
+01358534-a	slk:lemma	pozývajúci
 01378123-v	slk:lemma	roztrúsiť
 00186491-r	slk:lemma	formálne
 09959258-n	slk:lemma	policajt
-02436995-s	slk:lemma	striktný
+02436995-a	slk:lemma	striktný
 02899439-n	slk:lemma	nosník okuliarov
 15116283-n	slk:lemma	geologické obdobie
 00164444-v	slk:lemma	posilňovať sa
@@ -36476,10 +36476,10 @@
 04151940-n	slk:lemma	záštita
 00334996-v	slk:lemma	prerušiť
 00331655-n	slk:lemma	posunutie
-01517526-s	slk:lemma	bojový
+01517526-a	slk:lemma	bojový
 01900349-a	slk:lemma	dochvíľny
 09350524-n	slk:lemma	rieka Mekong
-00167829-s	slk:lemma	príjemný
+00167829-a	slk:lemma	príjemný
 01585759-v	slk:lemma	oslobodiť sa
 05820170-n	slk:lemma	zreteľ
 03926148-n	slk:lemma	fotografické príslušenstvo
@@ -36488,7 +36488,7 @@
 00613683-v	slk:lemma	zanechať
 00728641-n	slk:lemma	školská práca
 07151380-n	slk:lemma	fráza
-00330728-s	slk:lemma	centrálny
+00330728-a	slk:lemma	centrálny
 07623475-n	slk:lemma	mandľové pečivo
 03079230-n	slk:lemma	CD
 00665886-v	slk:lemma	potvrdzovať
@@ -36497,7 +36497,7 @@
 00431826-v	slk:lemma	slabnúť
 02519666-v	slk:lemma	chovať sa
 10112129-n	slk:lemma	mních
-00907400-s	slk:lemma	škodoradostný
+00907400-a	slk:lemma	škodoradostný
 00948206-n	slk:lemma	rozvoj
 07272172-n	slk:lemma	štítok
 01782650-v	slk:lemma	znepokojiť sa
@@ -36510,7 +36510,7 @@
 03718458-n	slk:lemma	kaštieľ
 01021629-v	slk:lemma	dohovoriť si
 00020476-r	slk:lemma	neustále
-01878870-s	slk:lemma	pekný
+01878870-a	slk:lemma	pekný
 04755783-n	slk:lemma	morálna istota
 09762509-n	slk:lemma	eso
 10176679-n	slk:lemma	pomocný robotník na farme, ranči
@@ -36522,7 +36522,7 @@
 01030132-v	slk:lemma	pomenúvať
 00376400-n	slk:lemma	zlomenie
 06277280-n	slk:lemma	televízia
-01263445-s	slk:lemma	zverský
+01263445-a	slk:lemma	zverský
 00224599-n	slk:lemma	lynčovanie
 05367735-n	slk:lemma	žalúdočná žila
 06730068-n	slk:lemma	žalobný dôvod
@@ -36533,11 +36533,11 @@
 02550698-v	slk:lemma	liečiť
 02862048-n	slk:lemma	drôtená košeľa
 00422281-r	slk:lemma	postupne
-02517169-s	slk:lemma	viditeľný
+02517169-a	slk:lemma	viditeľný
 01335075-v	slk:lemma	pokrývať fóliou
 10113583-n	slk:lemma	biely kôň
-01017439-s	slk:lemma	telesne schopný
-01420337-s	slk:lemma	poetický
+01017439-a	slk:lemma	telesne schopný
+01420337-a	slk:lemma	poetický
 00355080-r	slk:lemma	mnoho ráz
 00112393-r	slk:lemma	nevyhnutne
 05572227-n	slk:lemma	močový zvierač
@@ -36555,12 +36555,12 @@
 00047534-r	slk:lemma	a tiež
 07249585-n	slk:lemma	malý oznam
 13619764-n	slk:lemma	galón
-01006788-s	slk:lemma	ohraničený
-01461292-s	slk:lemma	sympatický
+01006788-a	slk:lemma	ohraničený
+01461292-a	slk:lemma	sympatický
 02469588-n	slk:lemma	rad Primates
 02383440-v	slk:lemma	opúšťať
 08226699-n	slk:lemma	dedina
-01127147-s	slk:lemma	hrozný
+01127147-a	slk:lemma	hrozný
 01810447-v	slk:lemma	pobúriť
 09849598-n	slk:lemma	miláčik
 01146012-a	slk:lemma	správny
@@ -36572,22 +36572,22 @@
 02857295-a	slk:lemma	básnický
 01875295-v	slk:lemma	kolembať sa
 02620587-v	slk:lemma	vytvárať
-02076988-s	slk:lemma	nesvojprávny (na súde)
+02076988-a	slk:lemma	nesvojprávny (na súde)
 14723079-n	slk:lemma	aktivátor
-01276150-s	slk:lemma	najdôležitejší
+01276150-a	slk:lemma	najdôležitejší
 02565491-v	slk:lemma	zabraňovať
 00904690-v	slk:lemma	obhájiť
 10142391-n	slk:lemma	starý otec
 04881623-n	slk:lemma	disciplína
 06833436-n	slk:lemma	V
-01676517-s	slk:lemma	skvelý
+01676517-a	slk:lemma	skvelý
 11410172-n	slk:lemma	fotoemisia
-00837415-s	slk:lemma	ťažký
-02503305-s	slk:lemma	zbytočný
+00837415-a	slk:lemma	ťažký
+02503305-a	slk:lemma	zbytočný
 05807012-n	slk:lemma	cit
 02671880-v	slk:lemma	uspokojovať
 01147222-n	slk:lemma	nezákonné zatknutie
-00796715-s	slk:lemma	teatrálny
+00796715-a	slk:lemma	teatrálny
 01633343-v	slk:lemma	dostať nápad
 00061598-n	slk:lemma	dokončenie
 00213694-n	slk:lemma	zrieknutie
@@ -36609,7 +36609,7 @@
 00128168-r	slk:lemma	poväčšine
 01034312-v	slk:lemma	pojednávať
 00342028-n	slk:lemma	otáčavý pohyb
-00527188-s	slk:lemma	celosvetový
+00527188-a	slk:lemma	celosvetový
 02568999-v	slk:lemma	prehnať niečo
 00360242-n	slk:lemma	strihanie
 00347180-n	slk:lemma	trasenie
@@ -36623,7 +36623,7 @@
 00397760-n	slk:lemma	vymazanie
 13623636-n	slk:lemma	kubický centimeter
 00225593-n	slk:lemma	zadusenie
-02503216-s	slk:lemma	nekvalitný
+02503216-a	slk:lemma	nekvalitný
 01494740-a	slk:lemma	neobvyklý
 00512843-n	slk:lemma	bláznovstvo
 00059413-r	slk:lemma	často
@@ -36638,11 +36638,11 @@
 12313005-n	slk:lemma	Hamamelidae
 00466053-v	slk:lemma	zrovnávať
 10249950-n	slk:lemma	právnik
-00082034-s	slk:lemma	nebojazlivý
-02343110-s	slk:lemma	prvotriedny
+00082034-a	slk:lemma	nebojazlivý
+02343110-a	slk:lemma	prvotriedny
 06431740-n	slk:lemma	kresťanská Biblia
 05951072-n	slk:lemma	tušenie
-01620286-s	slk:lemma	skrytý
+01620286-a	slk:lemma	skrytý
 05130875-n	slk:lemma	vzdialenosť v yardoch
 00017865-v	slk:lemma	ísť do postele
 04074482-n	slk:lemma	liečba
@@ -36650,7 +36650,7 @@
 00072989-v	slk:lemma	vypudiť
 02249438-v	slk:lemma	obnovovať
 09255207-n	slk:lemma	kontinentálna plošina
-00721371-s	slk:lemma	neistý
+00721371-a	slk:lemma	neistý
 08598301-n	slk:lemma	trávnik
 13138308-n	slk:lemma	kôstkoviny
 06610779-n	slk:lemma	podvod
@@ -36660,7 +36660,7 @@
 02345048-v	slk:lemma	lúpiť
 00358985-r	slk:lemma	po hodine
 03521076-n	slk:lemma	záves
-00529657-s	slk:lemma	pokojný
+00529657-a	slk:lemma	pokojný
 01122387-n	slk:lemma	tribút
 02972925-a	slk:lemma	izraelský
 04828925-n	slk:lemma	humanita
@@ -36671,24 +36671,24 @@
 08300429-n	slk:lemma	Všeobecná dohoda o clách a obchode
 01149621-n	slk:lemma	obmedzovanie
 03646296-n	slk:lemma	sústruh
-01465214-s	slk:lemma	milenecký
+01465214-a	slk:lemma	milenecký
 05220306-n	slk:lemma	telo dospelého muža
 05902872-n	slk:lemma	systém
 00268557-n	slk:lemma	uzdravenie
 00981830-n	slk:lemma	špionáž
-01234527-s	slk:lemma	šikmý
+01234527-a	slk:lemma	šikmý
 00503569-v	slk:lemma	povzbudzovať
 00222479-r	slk:lemma	dodatočne
 08593262-n	slk:lemma	priamka
-00345494-s	slk:lemma	meniaci sa
+00345494-a	slk:lemma	meniaci sa
 03137044-n	slk:lemma	priečnik
 00622584-n	slk:lemma	hon
-01961205-s	slk:lemma	náhodný
+01961205-a	slk:lemma	náhodný
 08552138-n	slk:lemma	kraj
 09114696-n	slk:lemma	NM
 00705924-v	slk:lemma	prebehnúť
 03407369-n	slk:lemma	elektrická poistka
-00839225-s	slk:lemma	efektívny
+00839225-a	slk:lemma	efektívny
 15230180-n	slk:lemma	večerné bohoslužby
 07363346-n	slk:lemma	klesanie
 00808182-n	slk:lemma	limitácia
@@ -36725,8 +36725,8 @@
 00396029-n	slk:lemma	odvodnenie
 15210045-n	slk:lemma	január
 00249164-r	slk:lemma	zvnútra
-02119213-s	slk:lemma	triezvy
-02570046-s	slk:lemma	obsahujúci múdrosť
+02119213-a	slk:lemma	triezvy
+02570046-a	slk:lemma	obsahujúci múdrosť
 01808769-v	slk:lemma	vzbudzovať odpor
 00590366-v	slk:lemma	chápať
 07989373-n	slk:lemma	manželský pár
@@ -36736,12 +36736,12 @@
 01813499-v	slk:lemma	rozveseliť
 04108268-n	slk:lemma	šnúra
 01072949-v	slk:lemma	zahrať
-00505410-s	slk:lemma	výnimočný
+00505410-a	slk:lemma	výnimočný
 00744616-n	slk:lemma	nespravodlivosť
 14436875-n	slk:lemma	uznanie
 00123365-r	slk:lemma	ekonomicky
 00358290-n	slk:lemma	rozdrvenie
-00813589-s	slk:lemma	pôvodný
+00813589-a	slk:lemma	pôvodný
 01106808-n	slk:lemma	obchodovanie
 13623636-n	slk:lemma	ml
 07562495-n	slk:lemma	doplnok výživy
@@ -36754,7 +36754,7 @@
 00607405-v	slk:lemma	študovať
 07661583-n	slk:lemma	pliecko
 03892425-n	slk:lemma	parketová podlaha
-00521811-s	slk:lemma	najvyššieho stupňa
+00521811-a	slk:lemma	najvyššieho stupňa
 01615991-v	slk:lemma	odkladať
 00112601-r	slk:lemma	čerstvo
 04520784-n	slk:lemma	kormidlo
@@ -36767,11 +36767,11 @@
 01014609-v	slk:lemma	zdôrazňovať
 14085474-n	slk:lemma	neschopnosť pohybu
 06495328-n	slk:lemma	súpis
-02363614-s	slk:lemma	odolný
+02363614-a	slk:lemma	odolný
 13354985-n	slk:lemma	výpis z účtu
 00203922-r	slk:lemma	správne
 05395690-n	slk:lemma	žalúdok
-00408445-s	slk:lemma	bledý
+00408445-a	slk:lemma	bledý
 00621734-v	slk:lemma	pomýliť
 03110470-n	slk:lemma	základný kameň
 07015510-n	slk:lemma	komédia
@@ -36814,19 +36814,19 @@
 08913434-n	slk:lemma	Irak
 02725714-v	slk:lemma	zdržiavať sa
 01195804-v	slk:lemma	rozhadzovať
-01876261-s	slk:lemma	pokrokový
+01876261-a	slk:lemma	pokrokový
 13565940-n	slk:lemma	telofáza
-01830599-s	slk:lemma	silný
+01830599-a	slk:lemma	silný
 15271008-n	slk:lemma	odklad
 04401088-n	slk:lemma	telefón
 02344381-v	slk:lemma	revanšovať sa
 01982866-v	slk:lemma	zodvihnúť
 05926358-n	slk:lemma	nepreniknuteľnosť
-00116245-s	slk:lemma	rozhorčený
+00116245-a	slk:lemma	rozhorčený
 00555325-a	slk:lemma	podmienený
 00081591-r	slk:lemma	týždenne
 08764107-n	slk:lemma	Nórsko
-01357027-s	slk:lemma	svieži
+01357027-a	slk:lemma	svieži
 02174115-v	slk:lemma	zacvendžať
 03140431-n	slk:lemma	fľaša na víno
 00227165-v	slk:lemma	zosilňovať sa
@@ -36844,7 +36844,7 @@
 00352826-v	slk:lemma	uzatvárať
 02640440-v	slk:lemma	okolkovať
 07208338-n	slk:lemma	odpor
-01936184-s	slk:lemma	bájny
+01936184-a	slk:lemma	bájny
 03882611-n	slk:lemma	obklad
 00109660-v	slk:lemma	meniť sa
 11910835-n	slk:lemma	astrovité
@@ -36853,7 +36853,7 @@
 08550966-n	slk:lemma	biskupstvo
 01144355-n	slk:lemma	plánovanie
 14234436-n	slk:lemma	nádor
-02333976-s	slk:lemma	znechutený
+02333976-a	slk:lemma	znechutený
 14450691-n	slk:lemma	potreba
 13572436-n	slk:lemma	odparovanie
 01193886-n	slk:lemma	oslobodenie
@@ -36862,23 +36862,23 @@
 15249636-n	slk:lemma	generácia
 00226566-v	slk:lemma	prehlbovať sa
 00319886-v	slk:lemma	piecť
-01990653-s	slk:lemma	stály
+01990653-a	slk:lemma	stály
 03197201-n	slk:lemma	digitálny voltmeter
 06964901-n	slk:lemma	francúzština
 07339329-n	slk:lemma	kontakt
 01278817-v	slk:lemma	zvraštiť sa
 02721547-a	slk:lemma	konský
 01660719-n	slk:lemma	plazy
-01388062-s	slk:lemma	náramný
+01388062-a	slk:lemma	náramný
 00237636-r	slk:lemma	úmyselne
 15252524-n	slk:lemma	pradávny čas
 10279778-n	slk:lemma	madam
 09989290-n	slk:lemma	urodzená pani
-00937341-s	slk:lemma	neskúsený
+00937341-a	slk:lemma	neskúsený
 10474950-n	slk:lemma	páchateľ
 01579813-v	slk:lemma	rozprestrieť
 03119790-n	slk:lemma	dráha
-00811536-s	slk:lemma	netrpezlivý
+00811536-a	slk:lemma	netrpezlivý
 00794079-v	slk:lemma	vzbudiť
 08610305-n	slk:lemma	Yellowstonský národný park
 07294019-n	slk:lemma	ovocie
@@ -36888,7 +36888,7 @@
 08197895-n	slk:lemma	banditi
 06816106-n	slk:lemma	noty
 13265011-n	slk:lemma	dar
-01440889-s	slk:lemma	dlhodobý
+01440889-a	slk:lemma	dlhodobý
 00017282-v	slk:lemma	zadriemať
 00710005-v	slk:lemma	viesť
 10554455-n	slk:lemma	štrajkokaz
@@ -36915,7 +36915,7 @@
 00902424-v	slk:lemma	oslobodiť
 14740915-n	slk:lemma	nenasýtená mastná kyselina
 02542280-v	slk:lemma	poddávať sa
-02331857-s	slk:lemma	úspešný
+02331857-a	slk:lemma	úspešný
 03465818-n	slk:lemma	riadiaci systém
 03340581-n	slk:lemma	plutva
 13260936-n	slk:lemma	hrubý obrat
@@ -36925,17 +36925,17 @@
 06665370-n	slk:lemma	protokol na prenos súborov
 06392001-n	slk:lemma	úsek
 06832464-n	slk:lemma	emko
-01779193-s	slk:lemma	materiálny
+01779193-a	slk:lemma	materiálny
 06407094-n	slk:lemma	autogram
 00167764-n	slk:lemma	mat
 15257829-n	slk:lemma	polčas
 00874067-n	slk:lemma	rozhodnutie
 02704617-v	slk:lemma	odvážiť
 00024047-v	slk:lemma	resuscitovať
-01950711-s	slk:lemma	neohrabaný
+01950711-a	slk:lemma	neohrabaný
 00796976-v	slk:lemma	odvrhnúť
 01558385-a	slk:lemma	motivovaný
-00856651-s	slk:lemma	plný citu
+00856651-a	slk:lemma	plný citu
 00753685-n	slk:lemma	šudiarstvo
 00169298-v	slk:lemma	ožiť
 07405893-n	slk:lemma	prúd
@@ -36972,32 +36972,32 @@
 04564698-n	slk:lemma	priechod
 10285135-n	slk:lemma	muž aristokratického pôvodu
 02426171-v	slk:lemma	zahájiť
-00414354-s	slk:lemma	súčasný
+00414354-a	slk:lemma	súčasný
 13253255-n	slk:lemma	akvizícia
 04495843-n	slk:lemma	vlečná loď
 04335435-n	slk:lemma	zberač
-01131454-s	slk:lemma	strašný
+01131454-a	slk:lemma	strašný
 01789064-n	slk:lemma	rad Galliformes
-01150063-s	slk:lemma	sužujúci sa láskou
+01150063-a	slk:lemma	sužujúci sa láskou
 00915722-n	slk:lemma	kultivácia
 00582195-n	slk:lemma	sociálna starostlivosť
 01412346-v	slk:lemma	zraziť (na zem, k zemi)
 14330046-n	slk:lemma	bolesť rebier
 15206097-n	slk:lemma	polovica storočia
 00597915-v	slk:lemma	osvojiť si
-01287486-s	slk:lemma	pozorovateľný
+01287486-a	slk:lemma	pozorovateľný
 02584097-v	slk:lemma	utiecť od vojska
 09247410-n	slk:lemma	oblak
 00210651-r	slk:lemma	voľne
-00533452-s	slk:lemma	pochopiteľný
-01419462-s	slk:lemma	analogický
+00533452-a	slk:lemma	pochopiteľný
+01419462-a	slk:lemma	analogický
 12713063-n	slk:lemma	kumkvat
 00891216-v	slk:lemma	pokrývať
 00047317-v	slk:lemma	vyskúšať
 02207206-v	slk:lemma	nakupovať
 02106030-n	slk:lemma	kólia
 02719930-v	slk:lemma	prináležať
-01025212-s	slk:lemma	tvrdohlavý
+01025212-a	slk:lemma	tvrdohlavý
 04645599-n	slk:lemma	neochota
 00075708-v	slk:lemma	unaviť
 10228278-n	slk:lemma	porotca
@@ -37017,7 +37017,7 @@
 00873682-v	slk:lemma	upovedomiť
 03300907-n	slk:lemma	Lodine
 10753546-n	slk:lemma	lump
-01662119-s	slk:lemma	zle načasovaný
+01662119-a	slk:lemma	zle načasovaný
 05750657-n	slk:lemma	módny štýl
 00167385-v	slk:lemma	naštrbovať (niečo)
 06878071-n	slk:lemma	úsmev
@@ -37034,7 +37034,7 @@
 00402128-n	slk:lemma	metamorfóza
 00416084-r	slk:lemma	v zámorí
 01552885-a	slk:lemma	niektorý
-00689878-s	slk:lemma	prípustný
+00689878-a	slk:lemma	prípustný
 00113009-r	slk:lemma	odznova
 02758581-v	slk:lemma	omrznúť srieňom
 01017643-v	slk:lemma	obraňovať
@@ -37046,7 +37046,7 @@
 01921559-n	slk:lemma	čeľaď červov
 14558226-n	slk:lemma	paralýza
 01818235-v	slk:lemma	posmeliť
-01940472-s	slk:lemma	realistický
+01940472-a	slk:lemma	realistický
 09331654-n	slk:lemma	jazero Ilmen
 09193282-n	slk:lemma	riečny nános
 00642098-v	slk:lemma	podeliť
@@ -37054,20 +37054,20 @@
 03122748-n	slk:lemma	prikrývka
 13835899-n	slk:lemma	juh
 01057759-n	slk:lemma	kŕmenie
-00178811-s	slk:lemma	akreditovaný
+00178811-a	slk:lemma	akreditovaný
 01177033-n	slk:lemma	nesúhlas
 01186208-v	slk:lemma	usporiadať (hostinu)
 08208016-n	slk:lemma	personál
 05080526-n	slk:lemma	poloha ležmo
-01735252-s	slk:lemma	materský
+01735252-a	slk:lemma	materský
 03210683-n	slk:lemma	dispenzor
 08566554-n	slk:lemma	záver
 00870213-v	slk:lemma	napomenúť
 02679415-n	slk:lemma	prímes
 04946553-n	slk:lemma	pocit na dotyk
-02121123-s	slk:lemma	nezodpovedný
+02121123-a	slk:lemma	nezodpovedný
 00827730-v	slk:lemma	hájiť
-01376355-s	slk:lemma	povestný
+01376355-a	slk:lemma	povestný
 02154508-v	slk:lemma	zisťovať
 06651577-n	slk:lemma	dôverná informácia
 01605404-v	slk:lemma	pokrývať
@@ -37076,14 +37076,14 @@
 06253690-n	slk:lemma	posolstvo
 05588174-n	slk:lemma	chrbtová kosť
 02408843-v	slk:lemma	pracovať ako tesár
-02161982-s	slk:lemma	dôležitý
+02161982-a	slk:lemma	dôležitý
 15167027-n	slk:lemma	nočná doba
 13312569-n	slk:lemma	pozemková daň
 03600806-n	slk:lemma	marihuanová cigareta
 00072012-v	slk:lemma	počúravať sa
-01265308-s	slk:lemma	humoristický
+01265308-a	slk:lemma	humoristický
 02854926-n	slk:lemma	blúza
-01126291-s	slk:lemma	strašný
+01126291-a	slk:lemma	strašný
 07373803-n	slk:lemma	zlúčenie
 00521296-v	slk:lemma	narušovať
 04662951-n	slk:lemma	všímavosť
@@ -37098,7 +37098,7 @@
 02373336-v	slk:lemma	riskovať
 10577284-n	slk:lemma	predavač na trhu
 01597096-v	slk:lemma	tlačiť (na niekoho)
-00438909-s	slk:lemma	šikovný
+00438909-a	slk:lemma	šikovný
 00073897-r	slk:lemma	hlavne
 10641755-n	slk:lemma	tajný agent
 03257877-n	slk:lemma	predmet dlhodobej spotreby
@@ -37111,7 +37111,7 @@
 00477941-v	slk:lemma	zhyzďovať
 00107144-r	slk:lemma	ako obyčajne
 02274482-v	slk:lemma	zmocňovať sa
-02144436-s	slk:lemma	pružný
+02144436-a	slk:lemma	pružný
 00594413-a	slk:lemma	stály
 01842888-v	slk:lemma	presunúť sa
 02083038-n	slk:lemma	čeľaď psovité
@@ -37120,8 +37120,8 @@
 01581217-v	slk:lemma	zavaliť
 00257269-v	slk:lemma	rozrastať sa
 08240633-n	slk:lemma	záujmová skupina
-00651039-s	slk:lemma	riskantný
-00803432-s	slk:lemma	mrazivý
+00651039-a	slk:lemma	riskantný
+00803432-a	slk:lemma	mrazivý
 14610548-n	slk:lemma	cerotová kyselina
 02291708-v	slk:lemma	dávať zisk
 02298632-v	slk:lemma	dražiť
@@ -37133,7 +37133,7 @@
 05546298-n	slk:lemma	papuľa
 04351550-n	slk:lemma	apartmán
 09620794-n	slk:lemma	domáci obyvateľ
-00084022-s	slk:lemma	vlčí
+00084022-a	slk:lemma	vlčí
 00325975-n	slk:lemma	horolezectvo
 01028748-v	slk:lemma	pomenúvať
 02871695-a	slk:lemma	obecný
@@ -37158,13 +37158,13 @@
 13086438-n	slk:lemma	krycia plodina
 15266685-n	slk:lemma	stred
 02731024-v	slk:lemma	ostávať
-01937390-s	slk:lemma	neskutočný
+01937390-a	slk:lemma	neskutočný
 08054076-n	slk:lemma	medicínska klinika
 01796346-v	slk:lemma	vzrušovať
 02701628-v	slk:lemma	ponechávať si
 02297142-v	slk:lemma	predložiť
 00612612-v	slk:lemma	sláviť
-00520892-s	slk:lemma	úplný
+00520892-a	slk:lemma	úplný
 01689880-a	slk:lemma	konvenčný
 10009484-n	slk:lemma	detektív
 14676756-n	slk:lemma	sochárska sadra
@@ -37173,17 +37173,17 @@
 15287830-n	slk:lemma	perióda
 03287178-n	slk:lemma	konečný produkt
 00086809-n	slk:lemma	nasťahovanie sa
-01563494-s	slk:lemma	mobilný
+01563494-a	slk:lemma	mobilný
 07574426-n	slk:lemma	občerstvenie
 06732581-n	slk:lemma	opätovné potvrdenie
-00611281-s	slk:lemma	klasický
+00611281-a	slk:lemma	klasický
 00524682-v	slk:lemma	osvojiť si
 05999266-n	slk:lemma	báza poznatkov
 07673397-n	slk:lemma	olej
 00189511-v	slk:lemma	zásobiť
 00064889-v	slk:lemma	znechutiť
 04380617-n	slk:lemma	stolná bielizeň
-00876204-s	slk:lemma	nečinný
+00876204-a	slk:lemma	nečinný
 13377268-n	slk:lemma	účet
 01450713-a	slk:lemma	nájdený
 00242003-n	slk:lemma	pokračovanie činnosti
@@ -37206,17 +37206,17 @@
 00891734-v	slk:lemma	poistiť poisťujúceho
 02564426-v	slk:lemma	odpúšťať
 00699815-v	slk:lemma	určovať sa
-00304949-s	slk:lemma	divoký
+00304949-a	slk:lemma	divoký
 05541231-n	slk:lemma	os frontale
 05563266-n	slk:lemma	noha
 12893094-n	slk:lemma	Solanum
-01175158-s	slk:lemma	vredový
+01175158-a	slk:lemma	vredový
 03512147-n	slk:lemma	helikoptéra
 06833112-n	slk:lemma	s
 02395003-n	slk:lemma	svine
 13931145-n	slk:lemma	priateľstvo
-02515001-s	slk:lemma	nehanebný
-00860932-s	slk:lemma	abstrakčný
+02515001-a	slk:lemma	nehanebný
+00860932-a	slk:lemma	abstrakčný
 10503452-n	slk:lemma	extrémista
 05544575-n	slk:lemma	sutura lamboidea
 00485264-r	slk:lemma	nezvyčajne
@@ -37227,7 +37227,7 @@
 09375223-n	slk:lemma	jadro (kométy)
 01571744-v	slk:lemma	popravovať garotou
 00869126-v	slk:lemma	odporovať
-01750386-s	slk:lemma	perfektný
+01750386-a	slk:lemma	perfektný
 02761696-n	slk:lemma	továreň na automobily
 11416988-n	slk:lemma	reakcia
 09039411-n	slk:lemma	Turecká republika
@@ -37261,7 +37261,7 @@
 13854488-n	slk:lemma	norma
 00109782-a	slk:lemma	klesajúci vzduch
 01577635-v	slk:lemma	strčiť
-00906099-s	slk:lemma	plný chvály
+00906099-a	slk:lemma	plný chvály
 06404147-n	slk:lemma	škrabopis
 02707251-v	slk:lemma	postaviť sa
 12581381-n	slk:lemma	Palmaceae
@@ -37288,7 +37288,7 @@
 09633969-n	slk:lemma	páchateľ
 02031622-v	slk:lemma	odpojiť
 00785959-n	slk:lemma	experiment
-00907400-s	slk:lemma	posmešný
+00907400-a	slk:lemma	posmešný
 02791385-n	slk:lemma	podstavec
 00033922-r	slk:lemma	zakrátko
 05761918-n	slk:lemma	pamäť
@@ -37296,7 +37296,7 @@
 07576438-n	slk:lemma	piknik
 08119525-n	slk:lemma	predavači
 02531625-v	slk:lemma	preskúšať
-01560821-s	slk:lemma	dojímavý
+01560821-a	slk:lemma	dojímavý
 01976220-v	slk:lemma	namočiť
 08295580-n	slk:lemma	Organizácia Spojených národov
 03507241-n	slk:lemma	teplo rodinného kozuba
@@ -37312,9 +37312,9 @@
 01993549-v	slk:lemma	prehnať
 04928903-n	slk:lemma	metóda
 02464693-a	slk:lemma	dôverný
-01154030-s	slk:lemma	hodvábny
+01154030-a	slk:lemma	hodvábny
 02001428-n	slk:lemma	Ciconiiformes
-00280463-s	slk:lemma	žiarivý
+00280463-a	slk:lemma	žiarivý
 00501870-n	slk:lemma	slovná hra
 01843055-v	slk:lemma	túlať sa
 00632627-v	slk:lemma	dôvodniť
@@ -37327,13 +37327,13 @@
 06790042-n	slk:lemma	mienenie
 10291469-n	slk:lemma	ozbrojenec
 13721804-n	slk:lemma	megatona
-00969264-s	slk:lemma	trochu čudácky
+00969264-a	slk:lemma	trochu čudácky
 00305283-r	slk:lemma	slobodne
-00461609-s	slk:lemma	hmlistý
-01375831-s	slk:lemma	svetoznámy
+00461609-a	slk:lemma	hmlistý
+01375831-a	slk:lemma	svetoznámy
 05165904-n	slk:lemma	škodlivosť
 15281329-n	slk:lemma	úrok z investície
-01674242-s	slk:lemma	každodenný
+01674242-a	slk:lemma	každodenný
 10547145-n	slk:lemma	svätec
 02723016-v	slk:lemma	šalieť
 15290132-n	slk:lemma	fáza
@@ -37341,8 +37341,8 @@
 06612266-n	slk:lemma	hlúpe reči
 01202728-v	slk:lemma	vyživovať
 02945820-a	slk:lemma	vývojový
-01763159-s	slk:lemma	mäkký
-01265308-s	slk:lemma	smiešny
+01763159-a	slk:lemma	mäkký
+01265308-a	slk:lemma	smiešny
 00660957-n	slk:lemma	starostlivosť o nohy
 00782057-v	slk:lemma	dožadovať sa
 02248808-v	slk:lemma	sprístupniť (data, informácie)
@@ -37363,7 +37363,7 @@
 14939445-n	slk:lemma	fluidum
 00700708-v	slk:lemma	ohraničovať
 10513120-n	slk:lemma	redaktor
-00550574-s	slk:lemma	nemenný
+00550574-a	slk:lemma	nemenný
 03345487-n	slk:lemma	hasičské auto
 06533648-n	slk:lemma	konštitúcia
 14491271-n	slk:lemma	nadbytok
@@ -37373,7 +37373,7 @@
 00196485-n	slk:lemma	zmena
 03954199-n	slk:lemma	architektonické plány
 02479323-v	slk:lemma	vydávať
-00808011-s	slk:lemma	nevýrazný
+00808011-a	slk:lemma	nevýrazný
 10206173-n	slk:lemma	informátor
 00397760-n	slk:lemma	škrt
 01438304-v	slk:lemma	dodať
@@ -37382,7 +37382,7 @@
 07206302-n	slk:lemma	odvolanie
 07010541-n	slk:lemma	dialógy
 00648692-n	slk:lemma	váhová analýza
-02436025-s	slk:lemma	neprijateľný
+02436025-a	slk:lemma	neprijateľný
 02480803-v	slk:lemma	objednať
 06612266-n	slk:lemma	hlúpe nezmysly
 00182406-v	slk:lemma	dodávať
@@ -37395,10 +37395,10 @@
 05629682-n	slk:lemma	peklo
 13686877-n	slk:lemma	šiling
 02467662-v	slk:lemma	krájať
-02372434-s	slk:lemma	prekrížený
+02372434-a	slk:lemma	prekrížený
 01711445-v	slk:lemma	predstaviť
 00109660-v	slk:lemma	zmeniť
-00201961-s	slk:lemma	transponovaný
+00201961-a	slk:lemma	transponovaný
 02401809-v	slk:lemma	vylúčiť
 01802309-n	slk:lemma	čeľaď bažantovité
 06502192-n	slk:lemma	kataster
@@ -37420,9 +37420,9 @@
 11455695-n	slk:lemma	fokálny bod
 04157703-n	slk:lemma	film
 06763273-n	slk:lemma	anotácia
-02279900-s	slk:lemma	statočný
+02279900-a	slk:lemma	statočný
 04340935-n	slk:lemma	pevnosť
-01993408-s	slk:lemma	skromný
+01993408-a	slk:lemma	skromný
 01067577-n	slk:lemma	spomalenie
 00841986-v	slk:lemma	žalovať
 01019524-n	slk:lemma	duplikovanie
@@ -37440,11 +37440,11 @@
 03196324-n	slk:lemma	číslicový počítač
 09255768-n	slk:lemma	Cookova úžina
 03637898-n	slk:lemma	gotické okno
-01390588-s	slk:lemma	obrovský
+01390588-a	slk:lemma	obrovský
 01051331-n	slk:lemma	umiestenie
 10420031-n	slk:lemma	signatár petície
 03297735-n	slk:lemma	podnik
-00392093-s	slk:lemma	snehobiely
+00392093-a	slk:lemma	snehobiely
 14006945-n	slk:lemma	aktivita
 01393714-v	slk:lemma	zametať
 00818974-v	slk:lemma	zaujať stanovisko
@@ -37456,7 +37456,7 @@
 00838043-v	slk:lemma	tváriť sa
 05956651-n	slk:lemma	právna zásada
 03709206-n	slk:lemma	zväčšovacie sklo
-01038580-s	slk:lemma	komunálny
+01038580-a	slk:lemma	komunálny
 00408660-a	slk:lemma	svetlý
 00462092-v	slk:lemma	potláčať silou
 04323026-n	slk:lemma	trh s cennými papiermi
@@ -37467,7 +37467,7 @@
 06520944-n	slk:lemma	dohoda
 00682230-v	slk:lemma	stanoviť cenu
 01410363-a	slk:lemma	odlišný
-01842198-s	slk:lemma	náhodný
+01842198-a	slk:lemma	náhodný
 03302121-n	slk:lemma	výkop
 09786585-n	slk:lemma	amatér
 04566257-n	slk:lemma	munícia
@@ -37493,18 +37493,18 @@
 00921738-v	slk:lemma	označiť
 01814815-v	slk:lemma	utešiť
 02787435-n	slk:lemma	čačka
-00049016-s	slk:lemma	komplementárny
+00049016-a	slk:lemma	komplementárny
 02788689-n	slk:lemma	tyč
 00283568-n	slk:lemma	chodenie
 02759614-v	slk:lemma	roznietiť
 01937994-a	slk:lemma	skutočný
 04677514-n	slk:lemma	forma
 00205046-v	slk:lemma	zdokonaľovať sa
-01251958-s	slk:lemma	studený
+01251958-a	slk:lemma	studený
 00168564-r	slk:lemma	šialene
 02563616-a	slk:lemma	ľahko ovládateľný
 02009122-v	slk:lemma	zmiznúť
-00398978-s	slk:lemma	rôzny
+00398978-a	slk:lemma	rôzny
 05000537-n	slk:lemma	korpulencia
 03128085-n	slk:lemma	viazanka
 02431971-v	slk:lemma	viesť
@@ -37519,7 +37519,7 @@
 05702726-n	slk:lemma	ohľad
 01614769-n	slk:lemma	rod Haliaeetus
 06656961-n	slk:lemma	fiškálna politika
-01515280-s	slk:lemma	zúčastnený
+01515280-a	slk:lemma	zúčastnený
 00072012-v	slk:lemma	pošťať sa
 08893492-n	slk:lemma	Vnútorné Hebridy
 01787955-v	slk:lemma	mrzieť
@@ -37531,7 +37531,7 @@
 08101410-n	slk:lemma	kmeň
 10037385-n	slk:lemma	korheľ
 12123244-n	slk:lemma	jačmeň
-00633581-s	slk:lemma	čestný
+00633581-a	slk:lemma	čestný
 01380122-v	slk:lemma	rozšíriť sa
 06353757-n	slk:lemma	kódovací systém
 00220409-n	slk:lemma	vražda
@@ -37545,7 +37545,7 @@
 03128519-n	slk:lemma	krém
 13624190-n	slk:lemma	dm³
 02260085-v	slk:lemma	odpredávať za nové
-00758800-s	slk:lemma	príjemný
+00758800-a	slk:lemma	príjemný
 04906471-n	slk:lemma	podriadenosť
 07509996-n	slk:lemma	údiv
 09703708-n	slk:lemma	obyvateľ mesta Cambridge
@@ -37568,12 +37568,12 @@
 01120069-v	slk:lemma	napadnúť
 00251820-r	slk:lemma	legálne
 10475835-n	slk:lemma	predavač reprodukcií a rytín
-01439784-s	slk:lemma	zdĺhavý
+01439784-a	slk:lemma	zdĺhavý
 02248808-v	slk:lemma	vybrať (z pamäti)
 00030142-v	slk:lemma	chichúňať sa
 01779165-v	slk:lemma	vystrašiť
 08234792-n	slk:lemma	podniková odborová organizácia
-01925708-s	slk:lemma	logický
+01925708-a	slk:lemma	logický
 02131279-v	slk:lemma	vyšetrovať
 00206867-r	slk:lemma	rýchlo
 09090825-n	slk:lemma	LA
@@ -37587,8 +37587,8 @@
 14294678-n	slk:lemma	omrzlina
 01194418-v	slk:lemma	usporiadať
 08213671-n	slk:lemma	bojová eskadra
-02059811-s	slk:lemma	nebezpečný
-02515001-s	slk:lemma	hnusný
+02059811-a	slk:lemma	nebezpečný
+02515001-a	slk:lemma	hnusný
 00794981-v	slk:lemma	robiť súpis
 00512186-v	slk:lemma	deaktivovať
 00818466-n	slk:lemma	správa
@@ -37605,15 +37605,15 @@
 05235461-n	slk:lemma	kraniometrický bod
 05862268-n	slk:lemma	homogénny polynóm
 00341560-v	slk:lemma	postúpiť
-02341864-s	slk:lemma	vynikajúci
+02341864-a	slk:lemma	vynikajúci
 10104209-n	slk:lemma	nadriadený
 08367100-n	slk:lemma	riadené hospodárstvo
-00714763-s	slk:lemma	obsahujúci žiadosť
+00714763-a	slk:lemma	obsahujúci žiadosť
 00782057-v	slk:lemma	prosiť
 13378518-n	slk:lemma	úver
 00843468-v	slk:lemma	dať vinu
 09272085-n	slk:lemma	fundamentálna častica
-01764351-s	slk:lemma	zdržiavajúci
+01764351-a	slk:lemma	zdržiavajúci
 00721755-v	slk:lemma	hrabať sa (v minulosti)
 09017526-n	slk:lemma	Arménsko
 03942920-n	slk:lemma	špendlíková hlavička
@@ -37637,18 +37637,18 @@
 13324188-n	slk:lemma	poplatok za použitie nábrežia
 13983304-n	slk:lemma	svetlo
 07251779-n	slk:lemma	aplauz
-00609564-s	slk:lemma	výstredný
-01385255-s	slk:lemma	obrovský
+00609564-a	slk:lemma	výstredný
+01385255-a	slk:lemma	obrovský
 14204095-n	slk:lemma	úpal
 07460104-n	slk:lemma	bežecké preteky
-02279723-s	slk:lemma	energický
+02279723-a	slk:lemma	energický
 02162947-v	slk:lemma	zatrblietať sa
 00464513-a	slk:lemma	logický
 01235258-n	slk:lemma	protiopatrenie
 09289709-n	slk:lemma	guľôčka
 14010148-n	slk:lemma	nečinnosť
 10612210-n	slk:lemma	lajdák
-00740217-s	slk:lemma	fixný
+00740217-a	slk:lemma	fixný
 00859153-v	slk:lemma	rozveseliť
 02152881-n	slk:lemma	korisť
 07556970-n	slk:lemma	chod
@@ -37661,7 +37661,7 @@
 07181935-n	slk:lemma	rozdielny názor
 00712031-n	slk:lemma	trenie
 13991823-n	slk:lemma	sloboda
-00966357-s	slk:lemma	starý
+00966357-a	slk:lemma	starý
 01483188-n	slk:lemma	čeľaď Lamnidae
 07122118-n	slk:lemma	hluk
 02492198-v	slk:lemma	baviť
@@ -37671,7 +37671,7 @@
 00079908-n	slk:lemma	kontremína
 00684838-v	slk:lemma	zahŕňať
 09966255-n	slk:lemma	vedúci obchodný pracovník
-00798491-s	slk:lemma	ožratý
+00798491-a	slk:lemma	ožratý
 00668099-v	slk:lemma	zvládať
 01811736-v	slk:lemma	nadchnúť
 08553535-n	slk:lemma	pásmo obytné
@@ -37692,24 +37692,24 @@
 01077350-n	slk:lemma	prevencia
 09020961-n	slk:lemma	Tadžická republika
 08381636-n	slk:lemma	plánovacia komisia
-00015247-s	slk:lemma	bohatý
+00015247-a	slk:lemma	bohatý
 08600760-n	slk:lemma	podnožník
-01208738-s	slk:lemma	dômyselný
+01208738-a	slk:lemma	dômyselný
 00932367-a	slk:lemma	nevhodný
-01037022-s	slk:lemma	rodený
+01037022-a	slk:lemma	rodený
 07417405-n	slk:lemma	krízová udalosť
 13999941-n	slk:lemma	odsúdenie na samoväzbu
 04861486-n	slk:lemma	nepoddajnosť
 15196537-n	slk:lemma	Vianoce
 05839024-n	slk:lemma	druh
 09242389-n	slk:lemma	priehlbina
-01461292-s	slk:lemma	milý
+01461292-a	slk:lemma	milý
 05784831-n	slk:lemma	premýšľanie
 10720964-n	slk:lemma	člen odborového zväzu
 10508710-n	slk:lemma	čitateľ
 05328867-n	slk:lemma	exokrinná žľaza
 09103943-n	slk:lemma	MS
-00028471-s	slk:lemma	putatívny
+00028471-a	slk:lemma	putatívny
 01439190-v	slk:lemma	chytať
 04782116-n	slk:lemma	hrôza
 00756598-n	slk:lemma	podvod
@@ -37732,13 +37732,13 @@
 09342141-n	slk:lemma	Loch Achray
 00190783-n	slk:lemma	zvládnutie
 00299580-v	slk:lemma	upraviť si
-01482140-s	slk:lemma	zosobášený
-02506922-s	slk:lemma	rozmanitý
+01482140-a	slk:lemma	zosobášený
+02506922-a	slk:lemma	rozmanitý
 09825519-n	slk:lemma	mŕtvola
 10640620-n	slk:lemma	manželka
 02023600-v	slk:lemma	zhromažďovať sa
 00293141-v	slk:lemma	krášliť
-02132224-s	slk:lemma	pikantný
+02132224-a	slk:lemma	pikantný
 13289467-n	slk:lemma	časť
 03797390-n	slk:lemma	krčah
 13405480-n	slk:lemma	opravná položka
@@ -37766,7 +37766,7 @@
 08070465-n	slk:lemma	poisťovateľ
 00384055-v	slk:lemma	premeniť sa
 02207206-v	slk:lemma	kúpiť
-01282510-s	slk:lemma	desivý
+01282510-a	slk:lemma	desivý
 06889330-n	slk:lemma	zablysnutie sa
 10247358-n	slk:lemma	dievča
 07941729-n	slk:lemma	biotické spoločenstvo
@@ -37778,7 +37778,7 @@
 02701628-v	slk:lemma	uchovávať si
 05404336-n	slk:lemma	sperma
 02579140-v	slk:lemma	osvedčiť sa
-01344171-s	slk:lemma	ohromujúci
+01344171-a	slk:lemma	ohromujúci
 00199659-v	slk:lemma	zreparovať
 09774266-n	slk:lemma	poradca
 13300141-n	slk:lemma	nezaplatenie
@@ -37805,7 +37805,7 @@
 03650173-n	slk:lemma	vrstva
 13085864-n	slk:lemma	žatva
 14336317-n	slk:lemma	porucha trávenia
-01808227-s	slk:lemma	úžasný
+01808227-a	slk:lemma	úžasný
 13987423-n	slk:lemma	šťastie
 05623181-n	slk:lemma	nadanie
 01569549-a	slk:lemma	medzištátny
@@ -37818,7 +37818,7 @@
 08191230-n	slk:lemma	pozemné vojsko
 08047890-n	slk:lemma	Armáda spásy
 13812173-n	slk:lemma	vzájomné porozumenie
-01990653-s	slk:lemma	rozhodný
+01990653-a	slk:lemma	rozhodný
 03148920-n	slk:lemma	okraj chodníka
 01835496-v	slk:lemma	prejsť
 01296154-v	slk:lemma	zošiť
@@ -37831,13 +37831,13 @@
 09968128-n	slk:lemma	pouličný predavač ovocia
 01743531-v	slk:lemma	napodobiť
 05377515-n	slk:lemma	portálny systém
-00122844-s	slk:lemma	konzekventný
+00122844-a	slk:lemma	konzekventný
 02289295-v	slk:lemma	získať
 03778600-n	slk:lemma	modul
 00782527-v	slk:lemma	nalákať
 01514655-v	slk:lemma	vypúšťať
 01792158-n	slk:lemma	kohút
-01668567-s	slk:lemma	metodický
+01668567-a	slk:lemma	metodický
 09861718-n	slk:lemma	podvodník
 00336430-n	slk:lemma	kývanie
 02993546-n	slk:lemma	ústredie
@@ -37855,7 +37855,7 @@
 09091668-n	slk:lemma	Monroe
 10216106-n	slk:lemma	investor
 01347138-a	slk:lemma	diaľkový (štúdium)
-00445169-s	slk:lemma	neďaleký
+00445169-a	slk:lemma	neďaleký
 00371264-v	slk:lemma	žeraviť
 00218427-n	slk:lemma	kynoženie
 03652100-n	slk:lemma	grafitová ceruzka
@@ -37865,7 +37865,7 @@
 13280658-n	slk:lemma	mzda
 05275466-n	slk:lemma	sedacia kosť
 01044114-v	slk:lemma	zamrmlať
-01710260-s	slk:lemma	bezplatný
+01710260-a	slk:lemma	bezplatný
 04071102-n	slk:lemma	útočisko
 05593017-n	slk:lemma	ramenná kosť
 07837545-n	slk:lemma	smotanová omáčka
@@ -37877,7 +37877,7 @@
 01480336-n	slk:lemma	Chondrichthyes
 00051590-r	slk:lemma	priamo
 00510189-n	slk:lemma	hlučné radovánky
-00014490-s	slk:lemma	výdatný
+00014490-a	slk:lemma	výdatný
 00050037-n	slk:lemma	prihlásenie
 14716997-n	slk:lemma	mosadz
 07204911-n	slk:lemma	odmietnutie
@@ -37891,7 +37891,7 @@
 00116588-r	slk:lemma	spoločnými silami
 00054435-r	slk:lemma	jednoducho
 04644161-n	slk:lemma	divokosť
-00357556-s	slk:lemma	osobitý
+00357556-a	slk:lemma	osobitý
 12583401-n	slk:lemma	trpasličia palma
 10091012-n	slk:lemma	agent provokatér
 01157517-v	slk:lemma	spotrebúvať
@@ -37901,7 +37901,7 @@
 01195804-v	slk:lemma	mariť
 00416216-n	slk:lemma	cesta ctnosti
 10150940-n	slk:lemma	pozvaná osoba
-01122595-s	slk:lemma	neznámy
+01122595-a	slk:lemma	neznámy
 13926535-n	slk:lemma	nominácia
 06024936-n	slk:lemma	odchýlka
 03746330-n	slk:lemma	pánske oblečenie
@@ -37918,7 +37918,7 @@
 05649385-n	slk:lemma	nedostatok kreativity
 00878636-v	slk:lemma	postupovať
 07320302-n	slk:lemma	zrodenie
-00522885-s	slk:lemma	úplný
+00522885-a	slk:lemma	úplný
 04190052-n	slk:lemma	polička
 00036762-n	slk:lemma	úspech
 06421685-n	slk:lemma	manuál
@@ -37927,7 +37927,7 @@
 03735637-n	slk:lemma	meracia žrď
 15266911-n	slk:lemma	zakončenie
 05710687-n	slk:lemma	zistenie
-02121123-s	slk:lemma	roztržitý
+02121123-a	slk:lemma	roztržitý
 06195249-n	slk:lemma	obrana
 02064887-v	slk:lemma	odchyľovať sa
 02931826-a	slk:lemma	nočný
@@ -37962,7 +37962,7 @@
 05770926-n	slk:lemma	mienenie
 01745125-n	slk:lemma	jedovatý had z čeľade Elapidae
 01587062-v	slk:lemma	obkľučovať
-00609564-s	slk:lemma	zvláštny
+00609564-a	slk:lemma	zvláštny
 01061333-n	slk:lemma	nárok
 01494310-v	slk:lemma	umiestniť
 05929008-n	slk:lemma	rola
@@ -37973,13 +37973,13 @@
 00014405-v	slk:lemma	odpočívať
 09380817-n	slk:lemma	Ouachita
 00073897-r	slk:lemma	najmä
-02002470-s	slk:lemma	vymedzený
+02002470-a	slk:lemma	vymedzený
 03279364-n	slk:lemma	elektronický voltmeter
 01803003-v	slk:lemma	hnevať
-00167829-s	slk:lemma	príťažlivý
+00167829-a	slk:lemma	príťažlivý
 09345932-n	slk:lemma	more
 03898129-n	slk:lemma	prepojovacia šnúra
-02587936-s	slk:lemma	hodný niečoho
+02587936-a	slk:lemma	hodný niečoho
 03253398-n	slk:lemma	potrubie
 04776699-n	slk:lemma	nepohyblivosť
 01587062-v	slk:lemma	obkolesiť
@@ -37987,9 +37987,9 @@
 09796062-n	slk:lemma	editor
 09355850-n	slk:lemma	močarina
 02814774-n	slk:lemma	plážové oblečenie
-01807964-s	slk:lemma	príjemný
+01807964-a	slk:lemma	príjemný
 01139636-n	slk:lemma	meno
-00729439-s	slk:lemma	hospodársky sebestačný
+00729439-a	slk:lemma	hospodársky sebestačný
 01047338-n	slk:lemma	oživenie
 02228698-v	slk:lemma	vykazovať
 01809321-v	slk:lemma	drviť
@@ -38020,11 +38020,11 @@
 05248181-n	slk:lemma	prechod
 02620466-v	slk:lemma	podriaďovať sa
 08975902-n	slk:lemma	Západný Pakistán
-00343226-s	slk:lemma	predurčený osudom
+00343226-a	slk:lemma	predurčený osudom
 06404147-n	slk:lemma	pravopisná nesprávnosť
 01410223-v	slk:lemma	zaútočiť
 00832347-a	slk:lemma	operatívny
-01246148-s	slk:lemma	nepriateľský
+01246148-a	slk:lemma	nepriateľský
 02700867-v	slk:lemma	obsahovať
 00120010-n	slk:lemma	hopkanie
 09984659-n	slk:lemma	klient
@@ -38042,17 +38042,17 @@
 05786184-n	slk:lemma	rozjímanie
 02327200-v	slk:lemma	zabezpečovať
 06252138-n	slk:lemma	komunikácia
-02568884-s	slk:lemma	prepojený
+02568884-a	slk:lemma	prepojený
 04796291-n	slk:lemma	zvyčajnosť
-00135092-s	slk:lemma	primeraný
+00135092-a	slk:lemma	primeraný
 06653363-n	slk:lemma	pravidlo dôkazu
-02411116-s	slk:lemma	majúci mohutnú hruď
+02411116-a	slk:lemma	majúci mohutnú hruď
 02552449-v	slk:lemma	obnovovať
 04335435-n	slk:lemma	kladkový zberač
 01582645-v	slk:lemma	narysovať
 00964694-v	slk:lemma	porozprávať sa
 00754942-v	slk:lemma	dožadovať sa
-02477557-s	slk:lemma	začlenený
+02477557-a	slk:lemma	začlenený
 01020356-v	slk:lemma	zapísať si
 00637259-v	slk:lemma	počítať
 00964343-n	slk:lemma	ozbrojený konflikt
@@ -38062,7 +38062,7 @@
 01142014-n	slk:lemma	povolenie
 05896618-n	slk:lemma	zbožné prianie
 00980038-n	slk:lemma	ofenzíva
-01366062-s	slk:lemma	smutný
+01366062-a	slk:lemma	smutný
 09191707-n	slk:lemma	rieka Aire
 03424103-n	slk:lemma	hlavný plynovod
 05521111-n	slk:lemma	vagína
@@ -38078,13 +38078,13 @@
 00224168-v	slk:lemma	odznieť
 07675627-n	slk:lemma	klobása
 08682389-n	slk:lemma	Nový svet
-00028471-s	slk:lemma	predpokladaný
+00028471-a	slk:lemma	predpokladaný
 04386051-n	slk:lemma	koník
 01030132-v	slk:lemma	menovať
-00122128-s	slk:lemma	predchádzajúci
+00122128-a	slk:lemma	predchádzajúci
 09024467-n	slk:lemma	Madrid
 02250899-a	slk:lemma	sprevádzaný
-00566342-s	slk:lemma	susedný
+00566342-a	slk:lemma	susedný
 00876332-v	slk:lemma	predkladať na diskusiu
 00159177-n	slk:lemma	privodenie
 02452464-n	slk:lemma	papuľa
@@ -38114,15 +38114,15 @@
 00806502-v	slk:lemma	sankcionovať
 02434976-v	slk:lemma	pridať sa k/ku
 00372013-n	slk:lemma	zhromažďovanie
-02557719-s	slk:lemma	živinový
+02557719-a	slk:lemma	živinový
 09772029-n	slk:lemma	tínedžer
-01629681-s	slk:lemma	nájazdový
+01629681-a	slk:lemma	nájazdový
 06443658-n	slk:lemma	Druhý list Korinťanom
 01582409-v	slk:lemma	hltať
 05218899-n	slk:lemma	sústava
 02206624-n	slk:lemma	nadčeľaď Apoidea
 09136182-n	slk:lemma	Filadelfia
-00390539-s	slk:lemma	mliečnobiely
+00390539-a	slk:lemma	mliečnobiely
 00226133-r	slk:lemma	ostražito
 10306181-n	slk:lemma	študent medicíny
 09992837-n	slk:lemma	dcéra
@@ -38168,7 +38168,7 @@
 00371059-n	slk:lemma	natiahnutie
 07295391-n	slk:lemma	výpoveď
 00366521-n	slk:lemma	rozpínanie
-00331167-s	slk:lemma	presne uprostred
+00331167-a	slk:lemma	presne uprostred
 00379754-n	slk:lemma	zmätenie
 00085811-r	slk:lemma	tempo, tempo
 00015303-v	slk:lemma	driemať
@@ -38186,13 +38186,13 @@
 13265904-n	slk:lemma	finančný príspevok
 05656537-n	slk:lemma	pohľad
 01761706-v	slk:lemma	vzrušovať
-01392249-s	slk:lemma	drobný
+01392249-a	slk:lemma	drobný
 05725879-n	slk:lemma	zóna komfortu
 00072012-v	slk:lemma	odľahčiť si (telesne)
 09805475-n	slk:lemma	architekt
 02487347-n	slk:lemma	makak
 00841986-v	slk:lemma	prezrádzať
-01723543-s	slk:lemma	objektívny
+01723543-a	slk:lemma	objektívny
 02108377-v	slk:lemma	podrobovať sa (čomu)
 06706676-n	slk:lemma	stuha
 01003249-v	slk:lemma	fotiť
@@ -38223,7 +38223,7 @@
 00395744-r	slk:lemma	majstrovsky
 08401554-n	slk:lemma	klientela
 09186064-n	slk:lemma	Aare
-00440579-s	slk:lemma	pomalý
+00440579-a	slk:lemma	pomalý
 07550369-n	slk:lemma	zloba
 14500567-n	slk:lemma	chaos
 02968473-n	slk:lemma	kočiar
@@ -38231,10 +38231,10 @@
 01843055-v	slk:lemma	cestovať
 01856626-v	slk:lemma	presídľovať sa
 02613860-v	slk:lemma	vynechávať
-02321809-s	slk:lemma	statný
+02321809-a	slk:lemma	statný
 03141823-n	slk:lemma	barla
 07992116-n	slk:lemma	kŕdeľ (husí)
-00197773-s	slk:lemma	najzadnejší
+00197773-a	slk:lemma	najzadnejší
 00634906-v	slk:lemma	rozriešiť
 08573472-n	slk:lemma	predná časť
 09211735-n	slk:lemma	Austrálske Alpy
@@ -38279,11 +38279,11 @@
 00256507-v	slk:lemma	opúchať
 03230785-n	slk:lemma	predbežná skica
 02208903-v	slk:lemma	dávať do (pre)nájmu
-01486854-s	slk:lemma	zdvojený
+01486854-a	slk:lemma	zdvojený
 02083806-v	slk:lemma	rozohniť
 01362736-v	slk:lemma	maľovať
 01325451-a	slk:lemma	výchovný
-00583842-s	slk:lemma	nehynúci
+00583842-a	slk:lemma	nehynúci
 02297409-v	slk:lemma	ponúkať
 00100883-r	slk:lemma	zďaleka
 01418288-a	slk:lemma	uvedený
@@ -38296,7 +38296,7 @@
 13639647-n	slk:lemma	jednotka osvetlenia
 15254550-n	slk:lemma	pravek
 00018302-r	slk:lemma	viac-menej
-01674242-s	slk:lemma	bežný
+01674242-a	slk:lemma	bežný
 07311115-n	slk:lemma	zmena polohy
 00151040-r	slk:lemma	ako, tak
 06652878-n	slk:lemma	spôsob práce parlamentu
@@ -38310,14 +38310,14 @@
 01105639-v	slk:lemma	prevýšiť
 07652052-n	slk:lemma	pečeň
 00010241-v	slk:lemma	konať mimovoľne
-01648491-s	slk:lemma	detinský
+01648491-a	slk:lemma	detinský
 00310201-n	slk:lemma	exkurzia
 03178782-n	slk:lemma	obrazový motív
 09053019-n	slk:lemma	Dakota
 15181444-n	slk:lemma	Svätý týždeň
 14751417-n	slk:lemma	kortikoid
 00253919-n	slk:lemma	sterilizácia
-01226660-s	slk:lemma	dôstojný
+01226660-a	slk:lemma	dôstojný
 06255777-n	slk:lemma	hárok
 05532225-n	slk:lemma	žalúdočno-črevný trakt
 01805982-v	slk:lemma	oceňovať
@@ -38325,8 +38325,8 @@
 15296687-n	slk:lemma	referenčný čas
 01171183-v	slk:lemma	prepláchnuť si/prepláknuť si (hrdlo, ústa, gágor
 09184834-n	slk:lemma	duševná energia
-00136589-s	slk:lemma	vyvolateľný
-00922051-s	slk:lemma	očarujúci
+00136589-a	slk:lemma	vyvolateľný
+00922051-a	slk:lemma	očarujúci
 00230746-v	slk:lemma	dorásť
 09140148-n	slk:lemma	TN
 02707251-v	slk:lemma	prečkať
@@ -38376,7 +38376,7 @@
 06502378-n	slk:lemma	písomný záznam
 08361924-n	slk:lemma	nadvláda
 01437254-v	slk:lemma	zaslať
-01709437-s	slk:lemma	platený vopred
+01709437-a	slk:lemma	platený vopred
 11456462-n	slk:lemma	priaznivé počasie
 03109881-n	slk:lemma	kút
 06763273-n	slk:lemma	vysvetlivka
@@ -38384,7 +38384,7 @@
 09346120-n	slk:lemma	pevnina
 14831178-n	slk:lemma	nekódovacia DNA
 04858455-n	slk:lemma	neohrozenosť
-01592857-s	slk:lemma	skromný
+01592857-a	slk:lemma	skromný
 01306425-v	slk:lemma	pobíjať
 08521267-n	slk:lemma	nebeská klenba
 07941729-n	slk:lemma	spoločenstvo
@@ -38407,7 +38407,7 @@
 04685396-n	slk:lemma	pôvab
 02127808-n	slk:lemma	mačka
 08702402-n	slk:lemma	juhoamerický národ
-01899167-s	slk:lemma	obozretný
+01899167-a	slk:lemma	obozretný
 04694441-n	slk:lemma	machuľa
 00451186-n	slk:lemma	cezpoľné jazdenie
 02321757-v	slk:lemma	kradnúť
@@ -38426,7 +38426,7 @@
 10776766-n	slk:lemma	predseda poslaneckého klubu
 10714054-n	slk:lemma	Trinidadčan
 04211356-n	slk:lemma	okenica
-02395810-s	slk:lemma	kyslý
+02395810-a	slk:lemma	kyslý
 05644922-n	slk:lemma	nedostatočná schopnosť
 04645943-n	slk:lemma	odpor
 02202384-v	slk:lemma	podržiavať si
@@ -38449,14 +38449,14 @@
 00426958-v	slk:lemma	vypariť sa
 00264386-v	slk:lemma	preháňať
 04808639-n	slk:lemma	popularita
-00260695-s	slk:lemma	malomeštiacky
+00260695-a	slk:lemma	malomeštiacky
 13319726-n	slk:lemma	základná sadzba
 01524199-v	slk:lemma	rozmotávať
 01058574-v	slk:lemma	povšimnúť si
 04675314-n	slk:lemma	efekt
 02201644-v	slk:lemma	rozdať
-02549691-s	slk:lemma	sparný
-00182961-s	slk:lemma	ručne poháňaný
+02549691-a	slk:lemma	sparný
+00182961-a	slk:lemma	ručne poháňaný
 02575082-v	slk:lemma	podvádzať
 01887474-n	slk:lemma	dobytok
 08377806-n	slk:lemma	hierarchia
@@ -38494,15 +38494,15 @@
 00845909-v	slk:lemma	podceňovať
 08273736-n	slk:lemma	posádka
 15213774-n	slk:lemma	december
-02057226-s	slk:lemma	laický
+02057226-a	slk:lemma	laický
 08366753-n	slk:lemma	ekonomika
 12707781-n	slk:lemma	citrusový strom
-02018141-s	slk:lemma	poetický
+02018141-a	slk:lemma	poetický
 14539268-n	slk:lemma	bezpečie
 09137869-n	slk:lemma	Južná Karolína
 15250312-n	slk:lemma	výročie
 00854904-v	slk:lemma	oblafnúť
-02333976-s	slk:lemma	otrávený
+02333976-a	slk:lemma	otrávený
 00766418-v	slk:lemma	presvedčiť (niekoho)
 06529219-n	slk:lemma	objednávka
 09774783-n	slk:lemma	zástanca
@@ -38531,18 +38531,18 @@
 01692786-a	slk:lemma	krytý
 05046659-n	slk:lemma	včasnosť
 14739978-n	slk:lemma	sorbová kyselina
-01265308-s	slk:lemma	komický
+01265308-a	slk:lemma	komický
 05338025-n	slk:lemma	sluchová artéria
 00612841-v	slk:lemma	potláčať
-01038580-s	slk:lemma	mestský
+01038580-a	slk:lemma	mestský
 02236355-n	slk:lemma	chrobák
 01199755-v	slk:lemma	nadýchať sa
 00455919-v	slk:lemma	dopĺňať
 06782019-n	slk:lemma	názor
 06892657-n	slk:lemma	benefičný koncert
-01765237-s	slk:lemma	preventívny
+01765237-a	slk:lemma	preventívny
 04493381-n	slk:lemma	nádrž
-02587936-s	slk:lemma	užitočný
+02587936-a	slk:lemma	užitočný
 01519977-v	slk:lemma	zmeniť
 00806621-n	slk:lemma	náhodná kontrola
 02333909-n	slk:lemma	potkan čierny
@@ -38553,7 +38553,7 @@
 13374281-n	slk:lemma	odložená platba
 03149951-n	slk:lemma	zvláštnosť
 09465459-n	slk:lemma	stavebná jednotka
-02068946-s	slk:lemma	identický
+02068946-a	slk:lemma	identický
 00634906-v	slk:lemma	chápať
 08415127-n	slk:lemma	nerozhodná porota
 10626540-n	slk:lemma	černokňažníčka
@@ -38561,12 +38561,12 @@
 04040759-n	slk:lemma	chladič
 02009433-v	slk:lemma	odchádzať
 03412058-n	slk:lemma	galéria
-00974519-s	slk:lemma	nemoderný
-02515001-s	slk:lemma	odporný
+00974519-a	slk:lemma	nemoderný
+02515001-a	slk:lemma	odporný
 08308497-n	slk:lemma	porada
 05405751-n	slk:lemma	pot
 01523823-v	slk:lemma	odmotať
-02060912-s	slk:lemma	sebazničujúci
+02060912-a	slk:lemma	sebazničujúci
 00991385-v	slk:lemma	objasňovať
 02281093-v	slk:lemma	urobiť si zásoby
 00964911-v	slk:lemma	spúšťať (rozhovor, tému)
@@ -38582,7 +38582,7 @@
 11803475-n	slk:lemma	podtrieda Caryophyllidae
 11804082-n	slk:lemma	rad Chenopodiales
 01984902-v	slk:lemma	posadiť sa
-00387392-s	slk:lemma	striebristý
+00387392-a	slk:lemma	striebristý
 04400289-n	slk:lemma	telekomunikácie
 02439829-n	slk:lemma	zadná noha
 01541231-v	slk:lemma	zapracovať
@@ -38592,17 +38592,17 @@
 00161294-r	slk:lemma	značne
 04335435-n	slk:lemma	vozík
 01079295-n	slk:lemma	predbežné liečebné opatrenia
-01844441-s	slk:lemma	predvarený
+01844441-a	slk:lemma	predvarený
 01249315-n	slk:lemma	udelenie milosti
 08285594-n	slk:lemma	odborná škola
 13461951-n	slk:lemma	popieranie
 02260085-v	slk:lemma	odpredať za nové
 02347637-v	slk:lemma	zaslať
-00010726-s	slk:lemma	hltavý
+00010726-a	slk:lemma	hltavý
 14939900-n	slk:lemma	tekutina
 02401809-v	slk:lemma	vylučovať
 02484957-v	slk:lemma	popraviť (na elektrickom kresle)
-01855086-s	slk:lemma	záložný
+01855086-a	slk:lemma	záložný
 05747582-n	slk:lemma	prehodnotenie
 01993549-v	slk:lemma	pohýnať sa
 10676018-n	slk:lemma	nadriadený pracovník
@@ -38632,7 +38632,7 @@
 00636061-v	slk:lemma	uhádnuť
 05854150-n	slk:lemma	vízia
 04847482-n	slk:lemma	dobrá vlastnosť
-01644847-s	slk:lemma	starobylý
+01644847-a	slk:lemma	starobylý
 01229938-n	slk:lemma	schôdza
 07623136-n	slk:lemma	múčnik
 05138958-n	slk:lemma	pozitívum
@@ -38641,13 +38641,13 @@
 09777353-n	slk:lemma	zmocnenec
 13253255-n	slk:lemma	prínos
 08111783-n	slk:lemma	civilizácia
-00063953-s	slk:lemma	nevhodný
-01320474-s	slk:lemma	zbavený viny
+00063953-a	slk:lemma	nevhodný
+01320474-a	slk:lemma	zbavený viny
 10380126-n	slk:lemma	optimista
 00625393-a	slk:lemma	reálny
 03443005-n	slk:lemma	bránkovisko
-00972642-s	slk:lemma	hypermoderný
-01263971-s	slk:lemma	neľútostný
+00972642-a	slk:lemma	hypermoderný
+01263971-a	slk:lemma	neľútostný
 06632358-n	slk:lemma	pozdrav
 00157950-v	slk:lemma	zväčšovať sa
 08551177-n	slk:lemma	postihnutá oblasť
@@ -38668,29 +38668,29 @@
 00041954-r	slk:lemma	spravidla
 13863771-n	slk:lemma	trajektória
 13685096-n	slk:lemma	sierraleonská menová jednotka
-00974159-s	slk:lemma	zastaralý
+00974159-a	slk:lemma	zastaralý
 15296687-n	slk:lemma	epocha
 03854065-n	slk:lemma	píšťalový organ
 02888659-a	slk:lemma	prímorský
-02388921-s	slk:lemma	domestikovaný
+02388921-a	slk:lemma	domestikovaný
 02257370-v	slk:lemma	vymieňať sa
 00075656-r	slk:lemma	prekvapený
 05320362-n	slk:lemma	šošovka
 00205046-v	slk:lemma	zdokonaliť
 04909414-n	slk:lemma	neposlušnosť
 10388924-n	slk:lemma	nositeľ
-01632066-s	slk:lemma	ospravedlňujúci
-01111418-s	slk:lemma	dobrosrdečný
+01632066-a	slk:lemma	ospravedlňujúci
+01111418-a	slk:lemma	dobrosrdečný
 05652396-n	slk:lemma	zmyslový systém
 06255777-n	slk:lemma	list
 06671484-n	slk:lemma	rady
 10515194-n	slk:lemma	reformátor
 00956687-v	slk:lemma	charakterizovať
 00232956-v	slk:lemma	opadnúť
-01854129-s	slk:lemma	doplnkový
+01854129-a	slk:lemma	doplnkový
 05161436-n	slk:lemma	dlh
 00737656-v	slk:lemma	zachvacovať
-02515001-s	slk:lemma	nezákonný
+02515001-a	slk:lemma	nezákonný
 01185981-v	slk:lemma	hostiť sa
 01424456-v	slk:lemma	objímať sa
 10020890-n	slk:lemma	lekárka
@@ -38705,7 +38705,7 @@
 06684383-n	slk:lemma	povinnosť
 07492655-n	slk:lemma	útecha
 04550426-n	slk:lemma	garderóba
-02059811-s	slk:lemma	hazardný
+02059811-a	slk:lemma	hazardný
 01985923-v	slk:lemma	poklesnúť
 04847991-n	slk:lemma	nadpozemská cnosť
 10332385-n	slk:lemma	mama
@@ -38716,7 +38716,7 @@
 00983824-v	slk:lemma	chrliť
 00718924-a	slk:lemma	subjektívny
 11665781-n	slk:lemma	trieda Dicotyledonae
-00624576-s	slk:lemma	slušný
+00624576-a	slk:lemma	slušný
 04486445-n	slk:lemma	maličkosť
 01106808-n	slk:lemma	transakcia
 05199286-n	slk:lemma	efektivita
@@ -38730,7 +38730,7 @@
 08514592-n	slk:lemma	obeh
 02064887-v	slk:lemma	odvracať sa
 03471473-n	slk:lemma	žľab
-01676517-s	slk:lemma	podivuhodný
+01676517-a	slk:lemma	podivuhodný
 03515338-n	slk:lemma	heraldika
 01970272-v	slk:lemma	vypariť
 05300507-n	slk:lemma	sluchový systém
@@ -38740,7 +38740,7 @@
 13747606-n	slk:lemma	šestnásť
 00231887-n	slk:lemma	anulovanie
 01322854-v	slk:lemma	pobiť
-00329034-s	slk:lemma	rozdelený na časti
+00329034-a	slk:lemma	rozdelený na časti
 08190482-n	slk:lemma	nepriateľ
 00807178-v	slk:lemma	neuznať
 00658942-a	slk:lemma	plošný
@@ -38751,28 +38751,28 @@
 01984317-v	slk:lemma	spadnúť
 02928347-a	slk:lemma	indický
 00901103-v	slk:lemma	zoznamovať
-01649271-s	slk:lemma	malý
-00814902-s	slk:lemma	dosť skorý
+01649271-a	slk:lemma	malý
+00814902-a	slk:lemma	dosť skorý
 05842706-n	slk:lemma	románska architektúra
 03930313-n	slk:lemma	plot
 02213690-v	slk:lemma	zadržiavať
 07573563-n	slk:lemma	veľká porcia jedla
-01167269-s	slk:lemma	profylaktický
+01167269-a	slk:lemma	profylaktický
 00877559-v	slk:lemma	konzultovať (s)
-01695269-s	slk:lemma	prikrytý
+01695269-a	slk:lemma	prikrytý
 07457834-n	slk:lemma	majstrovstvá
-01676026-s	slk:lemma	extrémny
-01155968-s	slk:lemma	oceľový
+01676026-a	slk:lemma	extrémny
+01155968-a	slk:lemma	oceľový
 00009147-v	slk:lemma	zvliekať (kožu)
 08187033-n	slk:lemma	spolok
-02346878-s	slk:lemma	komerčný
+02346878-a	slk:lemma	komerčný
 02153387-v	slk:lemma	podrobne preskúmať
 07208000-n	slk:lemma	odmietnutie
 10410996-n	slk:lemma	poľnohospodár
 01106670-v	slk:lemma	predchádzať
 06691989-n	slk:lemma	potlesk
 13259199-n	slk:lemma	obeh hotovosti
-01167540-s	slk:lemma	rekuperačný
+01167540-a	slk:lemma	rekuperačný
 00005526-v	slk:lemma	oddychovať
 10548227-n	slk:lemma	pomocník v obchode
 05407119-n	slk:lemma	vnútorná sekrécia
@@ -38788,7 +38788,7 @@
 01462005-v	slk:lemma	zjednotiť
 06432715-n	slk:lemma	Kniha Exodus
 03114359-a	slk:lemma	skalný
-00533221-s	slk:lemma	prístupný
+00533221-a	slk:lemma	prístupný
 07832902-n	slk:lemma	dresing
 00273445-v	slk:lemma	privykať si
 15267536-n	slk:lemma	ukončenie
@@ -38796,46 +38796,46 @@
 00755745-v	slk:lemma	vyžadovať
 04004099-n	slk:lemma	vyrovnávacia pamäť tlačiarne
 07840395-n	slk:lemma	omáčka z kari
-00892243-s	slk:lemma	rovný
+00892243-a	slk:lemma	rovný
 02707251-v	slk:lemma	čeliť
 01927654-a	slk:lemma	rasový
 03048883-n	slk:lemma	uzavretý obeh
-00746451-s	slk:lemma	spletitý
+00746451-a	slk:lemma	spletitý
 05989479-n	slk:lemma	teória
 07219923-n	slk:lemma	správa o činnosti
 00824767-v	slk:lemma	hromžiť
 02828884-n	slk:lemma	lavica
 06377442-n	slk:lemma	báseň
 14446298-n	slk:lemma	útulnosť
-00440579-s	slk:lemma	nedôvtipný
+00440579-a	slk:lemma	nedôvtipný
 03034903-a	slk:lemma	mariánsky
 15120823-n	slk:lemma	minulosť
 06844040-n	slk:lemma	otáznik
 01093085-n	slk:lemma	valutová transakcia
-01969348-s	slk:lemma	polročný
+01969348-a	slk:lemma	polročný
 01143040-n	slk:lemma	príprava
 00768778-v	slk:lemma	prehovoriť
 05456732-n	slk:lemma	zárodočná bunka
-02074929-s	slk:lemma	cvoknutý
+02074929-a	slk:lemma	cvoknutý
 01510082-v	slk:lemma	vyhadzovať
-00865007-s	slk:lemma	bez práce
+00865007-a	slk:lemma	bez práce
 12317763-n	slk:lemma	Juglandales
 07234657-n	slk:lemma	vzájomná žaloba
 06167328-n	slk:lemma	filozofická doktrína
 04395024-n	slk:lemma	plachta
 14709265-n	slk:lemma	etylalkohol
 00644583-v	slk:lemma	analyzovať
-01941814-s	slk:lemma	praktický
+01941814-a	slk:lemma	praktický
 00067265-r	slk:lemma	smerujúci dopredu
 00399223-n	slk:lemma	premena
 00593374-a	slk:lemma	ojedinelý
 01961691-v	slk:lemma	pohybovať plutvami
-00750602-s	slk:lemma	jasný
+00750602-a	slk:lemma	jasný
 01644746-v	slk:lemma	realizovať
 12582231-n	slk:lemma	palma
 00151689-v	slk:lemma	zmenšiť sa
 00610538-v	slk:lemma	pripomenúť
-01199083-s	slk:lemma	zmiešaný
+01199083-a	slk:lemma	zmiešaný
 04603081-n	slk:lemma	dielňa
 02733524-n	slk:lemma	oblúk
 10253995-n	slk:lemma	zákonodarca
@@ -38856,7 +38856,7 @@
 00907147-v	slk:lemma	posťažovať si
 01628946-a	slk:lemma	výbojný
 02162947-v	slk:lemma	zažiariť
-01178134-s	slk:lemma	sinavý
+01178134-a	slk:lemma	sinavý
 13838386-n	slk:lemma	vzťah založený na dôvere
 10121144-n	slk:lemma	predvolaná osoba
 09249418-n	slk:lemma	Colorado River
@@ -38868,10 +38868,10 @@
 04867871-n	slk:lemma	neúprimnosť
 04372370-n	slk:lemma	spínač
 06478582-n	slk:lemma	diplom
-01912858-s	slk:lemma	naivný
-02186338-s	slk:lemma	jednotka
+01912858-a	slk:lemma	naivný
+02186338-a	slk:lemma	jednotka
 05581932-n	slk:lemma	pokožka
-02074673-s	slk:lemma	diabolský
+02074673-a	slk:lemma	diabolský
 00043078-v	slk:lemma	vyparádiť
 06660396-n	slk:lemma	kvóta na dovoz
 00061595-v	slk:lemma	kastrovať
@@ -38884,13 +38884,13 @@
 09173777-n	slk:lemma	Citlaltepetl
 01982866-v	slk:lemma	povstať
 00437639-n	slk:lemma	stojka
-01287486-s	slk:lemma	zrejmý
+01287486-a	slk:lemma	zrejmý
 13246475-n	slk:lemma	nehnuteľnosti
 02066939-v	slk:lemma	pretiecť
 06533648-n	slk:lemma	základný zákon štátu
-01990653-s	slk:lemma	neotrasiteľný
+01990653-a	slk:lemma	neotrasiteľný
 01463965-a	slk:lemma	milujúci
-02097480-s	slk:lemma	lákavý
+02097480-a	slk:lemma	lákavý
 01777210-v	slk:lemma	mať rád
 03086974-a	slk:lemma	nerastný
 03104594-n	slk:lemma	odpis
@@ -38901,7 +38901,7 @@
 04743605-n	slk:lemma	podobnosť
 01059564-v	slk:lemma	ignorovať
 02073041-n	slk:lemma	rad Sirenia
-02161136-s	slk:lemma	podpísaný
+02161136-a	slk:lemma	podpísaný
 05079866-n	slk:lemma	pozícia
 07025604-n	slk:lemma	černošská hudba
 04849759-n	slk:lemma	počestnosť
@@ -38919,20 +38919,20 @@
 01326015-n	slk:lemma	hrebeň
 01463965-a	slk:lemma	láskyplný
 00080039-r	slk:lemma	dole
-02112108-s	slk:lemma	spojený
+02112108-a	slk:lemma	spojený
 07548567-n	slk:lemma	agresivita
 01808374-v	slk:lemma	znechutiť sa
-00937616-s	slk:lemma	neskúsený
+00937616-a	slk:lemma	neskúsený
 02460619-v	slk:lemma	prenajímať
 01462005-v	slk:lemma	spájať sa
 00582071-n	slk:lemma	úradovanie
-00170847-s	slk:lemma	lákavý
+00170847-a	slk:lemma	lákavý
 03020034-n	slk:lemma	čip
 02166460-v	slk:lemma	preskúmať
-00521811-s	slk:lemma	maximálny
+00521811-a	slk:lemma	maximálny
 01240210-n	slk:lemma	zákrok
 01996735-v	slk:lemma	pochodovať
-00082766-s	slk:lemma	agresívny
+00082766-a	slk:lemma	agresívny
 01431230-v	slk:lemma	bozkávať sa (s kým)
 01999798-v	slk:lemma	priviesť
 01217043-v	slk:lemma	podopierať
@@ -38963,12 +38963,12 @@
 01996735-v	slk:lemma	postupovať
 08057816-n	slk:lemma	reťazec
 09405949-n	slk:lemma	Červená rieka
-01822933-s	slk:lemma	matematický
+01822933-a	slk:lemma	matematický
 02862048-n	slk:lemma	zbroj
 06873571-n	slk:lemma	vizuálny signál
 00564857-v	slk:lemma	zhúžvať
 05321664-n	slk:lemma	membránový labyrint
-00876204-s	slk:lemma	zasnený
+00876204-a	slk:lemma	zasnený
 00794079-v	slk:lemma	vyvolať
 01782650-v	slk:lemma	vydesiť sa
 08744626-n	slk:lemma	Nogales
@@ -38977,22 +38977,22 @@
 06413889-n	slk:lemma	prospekt
 00607780-v	slk:lemma	pamätať
 00145929-n	slk:lemma	spojenie
-02214736-s	slk:lemma	sám
+02214736-a	slk:lemma	sám
 04904352-n	slk:lemma	pohoda
 01158181-v	slk:lemma	skonzumovať
 01218593-n	slk:lemma	uznanie
 03427296-n	slk:lemma	brána
 05872982-n	slk:lemma	prirodzené právo
 01026095-v	slk:lemma	nazývať
-01580775-s	slk:lemma	vyžadovaný
-00286837-s	slk:lemma	liberálny
+01580775-a	slk:lemma	vyžadovaný
+00286837-a	slk:lemma	liberálny
 01787106-v	slk:lemma	napáliť sa
 01792429-n	slk:lemma	kohútik
 02498320-v	slk:lemma	zarezervovať
 10018021-n	slk:lemma	odporca
 13669342-n	slk:lemma	iracký dinár
 00220023-n	slk:lemma	zabitie
-02215382-s	slk:lemma	jediný svojho druhu
+02215382-a	slk:lemma	jediný svojho druhu
 02121234-n	slk:lemma	Felis
 09287124-n	slk:lemma	Garonne
 01153486-v	slk:lemma	pomstiť sa
@@ -39018,12 +39018,12 @@
 04440486-n	slk:lemma	tovar z cínu
 00047056-r	slk:lemma	jasne
 01227675-v	slk:lemma	vnikať
-00566961-s	slk:lemma	priľahlý
+00566961-a	slk:lemma	priľahlý
 06817623-n	slk:lemma	písomný symbol
 13949802-n	slk:lemma	prednosť
 02129289-v	slk:lemma	zbadať
 15147504-n	slk:lemma	chlapčenstvo
-01673946-s	slk:lemma	obyčajný
+01673946-a	slk:lemma	obyčajný
 07887967-n	slk:lemma	svetlé pivo
 03696065-n	slk:lemma	priestor pre batožinu
 08796219-n	slk:lemma	Kalvária
@@ -39031,7 +39031,7 @@
 06151942-n	slk:lemma	kriminológia
 00257742-a	slk:lemma	lemovaný
 00205046-v	slk:lemma	zlepšovať sa
-01356143-s	slk:lemma	rýchlo rastúci
+01356143-a	slk:lemma	rýchlo rastúci
 01097292-n	slk:lemma	tržnica
 01092366-v	slk:lemma	bojovať
 02636708-a	slk:lemma	priepustný
@@ -39055,14 +39055,14 @@
 05064037-n	slk:lemma	obrys
 13312569-n	slk:lemma	daň, majetková
 00398704-n	slk:lemma	transformácia
-02576489-s	slk:lemma	drevený
+02576489-a	slk:lemma	drevený
 06478582-n	slk:lemma	osvedčenie
 08052549-n	slk:lemma	federálna vláda
 01014066-n	slk:lemma	zbierka
 00366675-n	slk:lemma	naťahovanie
 03384535-n	slk:lemma	tvar
 01821634-v	slk:lemma	dodávať života
-01492596-s	slk:lemma	nedospelý
+01492596-a	slk:lemma	nedospelý
 13417071-n	slk:lemma	cenný papier
 02514187-v	slk:lemma	zaobchádzať (s)
 00671190-v	slk:lemma	zmýliť sa
@@ -39072,7 +39072,7 @@
 10676877-n	slk:lemma	inšpektor
 02766328-a	slk:lemma	motivačný
 02230795-a	slk:lemma	numerický
-02177584-s	slk:lemma	zložitý
+02177584-a	slk:lemma	zložitý
 07286278-n	slk:lemma	hrozba vojny
 01471954-a	slk:lemma	neplnoletý
 04071102-n	slk:lemma	azyl
@@ -39087,13 +39087,13 @@
 07919572-n	slk:lemma	káva s mliekom a jemnou penou
 02327200-v	slk:lemma	zabezpečiť
 08569165-n	slk:lemma	extrém
-01383582-s	slk:lemma	astronomický
+01383582-a	slk:lemma	astronomický
 01459422-a	slk:lemma	ľúbezný
 01504130-v	slk:lemma	rozmiestniť
 10466918-n	slk:lemma	ochranca
 08390511-n	slk:lemma	milícia
 02321391-v	slk:lemma	ukradnúť
-01431112-s	slk:lemma	absurdný
+01431112-a	slk:lemma	absurdný
 00047317-v	slk:lemma	skúšať si
 01011031-v	slk:lemma	vyhlasovať
 00039297-n	slk:lemma	kontakt
@@ -39102,13 +39102,13 @@
 08716738-n	slk:lemma	Kambodža
 09933411-n	slk:lemma	spoluobžalovaný
 01001294-v	slk:lemma	dať najavo
-01937390-s	slk:lemma	klamný
+01937390-a	slk:lemma	klamný
 06073215-n	slk:lemma	štúdium cicavcov
 06518253-n	slk:lemma	darčeková knižná poukážka
 00124008-n	slk:lemma	bočné ostreľovanie
 03061505-n	slk:lemma	kokpit
 13980845-n	slk:lemma	rozpor
-01564315-s	slk:lemma	nehybný
+01564315-a	slk:lemma	nehybný
 01400562-a	slk:lemma	legálny
 13524925-n	slk:lemma	operácia
 02384041-v	slk:lemma	dosadiť
@@ -39119,7 +39119,7 @@
 02405390-v	slk:lemma	nahrádzať
 07059255-n	slk:lemma	žáner populárnej hudby
 01560320-a	slk:lemma	nedojatý
-01306645-s	slk:lemma	dobre informovaný
+01306645-a	slk:lemma	dobre informovaný
 07557434-n	slk:lemma	jedlo
 05999797-n	slk:lemma	vedecká disciplína
 04061969-n	slk:lemma	výklenok
@@ -39141,7 +39141,7 @@
 09465795-n	slk:lemma	elementárna štruktúra kryštálu
 06501311-n	slk:lemma	politická platforma
 00831191-n	slk:lemma	vonkajšie dýchanie
-02547862-s	slk:lemma	orosený
+02547862-a	slk:lemma	orosený
 00658052-v	slk:lemma	odhadovať
 03560567-n	slk:lemma	zapaľovanie
 02738701-v	slk:lemma	skrútiť sa
@@ -39152,7 +39152,7 @@
 06113597-n	slk:lemma	kinetika
 01523823-v	slk:lemma	rozmotať
 01810466-n	slk:lemma	holuby
-00798103-s	slk:lemma	totálne sťatý
+00798103-a	slk:lemma	totálne sťatý
 00854876-n	slk:lemma	orálny sex
 00658052-v	slk:lemma	klasifikovať
 03472232-n	slk:lemma	gymnastické náradie
@@ -39164,9 +39164,9 @@
 09451517-n	slk:lemma	povrch Zeme
 00426928-n	slk:lemma	rozptýlenie
 05222591-n	slk:lemma	jamka
-00625055-s	slk:lemma	značný
+00625055-a	slk:lemma	značný
 00283235-r	slk:lemma	donekonečna
-01865807-s	slk:lemma	orný
+01865807-a	slk:lemma	orný
 04153025-n	slk:lemma	nízke dvere
 13867492-n	slk:lemma	beztvarosť
 00859325-v	slk:lemma	naplniť radosťou
@@ -39177,9 +39177,9 @@
 02419773-v	slk:lemma	drieť
 04889779-n	slk:lemma	trpezlivosť
 00014742-v	slk:lemma	spať
-02344070-s	slk:lemma	rýdzi
+02344070-a	slk:lemma	rýdzi
 13300828-n	slk:lemma	odplata
-01081340-s	slk:lemma	úrodný
+01081340-a	slk:lemma	úrodný
 06832896-n	slk:lemma	kvéčko
 07143624-n	slk:lemma	audiencia
 07929519-n	slk:lemma	káva
@@ -39197,7 +39197,7 @@
 08226699-n	slk:lemma	obec
 00018813-v	slk:lemma	zobúdzať sa
 01023636-n	slk:lemma	konanie
-00748359-s	slk:lemma	vážny
+00748359-a	slk:lemma	vážny
 01291234-a	slk:lemma	vnútorný
 08420278-n	slk:lemma	depozitárna finančná inštitúcia
 08208560-n	slk:lemma	tím
@@ -39236,7 +39236,7 @@
 00077950-v	slk:lemma	zaškrtiť
 08763010-n	slk:lemma	Dominica
 01111028-v	slk:lemma	vyhrať
-01178458-s	slk:lemma	podobný kŕčovej žile
+01178458-a	slk:lemma	podobný kŕčovej žile
 09989045-n	slk:lemma	baba
 06694796-n	slk:lemma	referencia
 02799175-n	slk:lemma	baseballová palica
@@ -39244,14 +39244,14 @@
 04459122-n	slk:lemma	otvorené vozidlo
 01789514-v	slk:lemma	molestovať
 01329239-v	slk:lemma	zašiť
-02316992-s	slk:lemma	pokrivený
+02316992-a	slk:lemma	pokrivený
 12396666-n	slk:lemma	rod Cannabis
 05332569-n	slk:lemma	týmus
 00927261-n	slk:lemma	duševná práca
 10417551-n	slk:lemma	správca pozostalosti
 04486445-n	slk:lemma	banalita
 02556126-v	slk:lemma	podporiť
-01579128-s	slk:lemma	posledný
+01579128-a	slk:lemma	posledný
 01106405-a	slk:lemma	miestny
 09482916-n	slk:lemma	Yukon
 00988028-v	slk:lemma	stvárňovať
@@ -39280,7 +39280,7 @@
 00226133-r	slk:lemma	opatrne
 06467007-n	slk:lemma	výťah
 01340439-v	slk:lemma	pripevňovať
-02124253-s	slk:lemma	použiteľný
+02124253-a	slk:lemma	použiteľný
 02827160-a	slk:lemma	elektrický
 13317269-n	slk:lemma	nosnosť lode
 14482968-n	slk:lemma	výhliadky
@@ -39293,7 +39293,7 @@
 13308999-n	slk:lemma	poplatok
 13604718-n	slk:lemma	menová jednotka
 06773434-n	slk:lemma	dohoda
-01644225-s	slk:lemma	starší
+01644225-a	slk:lemma	starší
 05687338-n	slk:lemma	problém
 14129784-n	slk:lemma	dengue
 11665781-n	slk:lemma	trieda Magnoliopsida
@@ -39307,7 +39307,7 @@
 01789514-v	slk:lemma	domŕzať
 05980875-n	slk:lemma	cieľ
 01787955-v	slk:lemma	hnevať
-01830703-s	slk:lemma	prestížny
+01830703-a	slk:lemma	prestížny
 02810102-a	slk:lemma	pozemský
 00928630-v	slk:lemma	postupovať
 04056932-n	slk:lemma	syntetický hodváb
@@ -39341,7 +39341,7 @@
 03636248-n	slk:lemma	svietidlo
 02461372-n	slk:lemma	Pholidota
 06424869-n	slk:lemma	prístupový kľúč
-01243373-s	slk:lemma	nepriateľský
+01243373-a	slk:lemma	nepriateľský
 06200617-n	slk:lemma	láskavosť
 13456567-n	slk:lemma	úbytok
 07254267-n	slk:lemma	odstúpenie
@@ -39362,9 +39362,9 @@
 00742320-v	slk:lemma	postúpiť (informáciu)
 04632157-n	slk:lemma	energia
 02060141-v	slk:lemma	rozšíriť
-01692512-s	slk:lemma	prírodný
-00592880-s	slk:lemma	opakovaný
-00071427-s	slk:lemma	posadnutý divadlom
+01692512-a	slk:lemma	prírodný
+00592880-a	slk:lemma	opakovaný
+00071427-a	slk:lemma	posadnutý divadlom
 01204191-v	slk:lemma	živiť
 02249438-v	slk:lemma	obnoviť
 00040547-r	slk:lemma	nečakane
@@ -39378,7 +39378,7 @@
 05119367-n	slk:lemma	nadbytok
 06748969-n	slk:lemma	prognostikovanie
 00666510-v	slk:lemma	dokumentovať
-02164913-s	slk:lemma	tenký
+02164913-a	slk:lemma	tenký
 14494716-n	slk:lemma	sanitárne podmienky
 03953416-n	slk:lemma	dom modlitby
 01657723-n	slk:lemma	rod plazov
@@ -39389,20 +39389,20 @@
 05289057-n	slk:lemma	sval
 02157041-a	slk:lemma	bosý
 00296478-n	slk:lemma	chodenie
-01401105-s	slk:lemma	zákonný
+01401105-a	slk:lemma	zákonný
 06468328-n	slk:lemma	konspekt
-01761375-s	slk:lemma	verejne odsúdený
-02123007-s	slk:lemma	šantivý
+01761375-a	slk:lemma	verejne odsúdený
+02123007-a	slk:lemma	šantivý
 02327200-v	slk:lemma	opatriť (zabezpečiť)
 00177686-r	slk:lemma	naopak
 00142191-v	slk:lemma	formovať
 13312962-n	slk:lemma	daň z koncesovanej činnosti
 14764061-n	slk:lemma	kožušina
 09437454-n	slk:lemma	svah
-00886253-s	slk:lemma	nadšený
+00886253-a	slk:lemma	nadšený
 05298988-n	slk:lemma	črevá
 07588688-n	slk:lemma	hustá zeleninová polievka s krúpami
-00935359-s	slk:lemma	za smiešnu cenu
+00935359-a	slk:lemma	za smiešnu cenu
 14186541-n	slk:lemma	artritída
 02144835-v	slk:lemma	skryť
 13308864-n	slk:lemma	poplatok
@@ -39415,19 +39415,19 @@
 13370938-n	slk:lemma	bohatstvo
 09792555-n	slk:lemma	predchodca
 13789462-n	slk:lemma	exponenciála
-02460964-s	slk:lemma	ozajstný
+02460964-a	slk:lemma	ozajstný
 04566257-n	slk:lemma	zbrane
 02285205-v	slk:lemma	zaplatiť
 01522276-v	slk:lemma	natočiť
-01374183-s	slk:lemma	tvrdý
+01374183-a	slk:lemma	tvrdý
 01931768-v	slk:lemma	inštruovať
 15293227-n	slk:lemma	mier
 06444148-n	slk:lemma	List Efezanom
 02469835-v	slk:lemma	zlučovať
 06831712-n	slk:lemma	f
 00240184-n	slk:lemma	vznik
-00901060-s	slk:lemma	primárny
-01463414-s	slk:lemma	sužujúci sa láskou
+00901060-a	slk:lemma	primárny
+01463414-a	slk:lemma	sužujúci sa láskou
 00976953-n	slk:lemma	vpád
 00800930-v	slk:lemma	ignorovať
 08750986-n	slk:lemma	Guantanamo
@@ -39438,9 +39438,9 @@
 13112664-n	slk:lemma	krík
 02815950-n	slk:lemma	trám
 07053364-n	slk:lemma	svadobná pieseň
-01674134-s	slk:lemma	rutinný
+01674134-a	slk:lemma	rutinný
 00193130-v	slk:lemma	dodať ducha
-01177435-s	slk:lemma	vrastený
+01177435-a	slk:lemma	vrastený
 13725588-n	slk:lemma	tona
 00476140-n	slk:lemma	hra s loptou do kruhu
 01099592-v	slk:lemma	prehrávať
@@ -39453,26 +39453,26 @@
 02167875-v	slk:lemma	pozrieť sa na
 15256567-n	slk:lemma	hra
 07199565-n	slk:lemma	ohlas
-00053032-s	slk:lemma	priliehajúci
+00053032-a	slk:lemma	priliehajúci
 02163982-n	slk:lemma	chrobáky
-00515380-s	slk:lemma	úplný
+00515380-a	slk:lemma	úplný
 14911057-n	slk:lemma	uhľovodík
 06877990-n	slk:lemma	úškrnok
-01203986-s	slk:lemma	odstupňovaný
+01203986-a	slk:lemma	odstupňovaný
 03376159-n	slk:lemma	ovčinec
 00075998-v	slk:lemma	presiliť
-01163941-s	slk:lemma	harmonický
+01163941-a	slk:lemma	harmonický
 02387034-v	slk:lemma	vycvičiť sa
-00515380-s	slk:lemma	celý
+00515380-a	slk:lemma	celý
 09749614-n	slk:lemma	Singapurčan
 04539876-n	slk:lemma	dočasná pamäť
-00084022-s	slk:lemma	dravý
+00084022-a	slk:lemma	dravý
 06495328-n	slk:lemma	zoznam
 02531625-v	slk:lemma	testovať
-01874331-s	slk:lemma	lajdácky
+01874331-a	slk:lemma	lajdácky
 14764061-n	slk:lemma	kožuch
 00072012-v	slk:lemma	cikať
-01266397-s	slk:lemma	fraškovitý
+01266397-a	slk:lemma	fraškovitý
 01207609-n	slk:lemma	podpora
 02478701-v	slk:lemma	zlegalizovať
 09297920-n	slk:lemma	záliv Carpentaria
@@ -39480,7 +39480,7 @@
 02083806-v	slk:lemma	rozhýbať sa
 00452034-n	slk:lemma	zápasenie s býkmi
 02426171-v	slk:lemma	otvoriť
-00792202-s	slk:lemma	výsostný
+00792202-a	slk:lemma	výsostný
 11441416-n	slk:lemma	kozmický prach
 00744131-n	slk:lemma	poškodenie
 06827219-n	slk:lemma	tučné písmo
@@ -39489,7 +39489,7 @@
 04188643-n	slk:lemma	list
 07140659-n	slk:lemma	diskusia
 07289588-n	slk:lemma	div
-02013758-s	slk:lemma	obnovený
+02013758-a	slk:lemma	obnovený
 13985818-n	slk:lemma	emočné rozpoloženie
 05523629-n	slk:lemma	Cowperova žľaza
 11469691-n	slk:lemma	infračervené spektrum
@@ -39497,20 +39497,20 @@
 02450505-v	slk:lemma	predchádzať
 00153263-v	slk:lemma	zväčšovať
 01014821-v	slk:lemma	svedčiť
-02038126-s	slk:lemma	mohutný
+02038126-a	slk:lemma	mohutný
 04999401-n	slk:lemma	tučnota
 02090435-v	slk:lemma	točiť sa
-01223271-s	slk:lemma	dvojtvárny
-01393483-s	slk:lemma	miniatúrny
-00579498-s	slk:lemma	pútavý
+01223271-a	slk:lemma	dvojtvárny
+01393483-a	slk:lemma	miniatúrny
+00579498-a	slk:lemma	pútavý
 01639714-v	slk:lemma	rozvrhovať
 11630890-n	slk:lemma	cyprus
 00429964-r	slk:lemma	predčasne
-01723543-s	slk:lemma	nezaujatý
+01723543-a	slk:lemma	nezaujatý
 02709367-n	slk:lemma	kotva
 06445989-n	slk:lemma	List Títovi
 04388743-n	slk:lemma	rezervoár
-01270486-s	slk:lemma	rýchly
+01270486-a	slk:lemma	rýchly
 02725714-v	slk:lemma	vyhnúť sa
 05017230-n	slk:lemma	vnemová poznateľnosť
 05853273-n	slk:lemma	odvetvie
@@ -39521,7 +39521,7 @@
 03130689-a	slk:lemma	vlnený
 02641957-v	slk:lemma	zdržiavať
 00263642-n	slk:lemma	značkovanie
-00661640-s	slk:lemma	posekaný
+00661640-a	slk:lemma	posekaný
 02402825-v	slk:lemma	končiť pracovný pomer
 00499066-n	slk:lemma	tabuľková hra
 15196186-n	slk:lemma	25. december
@@ -39533,10 +39533,10 @@
 00393369-n	slk:lemma	vyrezanie
 02325366-n	slk:lemma	divoký králik
 01101391-a	slk:lemma	celkový
-00668208-s	slk:lemma	aktuálny
+00668208-a	slk:lemma	aktuálny
 01370561-v	slk:lemma	kopať
 03604156-n	slk:lemma	hracia skrinka
-01593079-s	slk:lemma	obyčajný
+01593079-a	slk:lemma	obyčajný
 10613996-n	slk:lemma	krásavica
 13603305-n	slk:lemma	jednotka dĺžky
 08512736-n	slk:lemma	medzná čiara
@@ -39570,7 +39570,7 @@
 07502669-n	slk:lemma	averzia
 01807170-v	slk:lemma	získavať obľubu
 02627753-v	slk:lemma	prameniť
-02064127-s	slk:lemma	nerozoznateľný
+02064127-a	slk:lemma	nerozoznateľný
 06552814-n	slk:lemma	kvitancia
 09545324-n	slk:lemma	duša
 02753044-n	slk:lemma	jadrová bomba
@@ -39591,7 +39591,7 @@
 01845477-n	slk:lemma	husotvaré
 00206144-r	slk:lemma	temne
 06333653-n	slk:lemma	pomenovanie
-01086915-s	slk:lemma	nahý
+01086915-a	slk:lemma	nahý
 01582645-v	slk:lemma	nakresliť
 08416328-n	slk:lemma	ľavé krídlo
 15244650-n	slk:lemma	chvíľa
@@ -39599,7 +39599,7 @@
 00018813-v	slk:lemma	prebudiť sa
 00607114-v	slk:lemma	preberať (látku, učivo)
 02349212-v	slk:lemma	poručiť
-00168694-s	slk:lemma	sympatický
+00168694-a	slk:lemma	sympatický
 06252954-n	slk:lemma	oznámenie
 08390511-n	slk:lemma	domobrana
 00249501-n	slk:lemma	vývoj
@@ -39614,12 +39614,12 @@
 02396205-v	slk:lemma	vymenovať
 01479805-a	slk:lemma	riadený posádkou
 00230746-v	slk:lemma	narásť
-00746047-s	slk:lemma	divný
+00746047-a	slk:lemma	divný
 01021420-v	slk:lemma	prichádzať k názoru
 13791389-n	slk:lemma	spojitosť
 08821578-n	slk:lemma	Kanadské prímorské provincie
-02257856-s	slk:lemma	vľúdny
-01512275-s	slk:lemma	intenzívny
+02257856-a	slk:lemma	vľúdny
+01512275-a	slk:lemma	intenzívny
 11427619-n	slk:lemma	žiara
 00183505-n	slk:lemma	počet hlasov
 00229605-v	slk:lemma	zvyšovať
@@ -39660,7 +39660,7 @@
 02330582-n	slk:lemma	Myomorpha
 04826235-n	slk:lemma	poctivosť
 06516955-n	slk:lemma	účet
-00587376-s	slk:lemma	korózny
+00587376-a	slk:lemma	korózny
 00046522-n	slk:lemma	styk
 08378819-n	slk:lemma	spoločenská štruktúra
 00618878-v	slk:lemma	spoznávať
@@ -39672,21 +39672,21 @@
 02005948-v	slk:lemma	doraziť
 00240184-n	slk:lemma	inovácia
 10509810-n	slk:lemma	obchodník s realitami
-02218314-s	slk:lemma	rozmanitý
+02218314-a	slk:lemma	rozmanitý
 00729378-v	slk:lemma	uvažovať
 03015149-n	slk:lemma	pohovka
 05922175-n	slk:lemma	podstata
 02613860-v	slk:lemma	vymeškávať
-02570643-s	slk:lemma	komický
+02570643-a	slk:lemma	komický
 00341757-v	slk:lemma	naťahovať sa
 13779032-n	slk:lemma	veľkosť
-01898722-s	slk:lemma	kritický
+01898722-a	slk:lemma	kritický
 02075462-v	slk:lemma	utiecť
 08652551-n	slk:lemma	južná hemisféra
 07248801-n	slk:lemma	reklama
 03706016-n	slk:lemma	magnetická bublinková pamäť
 09472135-n	slk:lemma	Vistula
-00901060-s	slk:lemma	prvotný
+00901060-a	slk:lemma	prvotný
 01810447-v	slk:lemma	poburovať
 02319290-v	slk:lemma	započítať nízku cenu
 07970721-n	slk:lemma	pokolenie
@@ -39699,16 +39699,16 @@
 00138508-v	slk:lemma	otočiť sa
 01017987-n	slk:lemma	kontinuácia
 02584097-v	slk:lemma	utekať od vojska
-01149358-s	slk:lemma	smejúci sa
-01535270-s	slk:lemma	extrémistický
+01149358-a	slk:lemma	smejúci sa
+01535270-a	slk:lemma	extrémistický
 01654628-v	slk:lemma	vytvoriť
 01184625-v	slk:lemma	zaopatrovať
 09044862-n	slk:lemma	USA
 10592397-n	slk:lemma	nákupca
-00341655-s	slk:lemma	neistý
+00341655-a	slk:lemma	neistý
 00066025-v	slk:lemma	mraučať
 07213395-n	slk:lemma	vyzradenie
-00953127-s	slk:lemma	izbový
+00953127-a	slk:lemma	izbový
 08759986-n	slk:lemma	Togská republika
 09641757-n	slk:lemma	Ázijka
 05168261-n	slk:lemma	význam
@@ -39726,13 +39726,13 @@
 03466947-n	slk:lemma	guilloche
 10306279-n	slk:lemma	médium
 02831724-n	slk:lemma	posteľ
-00370869-s	slk:lemma	belasý
+00370869-a	slk:lemma	belasý
 12485122-n	slk:lemma	Loganiaceae
 00108604-v	slk:lemma	podať
 00021766-a	slk:lemma	presný
 00754767-n	slk:lemma	podvod
-01940651-s	slk:lemma	praktický
-02515214-s	slk:lemma	hriešny
+01940651-a	slk:lemma	praktický
+02515214-a	slk:lemma	hriešny
 01888295-v	slk:lemma	vykradnúť sa
 07417851-n	slk:lemma	prelom
 07025900-n	slk:lemma	vážna hudba
@@ -39779,7 +39779,7 @@
 01278817-v	slk:lemma	skrčiť
 04737430-n	slk:lemma	likvidita
 00771341-v	slk:lemma	povzbudiť
-01729566-s	slk:lemma	niekdajší
+01729566-a	slk:lemma	niekdajší
 00432689-n	slk:lemma	koníček
 13526110-n	slk:lemma	biologický proces
 01725051-v	slk:lemma	zahrať
@@ -39806,13 +39806,13 @@
 03693474-n	slk:lemma	tete a tete
 02705201-n	slk:lemma	amfiteáter
 04857083-n	slk:lemma	odvaha
-02570643-s	slk:lemma	hlúpy
-01131454-s	slk:lemma	hnusný
+02570643-a	slk:lemma	hlúpy
+01131454-a	slk:lemma	hnusný
 00057042-r	slk:lemma	nijakým činom
 01096245-n	slk:lemma	biznis
 00075021-v	slk:lemma	ničiť sa
 02587375-v	slk:lemma	vládnuť
-00349894-s	slk:lemma	finálny
+00349894-a	slk:lemma	finálny
 06265272-n	slk:lemma	pošta prvej triedy
 04747798-n	slk:lemma	podobnosť
 00278040-n	slk:lemma	vlhnutie
@@ -39820,7 +39820,7 @@
 02163746-v	slk:lemma	špehovať
 02871525-n	slk:lemma	kníhkupectvo
 13338234-n	slk:lemma	vládna obligácia
-00667353-s	slk:lemma	aktuálny
+00667353-a	slk:lemma	aktuálny
 07238455-n	slk:lemma	špička
 09939313-n	slk:lemma	účastník boja
 00671190-v	slk:lemma	pomýliť sa v úsudku
@@ -39829,11 +39829,11 @@
 07504111-n	slk:lemma	nevoľnosť
 13583724-n	slk:lemma	jednotka
 02506546-v	slk:lemma	zaväzovať
-01044730-s	slk:lemma	nekonvenčný
+01044730-a	slk:lemma	nekonvenčný
 01950798-v	slk:lemma	poslať (loďou)
 06709533-n	slk:lemma	vyjadrenie nesúhlasu
 10153414-n	slk:lemma	chlapík
-01282510-s	slk:lemma	ohromný
+01282510-a	slk:lemma	ohromný
 00713594-n	slk:lemma	zaobchádzanie
 02409412-v	slk:lemma	najímať
 07324673-n	slk:lemma	vzrast
@@ -39856,7 +39856,7 @@
 09815188-n	slk:lemma	chuj
 10620027-n	slk:lemma	sociálna pracovníčka
 01195299-v	slk:lemma	vyskúšať
-01761375-s	slk:lemma	tabu
+01761375-a	slk:lemma	tabu
 02131418-n	slk:lemma	čeľaď medveďovité
 10371450-n	slk:lemma	funkcionár
 01439190-v	slk:lemma	chytiť
@@ -39867,7 +39867,7 @@
 02143283-v	slk:lemma	ukazovať
 03400798-n	slk:lemma	palivová bunka
 12268096-n	slk:lemma	rod dub
-02337188-s	slk:lemma	skromný
+02337188-a	slk:lemma	skromný
 01025563-n	slk:lemma	úradný šimeľ
 14731334-n	slk:lemma	aktín
 14422179-n	slk:lemma	zlepšenie
@@ -39882,18 +39882,18 @@
 05211044-n	slk:lemma	humor
 14422179-n	slk:lemma	meliorácia
 01048912-n	slk:lemma	zatajovanie
-01067415-s	slk:lemma	príležitostný
+01067415-a	slk:lemma	príležitostný
 05678932-n	slk:lemma	nevedomie
 09036880-n	slk:lemma	Bangkok
-00906655-s	slk:lemma	zľahčujúci
-01805801-s	slk:lemma	spokojný
+00906655-a	slk:lemma	zľahčujúci
+01805801-a	slk:lemma	spokojný
 00410247-n	slk:lemma	zvyk
 00418394-n	slk:lemma	rozčuľovanie
 15278691-n	slk:lemma	gigahertz
 00268557-n	slk:lemma	zotavenie
 14324274-n	slk:lemma	agónia
 13686137-n	slk:lemma	lilangeni
-01778935-s	slk:lemma	fyzický
+01778935-a	slk:lemma	fyzický
 01448100-v	slk:lemma	odtiahnuť
 00030647-v	slk:lemma	zrútiť sa
 00953216-v	slk:lemma	podávať slovami
@@ -39910,7 +39910,7 @@
 08756202-n	slk:lemma	Republika Trinidad a Tobago
 09492123-n	slk:lemma	mýtické monštrum
 01449974-v	slk:lemma	dovážať
-01374183-s	slk:lemma	drsný
+01374183-a	slk:lemma	drsný
 08681222-n	slk:lemma	kurz
 00074790-n	slk:lemma	mýlka
 00242003-n	slk:lemma	opätovné zahájenie
@@ -39930,7 +39930,7 @@
 01461328-v	slk:lemma	zložiť sa
 00658052-v	slk:lemma	ohodnotiť
 10613996-n	slk:lemma	kus
-01569166-s	slk:lemma	mnohonárodnostný
+01569166-a	slk:lemma	mnohonárodnostný
 15291498-n	slk:lemma	obdobie úradovania
 01577635-v	slk:lemma	namočiť
 07135080-n	slk:lemma	pletky
@@ -39977,7 +39977,7 @@
 01250101-n	slk:lemma	oprava
 08440630-n	slk:lemma	diktatúra
 01217043-v	slk:lemma	podporovať
-01674242-s	slk:lemma	obvyklý
+01674242-a	slk:lemma	obvyklý
 10748309-n	slk:lemma	nosič insígnií
 00775156-v	slk:lemma	hnevať sa
 05540407-n	slk:lemma	temeno hlavy
@@ -39991,7 +39991,7 @@
 03035715-n	slk:lemma	rezervoár
 10633450-n	slk:lemma	divák
 00714884-v	slk:lemma	prebrať niečo
-00937341-s	slk:lemma	naivný
+00937341-a	slk:lemma	naivný
 05462315-n	slk:lemma	nervová sústava
 00968211-v	slk:lemma	rozchyrovať sa
 04403413-n	slk:lemma	šošovka transfokátora
@@ -39999,7 +39999,7 @@
 08740875-n	slk:lemma	Spojené štáty mexické
 02412210-n	slk:lemma	vykastrovaný baran
 00157844-v	slk:lemma	zväčšovať sa
-01814252-s	slk:lemma	nevýhodný
+01814252-a	slk:lemma	nevýhodný
 03116530-n	slk:lemma	pult
 08759420-n	slk:lemma	Dahome
 05531814-n	slk:lemma	trachea
@@ -40034,21 +40034,21 @@
 02312996-v	slk:lemma	oslobodiť
 13346209-n	slk:lemma	vzájomné poistenie
 00085811-r	slk:lemma	náhlivo
-02481012-s	slk:lemma	rozdelený
+02481012-a	slk:lemma	rozdelený
 01239868-n	slk:lemma	záväzok
 00800930-v	slk:lemma	nevšímať si
 00698855-v	slk:lemma	uzniesť sa
 03241335-n	slk:lemma	fontána na pitie
 03174079-n	slk:lemma	delta krídlo
-01141468-s	slk:lemma	namáhavý
+01141468-a	slk:lemma	namáhavý
 14540220-n	slk:lemma	bezpečnosť, kolektívna
 00027384-r	slk:lemma	predsa len
 10597234-n	slk:lemma	ten, kto podpisuje
 01072949-v	slk:lemma	hrávať
 02703275-n	slk:lemma	strelivo
 11668573-n	slk:lemma	Arecidae
-00816839-s	slk:lemma	pokročilý
-00746047-s	slk:lemma	chúlostivý
+00816839-a	slk:lemma	pokročilý
+00746047-a	slk:lemma	chúlostivý
 01101913-v	slk:lemma	premáhať
 05710860-n	slk:lemma	videnie
 02484570-v	slk:lemma	popravovať (zastrelením)
@@ -40061,7 +40061,7 @@
 09307031-n	slk:lemma	Hudsonský záliv
 00658082-n	slk:lemma	liečenie
 08107191-n	slk:lemma	podrad
-00182225-s	slk:lemma	samovoľný
+00182225-a	slk:lemma	samovoľný
 05046009-n	slk:lemma	načasovanie
 15037877-n	slk:lemma	Rh-faktor
 00262249-n	slk:lemma	dekorácia
@@ -40071,7 +40071,7 @@
 02891188-n	slk:lemma	brdzy
 01812720-v	slk:lemma	napĺňať
 10339966-n	slk:lemma	muzikant
-02032850-s	slk:lemma	na pravoboku
+02032850-a	slk:lemma	na pravoboku
 09636890-n	slk:lemma	tmavá rasa
 07279687-n	slk:lemma	zákazka
 00636888-v	slk:lemma	podopierať
@@ -40080,9 +40080,9 @@
 08848731-n	slk:lemma	Východný Pakistán
 02085320-v	slk:lemma	pokryť sa
 05954481-n	slk:lemma	uvažovanie
-01050088-s	slk:lemma	osudný
+01050088-a	slk:lemma	osudný
 00104003-r	slk:lemma	v zahraničí
-00728431-s	slk:lemma	nezávislý
+00728431-a	slk:lemma	nezávislý
 14840755-n	slk:lemma	živel
 15298995-n	slk:lemma	vláda regenta
 07069948-n	slk:lemma	výraz
@@ -40090,13 +40090,13 @@
 00083585-n	slk:lemma	pozostalosť
 13809207-n	slk:lemma	komponent
 14340635-n	slk:lemma	striedavá horúčka
-00631798-s	slk:lemma	správny
-01808227-s	slk:lemma	ohromný
+00631798-a	slk:lemma	správny
+01808227-a	slk:lemma	ohromný
 00699815-v	slk:lemma	stanovovať
 00854420-v	slk:lemma	klamať
 06664051-n	slk:lemma	predpis
 00102586-v	slk:lemma	poškodiť
-01520091-s	slk:lemma	absolútny
+01520091-a	slk:lemma	absolútny
 00367976-n	slk:lemma	šírenie
 12584057-n	slk:lemma	rod Areca
 01227675-v	slk:lemma	vniknúť
@@ -40105,7 +40105,7 @@
 08514034-n	slk:lemma	centrum
 15118228-n	slk:lemma	pracovná doba
 00434374-v	slk:lemma	umrieť
-01982186-s	slk:lemma	symbolický
+01982186-a	slk:lemma	symbolický
 01178565-v	slk:lemma	nachovať
 11473291-n	slk:lemma	život
 01750167-n	slk:lemma	vretenica
@@ -40185,7 +40185,7 @@
 00387424-n	slk:lemma	krájanie
 01975753-v	slk:lemma	zvyšovať
 09921409-n	slk:lemma	hlupáčik
-01689223-s	slk:lemma	ošúchaný
+01689223-a	slk:lemma	ošúchaný
 00811375-v	slk:lemma	vyhýbať sa
 00110533-r	slk:lemma	doma
 02230772-v	slk:lemma	odovzdávať
@@ -40217,7 +40217,7 @@
 00908351-v	slk:lemma	vyživovať
 09007471-n	slk:lemma	európska časť Ruska
 01088437-n	slk:lemma	podpora počas nezamestnanosti
-01483677-s	slk:lemma	statočný
+01483677-a	slk:lemma	statočný
 00735936-n	slk:lemma	pochybenie
 00003826-v	slk:lemma	štikútať
 03772077-n	slk:lemma	kláštorný chrám
@@ -40232,7 +40232,7 @@
 05010627-n	slk:lemma	odrazivosť
 08916111-n	slk:lemma	Adrianopolis
 09840050-n	slk:lemma	herec
-01199083-s	slk:lemma	všelijaký
+01199083-a	slk:lemma	všelijaký
 00775156-v	slk:lemma	hašteriť sa
 02564674-v	slk:lemma	chrániť
 03405725-n	slk:lemma	kus nábytku
@@ -40250,17 +40250,17 @@
 02163982-n	slk:lemma	rad chrobáky
 05794403-n	slk:lemma	odôvodnenie
 07516756-n	slk:lemma	zlá nálada
-01975671-s	slk:lemma	vlastný
+01975671-a	slk:lemma	vlastný
 09503877-n	slk:lemma	nadprirodzené javy
-02378496-s	slk:lemma	simultánny
+02378496-a	slk:lemma	simultánny
 05241072-n	slk:lemma	kožná bunka
 03264542-n	slk:lemma	lem
 05274590-n	slk:lemma	etmoidálna kosť
 02012344-v	slk:lemma	preložiť
 00264386-v	slk:lemma	zvýšiť
 05820620-n	slk:lemma	ilustrácia
-00049016-s	slk:lemma	prídavný
-01581305-s	slk:lemma	nadbytočný
+00049016-a	slk:lemma	prídavný
+01581305-a	slk:lemma	nadbytočný
 01671039-v	slk:lemma	uštrikovať
 05616786-n	slk:lemma	riešenie
 02599636-v	slk:lemma	vykonávať
@@ -40280,7 +40280,7 @@
 14929662-n	slk:lemma	lamelová zmes
 02256354-v	slk:lemma	vyplácať
 02563327-v	slk:lemma	uskutočniť
-02295098-s	slk:lemma	spoľahlivý
+02295098-a	slk:lemma	spoľahlivý
 00806049-v	slk:lemma	poskytovať
 13736799-n	slk:lemma	polovička
 02702807-a	slk:lemma	kozmický
@@ -40306,11 +40306,11 @@
 04678908-n	slk:lemma	prezlečenie
 00359238-n	slk:lemma	zostrihávanie
 00069012-v	slk:lemma	stiecť
-01115635-s	slk:lemma	autentický
+01115635-a	slk:lemma	autentický
 10657969-n	slk:lemma	podielnik
 02269767-v	slk:lemma	redukovať
 02858816-a	slk:lemma	osobný
-00505410-s	slk:lemma	bezkonkurenčný
+00505410-a	slk:lemma	bezkonkurenčný
 00376400-n	slk:lemma	pretrhnutie
 02375131-v	slk:lemma	zúčastňovať sa
 07407137-n	slk:lemma	záplava
@@ -40326,13 +40326,13 @@
 07024929-n	slk:lemma	koncertná hudba
 06791372-n	slk:lemma	signál
 02657219-v	slk:lemma	rovnať sa
-01885991-s	slk:lemma	bezpečný
+01885991-a	slk:lemma	bezpečný
 07328305-n	slk:lemma	parameter
 08380768-n	slk:lemma	riaditeľská rada
 03974769-n	slk:lemma	špička strelnej zbrane
 06574473-n	slk:lemma	ovládač
 07961480-n	slk:lemma	kumulácia
-00966753-s	slk:lemma	cudzí
+00966753-a	slk:lemma	cudzí
 00763399-v	slk:lemma	stanoviť
 03452741-n	slk:lemma	klavír typu grand piano
 04721058-n	slk:lemma	neprimeranosť
@@ -40363,10 +40363,10 @@
 06135806-n	slk:lemma	náuka o meraní
 00632627-v	slk:lemma	logicky vyjadriť
 07120524-n	slk:lemma	pokrik
-01393483-s	slk:lemma	nepatrný
+01393483-a	slk:lemma	nepatrný
 08307589-n	slk:lemma	skupinové stretnutie
 00384620-v	slk:lemma	zlepšiť
-01593079-s	slk:lemma	jednoduchý
+01593079-a	slk:lemma	jednoduchý
 07286014-n	slk:lemma	náznak
 04535153-n	slk:lemma	vigneta
 14910748-n	slk:lemma	hydrid
@@ -40375,7 +40375,7 @@
 01761706-v	slk:lemma	rozochvievať
 00698855-v	slk:lemma	rozriešiť
 01392237-v	slk:lemma	otrieť
-02462375-s	slk:lemma	zinscenovaný
+02462375-a	slk:lemma	zinscenovaný
 13100677-n	slk:lemma	úponkovitá rastlina
 04270147-n	slk:lemma	lopatka
 03333851-n	slk:lemma	budiaci magnet
@@ -40398,7 +40398,7 @@
 01015244-v	slk:lemma	podať svedectvo
 04346679-n	slk:lemma	ihla
 06459323-n	slk:lemma	Kniha proroka Barucha
-00890351-s	slk:lemma	rovnocenný
+00890351-a	slk:lemma	rovnocenný
 07060440-n	slk:lemma	country
 00352826-v	slk:lemma	skončiť
 04559451-n	slk:lemma	kohútik
@@ -40415,15 +40415,15 @@
 01704761-a	slk:lemma	zreteľný
 02884450-n	slk:lemma	(mať v rukách) opraty
 06694540-n	slk:lemma	doporučenie (dobré slovo)
-00595299-s	slk:lemma	ustavičný
+00595299-a	slk:lemma	ustavičný
 09774266-n	slk:lemma	znalec
-02502578-s	slk:lemma	bezcenný
+02502578-a	slk:lemma	bezcenný
 01976220-v	slk:lemma	spúšťať
 09304465-n	slk:lemma	diera
 08052413-n	slk:lemma	impérium
-01216981-s	slk:lemma	predstieraný
+01216981-a	slk:lemma	predstieraný
 02496816-v	slk:lemma	udržať na uzde
-00959244-s	slk:lemma	stály
+00959244-a	slk:lemma	stály
 03391770-n	slk:lemma	rámec
 00037200-n	slk:lemma	uznanie
 09287968-n	slk:lemma	geologický útvar
@@ -40442,7 +40442,7 @@
 04557308-n	slk:lemma	farba vyrobená na vodnej báze
 00249313-v	slk:lemma	ustupovať
 07644382-n	slk:lemma	vtáčie mäso
-00331167-s	slk:lemma	centrálny
+00331167-a	slk:lemma	centrálny
 04897762-n	slk:lemma	spôsoby
 00806075-n	slk:lemma	vnútorná kontrola
 00588221-v	slk:lemma	chápať
@@ -40454,10 +40454,10 @@
 02969886-n	slk:lemma	nosič na aute
 14513259-n	slk:lemma	pozadie
 01552519-v	slk:lemma	odstrihnúť
-01854129-s	slk:lemma	podporný
+01854129-a	slk:lemma	podporný
 00095320-r	slk:lemma	nadol
 10021892-n	slk:lemma	doktor
-02448324-s	slk:lemma	citlivý
+02448324-a	slk:lemma	citlivý
 01030132-v	slk:lemma	vymenovávať
 13401013-n	slk:lemma	zadržovacie právo
 00949134-n	slk:lemma	užitie
@@ -40469,7 +40469,7 @@
 14475405-n	slk:lemma	smola
 09997622-n	slk:lemma	dlžník
 00622384-v	slk:lemma	zarážať
-01427333-s	slk:lemma	nákazlivý
+01427333-a	slk:lemma	nákazlivý
 05397333-n	slk:lemma	cieva
 05770664-n	slk:lemma	vyšší kognitívny proces
 13809920-n	slk:lemma	detail
@@ -40485,8 +40485,8 @@
 07480790-n	slk:lemma	cit
 08573258-n	slk:lemma	polárna oblasť
 06793817-n	slk:lemma	divadelný plagát
-01751609-s	slk:lemma	neopotrebovaný
-01625492-s	slk:lemma	mŕtvolný
+01751609-a	slk:lemma	neopotrebovaný
+01625492-a	slk:lemma	mŕtvolný
 02536329-v	slk:lemma	poťahovať nitky
 12702443-n	slk:lemma	čeľaď Oxalidaceae
 04910848-n	slk:lemma	dandizmus
@@ -40503,7 +40503,7 @@
 05148699-n	slk:lemma	úžitok
 15163797-n	slk:lemma	Pánov deň
 01234729-n	slk:lemma	odplata
-00574884-s	slk:lemma	staromódny
+00574884-a	slk:lemma	staromódny
 05280831-n	slk:lemma	kĺbna jamka
 09364778-n	slk:lemma	Namoi
 01534147-v	slk:lemma	špiniť sa
@@ -40516,7 +40516,7 @@
 00041188-n	slk:lemma	hra
 00466053-v	slk:lemma	usporiadať
 06504462-n	slk:lemma	správa
-02369179-s	slk:lemma	octový
+02369179-a	slk:lemma	octový
 03906997-n	slk:lemma	pero
 05013809-n	slk:lemma	teplota vznietenia
 02081578-v	slk:lemma	nechať
@@ -40555,16 +40555,16 @@
 03984381-n	slk:lemma	terasa
 02798370-a	slk:lemma	spoločenský
 01771390-v	slk:lemma	pohýnať (niekým)
-01735346-s	slk:lemma	materský
+01735346-a	slk:lemma	materský
 14816745-n	slk:lemma	palivo
 01813499-v	slk:lemma	spôsobiť radosť
-01132366-s	slk:lemma	korupčný
+01132366-a	slk:lemma	korupčný
 02787831-a	slk:lemma	rekreačný
 06263369-n	slk:lemma	noviny
 12280487-n	slk:lemma	čeľaď brezovité
 01639765-n	slk:lemma	žaba
 02452885-v	slk:lemma	nedovoliť
-01119661-s	slk:lemma	sklený
+01119661-a	slk:lemma	sklený
 08702402-n	slk:lemma	kraj Južnej Ameriky
 09870208-n	slk:lemma	boxer
 02131279-v	slk:lemma	kontrolovať
@@ -40576,7 +40576,7 @@
 07401960-n	slk:lemma	príliv
 04329958-n	slk:lemma	dvojité okno
 13128003-n	slk:lemma	vrcholec stromu
-00798491-s	slk:lemma	pijanský
+00798491-a	slk:lemma	pijanský
 07929351-n	slk:lemma	zrnko kávy
 01605753-a	slk:lemma	severný
 09191875-n	slk:lemma	Alabama
@@ -40593,10 +40593,10 @@
 06392935-n	slk:lemma	klauzula
 13933391-n	slk:lemma	konflikt záujmov
 01449974-v	slk:lemma	niesť
-02528566-s	slk:lemma	vypudený
-00440292-s	slk:lemma	obmedzený
+02528566-a	slk:lemma	vypudený
+00440292-a	slk:lemma	obmedzený
 15246258-n	slk:lemma	chvíľka
-01726859-s	slk:lemma	prihorlivý
+01726859-a	slk:lemma	prihorlivý
 09730533-n	slk:lemma	Škót
 03416329-n	slk:lemma	medzera
 01128193-v	slk:lemma	chrániť
@@ -40611,7 +40611,7 @@
 07191279-n	slk:lemma	dopyt
 08072536-n	slk:lemma	jednotný investičný fond
 08081403-n	slk:lemma	defenzíva
-01580775-s	slk:lemma	nevyhnutný
+01580775-a	slk:lemma	nevyhnutný
 01280014-v	slk:lemma	kriviť
 04796946-n	slk:lemma	nezvyčajnosť
 09091285-n	slk:lemma	Alexandria
@@ -40624,7 +40624,7 @@
 02231661-v	slk:lemma	odovzdať
 02409702-n	slk:lemma	rod Bibos
 02755352-n	slk:lemma	spona
-00304670-s	slk:lemma	búrlivý
+00304670-a	slk:lemma	búrlivý
 07731122-n	slk:lemma	náhrada kávy
 01789064-n	slk:lemma	Galliformes
 03849814-n	slk:lemma	opera
@@ -40674,18 +40674,18 @@
 14781631-n	slk:lemma	krveľ
 01682229-a	slk:lemma	orientovaný
 01511706-v	slk:lemma	poháňať
-01141595-s	slk:lemma	drevený
+01141595-a	slk:lemma	drevený
 02386853-n	slk:lemma	záprahový kôň
 00054821-n	slk:lemma	evakuácia
-01440574-s	slk:lemma	pomerne dlhý
-02363811-s	slk:lemma	zaočkovaný
+01440574-a	slk:lemma	pomerne dlhý
+02363811-a	slk:lemma	zaočkovaný
 00965687-v	slk:lemma	ohlásiť sa
 00531489-v	slk:lemma	znížiť
 01532589-v	slk:lemma	vyčistiť
 08056231-n	slk:lemma	závod
 06608143-n	slk:lemma	táranina
 08080947-n	slk:lemma	jednotka
-00522463-s	slk:lemma	dôkladný
+00522463-a	slk:lemma	dôkladný
 08616311-n	slk:lemma	trasa
 01873294-v	slk:lemma	posunúť
 02754197-a	slk:lemma	právny
@@ -40713,7 +40713,7 @@
 06392935-n	slk:lemma	článok
 13323988-n	slk:lemma	školné
 00694681-n	slk:lemma	spravodlivosť
-01603518-s	slk:lemma	juhovýchodný
+01603518-a	slk:lemma	juhovýchodný
 02367032-v	slk:lemma	odstúpiť
 00995119-a	slk:lemma	priaznivý
 06449735-n	slk:lemma	Starý zákon
@@ -40723,12 +40723,12 @@
 05750657-n	slk:lemma	móda
 02834778-n	slk:lemma	bicykel
 00599720-v	slk:lemma	poúčať
-00170847-s	slk:lemma	atraktívny
+00170847-a	slk:lemma	atraktívny
 02719930-v	slk:lemma	patriť (niekam)
 01067362-n	slk:lemma	odklad
-01880918-s	slk:lemma	špatný
+01880918-a	slk:lemma	špatný
 00910555-v	slk:lemma	namietať
-01788048-s	slk:lemma	károvaný
+01788048-a	slk:lemma	károvaný
 05529159-n	slk:lemma	hrdelná časť hltanu
 04693900-n	slk:lemma	škvrna
 02673134-v	slk:lemma	vyrovnať
@@ -40755,7 +40755,7 @@
 07285403-n	slk:lemma	zážitok
 03054605-n	slk:lemma	trieštivá bomba plnená guličkami
 00789138-v	slk:lemma	preskúmať
-01936528-s	slk:lemma	zdanlivý
+01936528-a	slk:lemma	zdanlivý
 02493260-v	slk:lemma	popíjať
 08276342-n	slk:lemma	vzdelávacia inštitúcia
 14842091-n	slk:lemma	výdych
@@ -40774,12 +40774,12 @@
 01378331-v	slk:lemma	posypať
 10652837-n	slk:lemma	prednosta stanice
 03932203-n	slk:lemma	úryvok
-01975671-s	slk:lemma	príslušný
+01975671-a	slk:lemma	príslušný
 08500213-n	slk:lemma	hlbina
 00007347-n	slk:lemma	pôvodca
 01947352-v	slk:lemma	doplávať na chrbáte
 02974697-n	slk:lemma	puzdro
-00211564-s	slk:lemma	lisý
+00211564-a	slk:lemma	lisý
 09428967-n	slk:lemma	naplavenina
 00181576-r	slk:lemma	jemne
 04953380-n	slk:lemma	záblesk
@@ -40787,8 +40787,8 @@
 13616054-n	slk:lemma	priestorová miera obsahu
 02210855-v	slk:lemma	získavať
 01845272-n	slk:lemma	rad Anseriformes
-00833018-s	slk:lemma	v činnosti
-02384077-s	slk:lemma	veľavravný
+00833018-a	slk:lemma	v činnosti
+02384077-a	slk:lemma	veľavravný
 01095753-n	slk:lemma	obchodná činnosť
 05057917-n	slk:lemma	SHF
 02210855-v	slk:lemma	získať
@@ -40806,8 +40806,8 @@
 02066939-v	slk:lemma	tiecť prúdom
 05638987-n	slk:lemma	umelecké majtrovstvo
 00072012-v	slk:lemma	počúrať
-00704360-s	slk:lemma	osamelý
-02132735-s	slk:lemma	intímny
+00704360-a	slk:lemma	osamelý
+02132735-a	slk:lemma	intímny
 00880269-n	slk:lemma	pozorovanie
 08710325-n	slk:lemma	St. John's, Saint John's
 00163704-r	slk:lemma	hore nohami
@@ -40815,7 +40815,7 @@
 03668642-n	slk:lemma	podoba
 08613000-n	slk:lemma	pobrežie
 07150023-n	slk:lemma	rokovanie o kolektívnej zmluve
-01264913-s	slk:lemma	žartovný
+01264913-a	slk:lemma	žartovný
 00207668-r	slk:lemma	oddelene
 02906254-n	slk:lemma	bronzová medaila
 08721559-n	slk:lemma	Gran Santiago
@@ -40825,7 +40825,7 @@
 00435778-n	slk:lemma	gymnastické cvičenie
 10059582-n	slk:lemma	nadšenenc
 03132715-a	slk:lemma	amónny
-00811536-s	slk:lemma	nedočkavý
+00811536-a	slk:lemma	nedočkavý
 00604576-v	slk:lemma	zapamätávať
 10119874-n	slk:lemma	predák partie
 00017881-r	slk:lemma	v tom čase
@@ -40858,7 +40858,7 @@
 00811171-v	slk:lemma	obísť
 00258904-r	slk:lemma	po prsia
 13977184-n	slk:lemma	neporiadok
-01435060-s	slk:lemma	s dlhým doletom
+01435060-a	slk:lemma	s dlhým doletom
 08739829-n	slk:lemma	Panamská kanálová zóna
 09364954-n	slk:lemma	Nan
 00802238-n	slk:lemma	riziko
@@ -40872,13 +40872,13 @@
 04148054-n	slk:lemma	nožnice
 02678839-v	slk:lemma	upútať
 10388924-n	slk:lemma	majiteľ
-01393483-s	slk:lemma	maličký
+01393483-a	slk:lemma	maličký
 01060924-n	slk:lemma	dodávanie
 02066510-v	slk:lemma	hýbať sa
 03014705-n	slk:lemma	kufor
-01993408-s	slk:lemma	slušný
+01993408-a	slk:lemma	slušný
 00941990-v	slk:lemma	hovoriť
-02257856-s	slk:lemma	priateľský
+02257856-a	slk:lemma	priateľský
 03664943-n	slk:lemma	väzivo
 08418420-n	slk:lemma	komerčná banka
 08653474-n	slk:lemma	prázdno
@@ -40895,7 +40895,7 @@
 09974648-n	slk:lemma	robotník
 03839993-n	slk:lemma	brzda
 02974023-a	slk:lemma	barokový
-01756292-s	slk:lemma	prchavý
+01756292-a	slk:lemma	prchavý
 05225602-n	slk:lemma	vnútorná stavba tela
 02493030-v	slk:lemma	navštíviť
 01203277-n	slk:lemma	riadená diskusia o riešení nových problémov
@@ -40904,7 +40904,7 @@
 00875394-v	slk:lemma	navrhnúť
 01759326-v	slk:lemma	vzbudiť
 00877327-v	slk:lemma	zisťovať
-00218950-s	slk:lemma	vzhľadný
+00218950-a	slk:lemma	vzhľadný
 01761706-v	slk:lemma	zalomcovať
 00859325-v	slk:lemma	povzbudiť
 08250501-n	slk:lemma	rocková skupina
@@ -40916,14 +40916,14 @@
 01523986-v	slk:lemma	stáčať
 01410223-v	slk:lemma	útočiť
 00817311-v	slk:lemma	pripúšťať
-00874226-s	slk:lemma	veselý
+00874226-a	slk:lemma	veselý
 04304375-n	slk:lemma	štartér
 05675905-n	slk:lemma	vedomie
-01126291-s	slk:lemma	príšerný
+01126291-a	slk:lemma	príšerný
 02260362-v	slk:lemma	kšeftovať
 02890874-a	slk:lemma	horský
 13263779-n	slk:lemma	odkázaný majetok
-00167077-s	slk:lemma	charizmatický
+00167077-a	slk:lemma	charizmatický
 03177349-n	slk:lemma	úložné miesto
 13746672-n	slk:lemma	jedenásť
 04074963-n	slk:lemma	diaľkový ovládač
@@ -40937,7 +40937,7 @@
 14414294-n	slk:lemma	oddelenie
 02247977-v	slk:lemma	znovu získavať
 06636524-n	slk:lemma	zápisník
-02514380-s	slk:lemma	odporný
+02514380-a	slk:lemma	odporný
 05905348-n	slk:lemma	schéma
 02189168-v	slk:lemma	začuť
 13086753-n	slk:lemma	úroda ovocia
@@ -40960,7 +40960,7 @@
 08747494-n	slk:lemma	Britská Západná India
 04971928-n	slk:lemma	hnedá farba
 00751145-n	slk:lemma	falšovanie
-00488998-s	slk:lemma	nezvyčajný
+00488998-a	slk:lemma	nezvyčajný
 05016171-n	slk:lemma	vysoká teplota
 03832673-n	slk:lemma	prenosný počítač
 06887726-n	slk:lemma	prejav
@@ -40969,7 +40969,7 @@
 01203277-n	slk:lemma	brainstorming
 05132340-n	slk:lemma	úroveň mora
 00104528-r	slk:lemma	nanajvýš
-00059782-s	slk:lemma	husto pokrytý
+00059782-a	slk:lemma	husto pokrytý
 13742573-n	slk:lemma	jednotka
 00140566-r	slk:lemma	neprirodzene
 02545578-v	slk:lemma	riskovať
@@ -40977,12 +40977,12 @@
 00013615-v	slk:lemma	vystupovať
 00767122-v	slk:lemma	presviedčať k zmene názoru
 04494204-n	slk:lemma	elektrónka
-01523249-s	slk:lemma	ovládateľný
+01523249-a	slk:lemma	ovládateľný
 11427619-n	slk:lemma	polárna žiara
 05031560-n	slk:lemma	chrabrosť
 10028123-n	slk:lemma	bojovník za mier
 04892794-n	slk:lemma	obozretnosť
-01497245-s	slk:lemma	hutný
+01497245-a	slk:lemma	hutný
 04762633-n	slk:lemma	špecifikum
 12313005-n	slk:lemma	podtrieda Hamamelidae
 00896141-v	slk:lemma	ospravedlniť
@@ -40991,8 +40991,8 @@
 13246662-n	slk:lemma	pozemky
 00166172-n	slk:lemma	ťah
 02705428-v	slk:lemma	predlžovať
-00309740-s	slk:lemma	istý
-00402855-s	slk:lemma	jasný
+00309740-a	slk:lemma	istý
+00402855-a	slk:lemma	jasný
 01033527-v	slk:lemma	pokrývať (tematicky)
 00724081-a	slk:lemma	spoľahlivý
 01116380-a	slk:lemma	sfalšovaný
@@ -41000,12 +41000,12 @@
 03878066-n	slk:lemma	palác
 00437125-v	slk:lemma	diverzifikovať
 06364329-n	slk:lemma	literárny text
-00979031-s	slk:lemma	bezprostredný
+00979031-a	slk:lemma	bezprostredný
 07054433-n	slk:lemma	tanečná hudba
 01808374-v	slk:lemma	hnusiť sa
 06832248-n	slk:lemma	k
 13396054-n	slk:lemma	finančné záväzky
-01854129-s	slk:lemma	vedľajší
+01854129-a	slk:lemma	vedľajší
 00059989-n	slk:lemma	únik
 06780882-n	slk:lemma	zábava
 00039318-r	slk:lemma	zreteľne
@@ -41037,7 +41037,7 @@
 09393605-n	slk:lemma	nížina
 00212414-v	slk:lemma	zachovať si
 14285662-n	slk:lemma	poranenie
-02421364-s	slk:lemma	zdržanlivý
+02421364-a	slk:lemma	zdržanlivý
 14831338-n	slk:lemma	odpadová DNA
 06514093-n	slk:lemma	výpoveď
 01150200-n	slk:lemma	zbavenie
@@ -41048,7 +41048,7 @@
 05623628-n	slk:lemma	dosah
 01015244-v	slk:lemma	prinášať dôkaz(y)
 00891216-v	slk:lemma	kryť
-01046226-s	slk:lemma	ľudový
+01046226-a	slk:lemma	ľudový
 00312380-v	slk:lemma	zotmiť sa
 07179342-n	slk:lemma	kompromis
 01816431-v	slk:lemma	uspokojovať
@@ -41056,13 +41056,13 @@
 01651293-v	slk:lemma	ujať sa
 06768901-n	slk:lemma	nové vyhlásenie
 01534147-v	slk:lemma	zamazať
-01788048-s	slk:lemma	pepita
+01788048-a	slk:lemma	pepita
 07515560-n	slk:lemma	pohoda
-00361125-s	slk:lemma	čistý
+00361125-a	slk:lemma	čistý
 14310504-n	slk:lemma	tetanus
-01443097-s	slk:lemma	letmý
+01443097-a	slk:lemma	letmý
 04005630-n	slk:lemma	väzenie
-02003023-s	slk:lemma	do každého počasia
+02003023-a	slk:lemma	do každého počasia
 02087956-a	slk:lemma	spôsobilý pre námornú plavbu
 00193486-v	slk:lemma	zlúčiť
 00167385-v	slk:lemma	naštrbiť (niečo)
@@ -41072,7 +41072,7 @@
 01524885-n	slk:lemma	podrad Oscines
 09851575-n	slk:lemma	zasnúbený
 00069173-n	slk:lemma	porušenie zmluvy
-01395821-s	slk:lemma	poslušný
+01395821-a	slk:lemma	poslušný
 15141894-n	slk:lemma	trvanlivosť
 13126684-n	slk:lemma	koreňové vlásky
 00213052-n	slk:lemma	postúpenie
@@ -41085,9 +41085,9 @@
 09014586-n	slk:lemma	Moldavská republika
 00965404-n	slk:lemma	násilný čin
 01955508-v	slk:lemma	posielať (za adresátom)
-01950198-s	slk:lemma	ťarbavý
+01950198-a	slk:lemma	ťarbavý
 02165304-v	slk:lemma	nakuknúť
-01368464-s	slk:lemma	náhrobný
+01368464-a	slk:lemma	náhrobný
 02320374-v	slk:lemma	započítať si
 01993549-v	slk:lemma	preháňať
 01017826-v	slk:lemma	uplatňovať nárok
@@ -41098,7 +41098,7 @@
 02460199-v	slk:lemma	prenajímať
 01886728-v	slk:lemma	priplávať pozdĺž pobrežia
 02471327-v	slk:lemma	verbovať
-02378347-s	slk:lemma	existujúci súčasne
+02378347-a	slk:lemma	existujúci súčasne
 00770437-v	slk:lemma	zapríčiniť
 08266070-n	slk:lemma	profesionálna organizácia
 01465994-n	slk:lemma	kmeň chordáty
@@ -41123,7 +41123,7 @@
 02807731-n	slk:lemma	kúpeľňa
 00027384-r	slk:lemma	predsa
 05128870-n	slk:lemma	výmera v akroch
-00282675-s	slk:lemma	jemný
+00282675-a	slk:lemma	jemný
 09734294-n	slk:lemma	Thajčan
 00896141-v	slk:lemma	obhajovať
 00418025-n	slk:lemma	zlé zaobchádzanie
@@ -41151,16 +41151,16 @@
 05985381-n	slk:lemma	náuka
 04518764-n	slk:lemma	cestovná batožina
 03073977-n	slk:lemma	pilier
-00682521-s	slk:lemma	celkom hluchý
+00682521-a	slk:lemma	celkom hluchý
 08776687-n	slk:lemma	Ekvádor
 07969695-n	slk:lemma	rodina
 02050132-v	slk:lemma	prejsť
 05816790-n	slk:lemma	údaj meradla
 09344863-n	slk:lemma	Mackenzie
-01149358-s	slk:lemma	usmievavý
+01149358-a	slk:lemma	usmievavý
 14917859-n	slk:lemma	magnetický atrament
 09968259-n	slk:lemma	kostymérka
-02587738-s	slk:lemma	cenný
+02587738-a	slk:lemma	cenný
 07291794-n	slk:lemma	konečná etapa
 09304750-n	slk:lemma	dutina
 05269901-n	slk:lemma	kosť
@@ -41175,7 +41175,7 @@
 08054721-n	slk:lemma	finančná inštitúcia
 01058574-v	slk:lemma	nadhodiť
 02141973-v	slk:lemma	zvýrazniť
-01917594-s	slk:lemma	pochybný
+01917594-a	slk:lemma	pochybný
 02758581-v	slk:lemma	zmrznúť
 01136519-n	slk:lemma	usporiadanie
 02392762-v	slk:lemma	umiestniť
@@ -41188,12 +41188,12 @@
 02858231-a	slk:lemma	filozofický
 00284544-n	slk:lemma	vychádzka
 05964445-n	slk:lemma	vláda väčšiny
-00065064-s	slk:lemma	plusový
+00065064-a	slk:lemma	plusový
 00510189-n	slk:lemma	hýrenie
 02861617-a	slk:lemma	obrázkový
 00310201-n	slk:lemma	odbočka
 14685641-n	slk:lemma	mestský plyn
-00264178-s	slk:lemma	odvážny
+00264178-a	slk:lemma	odvážny
 01448100-v	slk:lemma	vliecť
 07288639-n	slk:lemma	spoločenská udalosť
 02470451-n	slk:lemma	vyššie primáty
@@ -41204,29 +41204,29 @@
 00653620-v	slk:lemma	prirovnávať
 10628644-n	slk:lemma	panovník
 06841365-n	slk:lemma	interpunkčné znamienko
-02114613-s	slk:lemma	hnisavý
+02114613-a	slk:lemma	hnisavý
 02471327-v	slk:lemma	naverbovať
 05125377-n	slk:lemma	sféra pôsobenia
 06526124-n	slk:lemma	poistenie na dodatočné pokrytie špecifického poistenia
 13745086-n	slk:lemma	VIII
 04544138-n	slk:lemma	paženie
-00587376-s	slk:lemma	leptavý
+00587376-a	slk:lemma	leptavý
 00911048-n	slk:lemma	konštrukcia
 01790020-v	slk:lemma	znervózniť
 02409702-n	slk:lemma	Bibos
 05722427-n	slk:lemma	dotyk
 00222485-n	slk:lemma	ničenie seba samého
-02547862-s	slk:lemma	zarosený
+02547862-a	slk:lemma	zarosený
 10548227-n	slk:lemma	predavačka
 04495843-n	slk:lemma	remorkér
-02038126-s	slk:lemma	rozložitý
+02038126-a	slk:lemma	rozložitý
 00158309-r	slk:lemma	presne
 08621598-n	slk:lemma	pozícia
 02062744-n	slk:lemma	veľryba
 04360501-n	slk:lemma	podpera
 12319687-n	slk:lemma	rod orechovec
-01453809-s	slk:lemma	hlučný
-02390724-s	slk:lemma	búrlivý
+01453809-a	slk:lemma	hlučný
+02390724-a	slk:lemma	búrlivý
 00059086-r	slk:lemma	veľa
 08356903-n	slk:lemma	súdna zložka
 00522145-n	slk:lemma	ukázanie
@@ -41258,32 +41258,32 @@
 00876332-v	slk:lemma	predkladať závet
 02910542-n	slk:lemma	plátno
 14980579-n	slk:lemma	ropa
-01769378-s	slk:lemma	privátny
+01769378-a	slk:lemma	privátny
 00912048-v	slk:lemma	skríknuť
-01520091-s	slk:lemma	kompletný
+01520091-a	slk:lemma	kompletný
 07510495-n	slk:lemma	ohromenie
-01185916-s	slk:lemma	súvislý
+01185916-a	slk:lemma	súvislý
 00088120-v	slk:lemma	prechladnúť
 13526110-n	slk:lemma	organický proces
 08071229-n	slk:lemma	investičný fond
 02439929-n	slk:lemma	labka
-00035978-s	slk:lemma	rušný
+00035978-a	slk:lemma	rušný
 00041954-r	slk:lemma	v zásade
 02457825-v	slk:lemma	nerešpektovať
 00340403-r	slk:lemma	priamo
 15297472-n	slk:lemma	skúšobná lehota
-01916784-s	slk:lemma	diskutabilný
+01916784-a	slk:lemma	diskutabilný
 03586911-n	slk:lemma	železiareň
 00908621-v	slk:lemma	pravidelne navštevovať
 05035961-n	slk:lemma	zápal
-02226979-s	slk:lemma	perfektný
+02226979-a	slk:lemma	perfektný
 06389398-n	slk:lemma	okraj
 08796219-n	slk:lemma	Golgotha
-00798103-s	slk:lemma	opitý namol
+00798103-a	slk:lemma	opitý namol
 14857897-n	slk:lemma	trosky
 03721047-n	slk:lemma	guľôčka
 07249817-n	slk:lemma	podpora predaja
-01881478-s	slk:lemma	nesprávny
+01881478-a	slk:lemma	nesprávny
 09375891-n	slk:lemma	rieka Ob
 02531625-v	slk:lemma	vyskúšať
 09381048-n	slk:lemma	Ouse
@@ -41297,14 +41297,14 @@
 05661996-n	slk:lemma	systém
 00273133-r	slk:lemma	šialene
 13836841-n	slk:lemma	obchodný vzťah
-00176387-s	slk:lemma	nádejný
+00176387-a	slk:lemma	nádejný
 05934673-n	slk:lemma	bokorys
 05718254-n	slk:lemma	zvuk
 05031849-n	slk:lemma	pevnosť
 05791452-n	slk:lemma	priorita
 03945167-n	slk:lemma	fajka
 09972661-n	slk:lemma	kovboj
-02450512-s	slk:lemma	toxický
+02450512-a	slk:lemma	toxický
 05704096-n	slk:lemma	pozor
 09399592-n	slk:lemma	výčnelok
 05465567-n	slk:lemma	nervová bunka
@@ -41313,7 +41313,7 @@
 00548326-n	slk:lemma	hranie
 06832248-n	slk:lemma	K
 01664172-v	slk:lemma	variť si
-00587376-s	slk:lemma	rozleptávajúci
+00587376-a	slk:lemma	rozleptávajúci
 08740875-n	slk:lemma	Mexiko
 02401031-n	slk:lemma	zástupca čeľade turovité
 02206619-v	slk:lemma	zaberať
@@ -41322,7 +41322,7 @@
 04960582-n	slk:lemma	uhľovočierna
 13969101-n	slk:lemma	pokoj
 06789411-n	slk:lemma	cirkevná doktrína
-02339577-s	slk:lemma	vysoký
+02339577-a	slk:lemma	vysoký
 08847694-n	slk:lemma	Arabský poloostrov
 13148791-n	slk:lemma	čeľaď Piperaceae
 00945401-n	slk:lemma	vyhľadávanie
@@ -41344,21 +41344,21 @@
 00512522-n	slk:lemma	flirtovanie
 00112843-r	slk:lemma	nanovo
 05454070-n	slk:lemma	erytrocyt
-02229961-s	slk:lemma	ponižujúci
+02229961-a	slk:lemma	ponižujúci
 13165727-n	slk:lemma	konár
-01024228-s	slk:lemma	ohybný
+01024228-a	slk:lemma	ohybný
 10006511-n	slk:lemma	následník
 10720453-n	slk:lemma	díler
 03708425-n	slk:lemma	dynamo
 01846658-v	slk:lemma	priplaviť sa
-00338013-s	slk:lemma	neistý
+00338013-a	slk:lemma	neistý
 14603798-n	slk:lemma	plyn proti občianskym nepokojom
 10030277-n	slk:lemma	dramatik
 02702807-a	slk:lemma	vesmírny
 09161615-n	slk:lemma	Guyanská vysočina
 00509566-n	slk:lemma	hazardná hra o peniaze
 00620752-n	slk:lemma	výkon práce
-02558528-s	slk:lemma	výdatný
+02558528-a	slk:lemma	výdatný
 04262161-n	slk:lemma	ozvučnica
 00696414-v	slk:lemma	obzrieť sa
 06405589-n	slk:lemma	vlastnoručný podpis
@@ -41408,7 +41408,7 @@
 00671335-v	slk:lemma	odhadovať nízko
 02682773-v	slk:lemma	chrániť
 09166127-n	slk:lemma	Nizozemsko
-00218305-s	slk:lemma	okúzľujúci
+00218305-a	slk:lemma	okúzľujúci
 06491786-n	slk:lemma	zoznam
 00699815-v	slk:lemma	stanovovať sa
 08960548-n	slk:lemma	Lichtenštajnsko
@@ -41416,7 +41416,7 @@
 02566528-v	slk:lemma	prekračovať
 00796976-v	slk:lemma	vyjadriť pohŕdanie
 08588916-n	slk:lemma	ionosféra
-00067379-s	slk:lemma	lepší
+00067379-a	slk:lemma	lepší
 02586619-v	slk:lemma	panovať
 01873784-v	slk:lemma	povzbudiť
 08722270-n	slk:lemma	Vina del Mar
@@ -41424,11 +41424,11 @@
 01804595-v	slk:lemma	získavať si (niečiu priazeň)
 00137313-v	slk:lemma	zapôsobiť
 01041415-v	slk:lemma	zakývať
-01499269-s	slk:lemma	nezmerateľný
+01499269-a	slk:lemma	nezmerateľný
 09996481-n	slk:lemma	hluchá osoba
 00066025-v	slk:lemma	zamravčať
 01850315-v	slk:lemma	presúvať sa
-00309620-s	slk:lemma	detailný
+00309620-a	slk:lemma	detailný
 00746232-n	slk:lemma	zneuctenie
 01587062-v	slk:lemma	obklopiť
 02420789-v	slk:lemma	zúčastniť sa brigády
@@ -41437,12 +41437,12 @@
 09145083-n	slk:lemma	Laredo
 08401248-n	slk:lemma	odnož
 04688246-n	slk:lemma	atraktívnosť
-00370869-s	slk:lemma	modrý
+00370869-a	slk:lemma	modrý
 00019792-v	slk:lemma	napádať
 00957176-a	slk:lemma	neférový
-00326608-s	slk:lemma	impulzívny
+00326608-a	slk:lemma	impulzívny
 04891333-n	slk:lemma	pochabosť
-01982957-s	slk:lemma	prestížny
+01982957-a	slk:lemma	prestížny
 06711855-n	slk:lemma	napomenutie
 01208708-v	slk:lemma	pokryť
 00656192-n	slk:lemma	domáca opatera
@@ -41450,7 +41450,7 @@
 15055442-n	slk:lemma	vodná para
 10258602-n	slk:lemma	udeľovateľ povolení
 01437888-v	slk:lemma	poslať
-00848983-s	slk:lemma	záväzný
+00848983-a	slk:lemma	záväzný
 09842047-n	slk:lemma	basketbalista
 00749376-v	slk:lemma	hovoriť cestu
 00634862-a	slk:lemma	napraviteľný
@@ -41458,7 +41458,7 @@
 02051694-v	slk:lemma	prejsť
 08266235-n	slk:lemma	tabuľka
 05309591-n	slk:lemma	tvrdé podnebie
-00608791-s	slk:lemma	neobvyklý
+00608791-a	slk:lemma	neobvyklý
 00069012-v	slk:lemma	prúdiť
 05456622-n	slk:lemma	tuková bunka
 00014285-r	slk:lemma	značne
@@ -41479,7 +41479,7 @@
 07848338-n	slk:lemma	maslo
 05282000-n	slk:lemma	spánková kosť
 05513302-n	slk:lemma	reprodukčný orgán
-01132366-s	slk:lemma	škodlivý
+01132366-a	slk:lemma	škodlivý
 01970826-v	slk:lemma	klesnúť
 07992450-n	slk:lemma	taxonomická jednotka
 00031921-n	slk:lemma	vzťah
@@ -41491,17 +41491,17 @@
 10752480-n	slk:lemma	podvedený
 08702402-n	slk:lemma	národ Južnej Ameriky
 08723006-n	slk:lemma	Čína
-01362387-s	slk:lemma	smutný
+01362387-a	slk:lemma	smutný
 03401129-n	slk:lemma	ukazovateľ zásoby paliva
 02755017-v	slk:lemma	neprijať
 00099089-v	slk:lemma	pokryť sa
 02136271-v	slk:lemma	odrážať sa
 00376106-v	slk:lemma	rozmraziť
-00309620-s	slk:lemma	podrobný
+00309620-a	slk:lemma	podrobný
 01604226-a	slk:lemma	severný
 01641914-v	slk:lemma	štartovať
 10533013-n	slk:lemma	súťažiaci
-00082034-s	slk:lemma	neoblomný
+00082034-a	slk:lemma	neoblomný
 02479990-v	slk:lemma	rozmiestňovať
 00869596-v	slk:lemma	škriepiť sa
 13905121-n	slk:lemma	incisura
@@ -41540,7 +41540,7 @@
 02136754-v	slk:lemma	odrážať
 14474264-n	slk:lemma	požehnanie
 02412440-n	slk:lemma	jahňa
-02018649-s	slk:lemma	prozaický
+02018649-a	slk:lemma	prozaický
 14439294-n	slk:lemma	reputácia
 00250570-r	slk:lemma	ročne
 02299801-v	slk:lemma	ponúkať vyššiu cenu
@@ -41550,7 +41550,7 @@
 08457976-n	slk:lemma	sled
 00165269-r	slk:lemma	v pravý čas
 06962600-n	slk:lemma	latinčina
-02418093-s	slk:lemma	mysliteľný
+02418093-a	slk:lemma	mysliteľný
 01698271-v	slk:lemma	komponovať
 05790944-n	slk:lemma	alternatíva
 02866578-n	slk:lemma	bomba
@@ -41558,7 +41558,7 @@
 04889779-n	slk:lemma	pokora
 01150559-v	slk:lemma	mieriť
 00118268-n	slk:lemma	červeň
-00015247-s	slk:lemma	bujný
+00015247-a	slk:lemma	bujný
 04348184-n	slk:lemma	ponorná bojová loď
 01098706-v	slk:lemma	odvádzať
 07135080-n	slk:lemma	rozprávanie
@@ -41566,7 +41566,7 @@
 01146576-n	slk:lemma	odňatie slobody
 02954340-n	slk:lemma	čiapka
 13800539-n	slk:lemma	koordinácia
-01372948-s	slk:lemma	vľúdny
+01372948-a	slk:lemma	vľúdny
 01981543-n	slk:lemma	čeľaď Majidae
 01176335-n	slk:lemma	ruvačka
 00867644-v	slk:lemma	odôvodňovať
@@ -41575,7 +41575,7 @@
 02166460-v	slk:lemma	skúmať
 01236173-n	slk:lemma	svár
 07303697-n	slk:lemma	ohnivé peklo
-00012362-s	slk:lemma	pojmový
+00012362-a	slk:lemma	pojmový
 13925188-n	slk:lemma	saturácia
 04405907-n	slk:lemma	televízor
 07443210-n	slk:lemma	oslabovanie
@@ -41591,7 +41591,7 @@
 04059701-n	slk:lemma	zadok
 01578254-v	slk:lemma	potopiť sa
 06726158-n	slk:lemma	deklarácia
-02587556-s	slk:lemma	cenný
+02587556-a	slk:lemma	cenný
 09272085-n	slk:lemma	elementárna časica
 14686723-n	slk:lemma	gazohol
 00257269-v	slk:lemma	zväčšiť sa
@@ -41610,7 +41610,7 @@
 06790042-n	slk:lemma	princíp
 15033189-n	slk:lemma	piperín
 00102586-v	slk:lemma	uškodiť
-00447472-s	slk:lemma	susedný
+00447472-a	slk:lemma	susedný
 04691178-n	slk:lemma	znetvorenie
 00798717-v	slk:lemma	odvolávať
 01983771-v	slk:lemma	zmeniť (polohu, postoj, pozíciu)
@@ -41643,7 +41643,7 @@
 11509066-n	slk:lemma	snehová vločka
 08299493-n	slk:lemma	agentúra OSN
 01803380-v	slk:lemma	hnevať
-02281182-s	slk:lemma	nadšený
+02281182-a	slk:lemma	nadšený
 13972601-n	slk:lemma	spoločenská zmluva
 08114861-n	slk:lemma	oblasť
 02372605-v	slk:lemma	ísť
@@ -41662,16 +41662,16 @@
 05031560-n	slk:lemma	statočnosť
 01171183-v	slk:lemma	usrknúť si
 04583776-n	slk:lemma	široké plátno v kine
-01266397-s	slk:lemma	smiešny
+01266397-a	slk:lemma	smiešny
 04682462-n	slk:lemma	škvrna
 02429695-n	slk:lemma	jeleňovité
 00029367-r	slk:lemma	naviac
 01138204-v	slk:lemma	ležať v úkryte
-00250739-s	slk:lemma	príliš riskujúci
+00250739-a	slk:lemma	príliš riskujúci
 01153548-n	slk:lemma	znevýhodňovanie
-02030562-s	slk:lemma	krajne pravicový
+02030562-a	slk:lemma	krajne pravicový
 13267014-n	slk:lemma	dotácia
-01706465-s	slk:lemma	utajený
+01706465-a	slk:lemma	utajený
 02382367-v	slk:lemma	podať demisiu
 07494363-n	slk:lemma	bolesť
 04505470-n	slk:lemma	klávesnica písacieho stroja
@@ -41684,7 +41684,7 @@
 00897746-v	slk:lemma	spýtať sa
 04473432-n	slk:lemma	prepravný systém
 04663494-n	slk:lemma	pozornosť
-02229961-s	slk:lemma	nízky
+02229961-a	slk:lemma	nízky
 05000342-n	slk:lemma	tučnota
 01467370-v	slk:lemma	obkolesiť
 05937112-n	slk:lemma	príklad
@@ -41722,9 +41722,9 @@
 00960562-v	slk:lemma	dabovať
 02899112-a	slk:lemma	faktický
 00868471-v	slk:lemma	tváriť sa akoby sa nič nestalo
-01698103-s	slk:lemma	pokrytý obkladačkami
+01698103-a	slk:lemma	pokrytý obkladačkami
 05832264-n	slk:lemma	trápenie
-01676517-s	slk:lemma	obdivuhodný
+01676517-a	slk:lemma	obdivuhodný
 07164546-n	slk:lemma	ponúknutie
 09372504-n	slk:lemma	Severná Amerika
 00954608-v	slk:lemma	zverejňovať
@@ -41756,7 +41756,7 @@
 01619354-v	slk:lemma	obnoviť
 02608347-v	slk:lemma	začínať sa
 00278403-n	slk:lemma	zavlažovanie
-01880918-s	slk:lemma	neslušný
+01880918-a	slk:lemma	neslušný
 01725530-v	slk:lemma	prehrať
 08378698-n	slk:lemma	kastový systém
 01101734-v	slk:lemma	triumfovať
@@ -41769,7 +41769,7 @@
 06832356-n	slk:lemma	l
 02106506-v	slk:lemma	uvedomiť si
 13259013-n	slk:lemma	pokles nepredaných aktív
-00012689-s	slk:lemma	myšlienkový
+00012689-a	slk:lemma	myšlienkový
 12710693-n	slk:lemma	sladký pomaranč
 00183823-r	slk:lemma	dôstojne
 14934655-n	slk:lemma	velínový papier
@@ -41791,7 +41791,7 @@
 13970236-n	slk:lemma	mier
 10209888-n	slk:lemma	poistná osoba
 06660396-n	slk:lemma	kvóta
-00750296-s	slk:lemma	podstatný
+00750296-a	slk:lemma	podstatný
 05714894-n	slk:lemma	pach
 06128570-n	slk:lemma	informatika
 04935528-n	slk:lemma	lepivosť
@@ -41811,7 +41811,7 @@
 09473397-n	slk:lemma	Volkov
 13658828-n	slk:lemma	cm
 08078020-n	slk:lemma	rodina
-00850053-s	slk:lemma	luxusný
+00850053-a	slk:lemma	luxusný
 08361924-n	slk:lemma	hegemónia
 10578162-n	slk:lemma	študent v seminári
 02421374-v	slk:lemma	oslobodzovať
@@ -41825,7 +41825,7 @@
 05154908-n	slk:lemma	subvencia
 10312077-n	slk:lemma	hutník
 01073995-n	slk:lemma	prekážka
-01808227-s	slk:lemma	báječný
+01808227-a	slk:lemma	báječný
 07404944-n	slk:lemma	zosuv
 03930313-n	slk:lemma	ohrada
 05593476-n	slk:lemma	lakeť
@@ -41875,7 +41875,7 @@
 07294423-n	slk:lemma	zaslúžený trest
 01035853-n	slk:lemma	eucharistia
 02519055-v	slk:lemma	presadzovať sa
-01211296-s	slk:lemma	pokročilý
+01211296-a	slk:lemma	pokročilý
 00361065-r	slk:lemma	totožne
 01686132-v	slk:lemma	znázorňovať
 00836705-v	slk:lemma	nesprávne opísať
@@ -41893,7 +41893,7 @@
 01127623-n	slk:lemma	uvalenie
 02062212-v	slk:lemma	vrhnúť
 00099089-v	slk:lemma	pokrývať sa
-01842468-s	slk:lemma	príležitostný
+01842468-a	slk:lemma	príležitostný
 03433877-n	slk:lemma	zdroj
 00254614-r	slk:lemma	najprv
 00378985-n	slk:lemma	kombinácia
@@ -41911,7 +41911,7 @@
 10569411-n	slk:lemma	agent, tajný
 01393714-v	slk:lemma	zamiesť
 06566077-n	slk:lemma	programový balík
-02090228-s	slk:lemma	pokútny
+02090228-a	slk:lemma	pokútny
 00379993-n	slk:lemma	vrava
 14796073-n	slk:lemma	hydroxybenzén
 03879705-n	slk:lemma	paleta
@@ -41920,7 +41920,7 @@
 08674739-n	slk:lemma	pozemok
 00552815-v	slk:lemma	kaziť sa
 02880393-n	slk:lemma	luk a šípy
-00608791-s	slk:lemma	zvláštny
+00608791-a	slk:lemma	zvláštny
 00223500-v	slk:lemma	oslabovať
 02964634-n	slk:lemma	nákladný priestor
 00003431-v	slk:lemma	grgať
@@ -41932,7 +41932,7 @@
 01812720-v	slk:lemma	oduševňovať
 09715427-n	slk:lemma	Dublinčan
 02387486-v	slk:lemma	vzdelávať sa
-01640261-s	slk:lemma	dlhotrvajúci
+01640261-a	slk:lemma	dlhotrvajúci
 01412346-v	slk:lemma	uspávať úderom
 04357930-n	slk:lemma	kompresor
 03932670-n	slk:lemma	handra
@@ -41940,8 +41940,8 @@
 04756504-n	slk:lemma	pravdepodobnosť
 14980579-n	slk:lemma	petrolej
 00466053-v	slk:lemma	zarovnať
-01509367-s	slk:lemma	mierny
-01439496-s	slk:lemma	stály
+01509367-a	slk:lemma	mierny
+01439496-a	slk:lemma	stály
 01651293-v	slk:lemma	podniknúť
 04959230-n	slk:lemma	farebný tón
 06466787-n	slk:lemma	Žalm
@@ -41952,7 +41952,7 @@
 01850315-v	slk:lemma	odsunovať
 07373602-n	slk:lemma	fúzia
 05202497-n	slk:lemma	schopnosť
-01599898-s	slk:lemma	psychický
+01599898-a	slk:lemma	psychický
 00715541-v	slk:lemma	vymedziť
 00360932-v	slk:lemma	narodiť sa
 02578872-v	slk:lemma	dodržovať
@@ -42005,7 +42005,7 @@
 00770270-n	slk:lemma	priestupok
 01532589-v	slk:lemma	čistiť
 04585745-n	slk:lemma	rumpál
-02043051-s	slk:lemma	okrúhly
+02043051-a	slk:lemma	okrúhly
 14778436-n	slk:lemma	činiteľ
 01619929-v	slk:lemma	ničiť
 00024682-r	slk:lemma	nijako
@@ -42013,36 +42013,36 @@
 07503987-n	slk:lemma	antipatia
 10583387-n	slk:lemma	osadník
 03990474-n	slk:lemma	hrniec
-00164308-s	slk:lemma	pozorný
+00164308-a	slk:lemma	pozorný
 02106506-v	slk:lemma	uvedomovať si
 09626238-n	slk:lemma	rovnakopostavený
 09621545-n	slk:lemma	vzdelanec
 10487592-n	slk:lemma	odborník v psefológii
 05728493-n	slk:lemma	logická štruktúra
 08453108-n	slk:lemma	zákony
-01871473-s	slk:lemma	zárobkový
-02542148-s	slk:lemma	zasiahnutý
+01871473-a	slk:lemma	zárobkový
+02542148-a	slk:lemma	zasiahnutý
 00249164-r	slk:lemma	vnútorne
 14323683-n	slk:lemma	bolesť
 03212003-n	slk:lemma	jednorazový
 02407338-v	slk:lemma	zvádzať boj s
 00820976-v	slk:lemma	dokazovať
 03595860-n	slk:lemma	tryskové lietadlo
-02368566-s	slk:lemma	sladučký
+02368566-a	slk:lemma	sladučký
 05047279-n	slk:lemma	predchádzajúce poradie
 05031012-n	slk:lemma	odolnosť
 05333259-n	slk:lemma	vylučovací orgán
 11900058-n	slk:lemma	čeľaď Papaveraceae
 00858188-n	slk:lemma	spanie
 05893261-n	slk:lemma	nevyhnutný predpoklad
-00076127-s	slk:lemma	prijateľný
+00076127-a	slk:lemma	prijateľný
 03988170-n	slk:lemma	stĺp
 10546633-n	slk:lemma	námorník
 00463543-n	slk:lemma	ľadový hokej
 02193194-v	slk:lemma	rozlíšiť
 14052403-n	slk:lemma	porucha
 14023997-n	slk:lemma	vzrušenie
-00666960-s	slk:lemma	obežný
+00666960-a	slk:lemma	obežný
 03041810-n	slk:lemma	nadstavba s bazilikovými oknami
 01567275-v	slk:lemma	nasadiť
 04145056-n	slk:lemma	javisková úprava
@@ -42052,7 +42052,7 @@
 12321873-n	slk:lemma	hikora
 02945161-n	slk:lemma	tábor
 05024254-n	slk:lemma	hmotnosť
-00692255-s	slk:lemma	prebroditeľný
+00692255-a	slk:lemma	prebroditeľný
 05930736-n	slk:lemma	tvar
 01767949-v	slk:lemma	zasiahnuť (mať dosah, vplyv)
 02526085-v	slk:lemma	dosiahnuť
@@ -42061,24 +42061,24 @@
 00449692-v	slk:lemma	vyprázdňovať
 00806314-v	slk:lemma	schváliť
 01790020-v	slk:lemma	znepokojiť
-00979862-s	slk:lemma	rýchly
+00979862-a	slk:lemma	rýchly
 07941729-n	slk:lemma	živé spoločenstvo
 09925592-n	slk:lemma	reklamujúci
 01543123-v	slk:lemma	sedávať
 04925218-n	slk:lemma	mentálna úroveň
 05370918-n	slk:lemma	krčná žila
 00040365-r	slk:lemma	znovu
-01636205-s	slk:lemma	legitímny
+01636205-a	slk:lemma	legitímny
 00102029-r	slk:lemma	široko-ďaleko
 02758863-n	slk:lemma	diaľnica
 01860795-v	slk:lemma	pozastaviť sa
-02587936-s	slk:lemma	poriadny
+02587936-a	slk:lemma	poriadny
 00074790-n	slk:lemma	chaos
-00973677-s	slk:lemma	módny
+00973677-a	slk:lemma	módny
 04796291-n	slk:lemma	obyčajnosť
 14951110-n	slk:lemma	blok na písanie
 08405723-n	slk:lemma	impérium
-00971506-s	slk:lemma	podľa poslednej módy
+00971506-a	slk:lemma	podľa poslednej módy
 02172888-v	slk:lemma	zaznieť
 02538765-v	slk:lemma	zastarať sa
 05003590-n	slk:lemma	pôvab
@@ -42097,14 +42097,14 @@
 02919792-n	slk:lemma	chata, bungalov
 06158346-n	slk:lemma	filozofia
 08406619-n	slk:lemma	charitatívna organizácia
-00547317-s	slk:lemma	súhrnný
+00547317-a	slk:lemma	súhrnný
 14386022-n	slk:lemma	xenofóbia
 14103288-n	slk:lemma	srdcová choroba
 05601758-n	slk:lemma	charakteristika
 00227165-v	slk:lemma	zosilniť
 00212414-v	slk:lemma	zachovávať si
 07454452-n	slk:lemma	akademické cvičenie
-01973311-s	slk:lemma	prepojený
+01973311-a	slk:lemma	prepojený
 02402825-v	slk:lemma	dávať výpoveď
 02167435-v	slk:lemma	dohliadnuť na
 00770437-v	slk:lemma	primäť
@@ -42136,7 +42136,7 @@
 14360320-n	slk:lemma	nevoľnosť
 10225219-n	slk:lemma	právnik
 01976220-v	slk:lemma	strkať do vody
-01080900-s	slk:lemma	hojný
+01080900-a	slk:lemma	hojný
 06530789-n	slk:lemma	plná moc právneho zástupcu
 02785874-a	slk:lemma	provinčný
 14478684-n	slk:lemma	krach
@@ -42163,7 +42163,7 @@
 04170515-n	slk:lemma	samočinný štartér
 00921072-v	slk:lemma	domnievať sa
 01344293-v	slk:lemma	odpútať
-02347086-s	slk:lemma	úbohý
+02347086-a	slk:lemma	úbohý
 13555915-n	slk:lemma	prepadlisko
 01062253-v	slk:lemma	vyhlásiť
 00210797-n	slk:lemma	koniec
@@ -42176,7 +42176,7 @@
 00314835-r	slk:lemma	úprimne
 02130524-v	slk:lemma	kuknúť sa
 00078760-v	slk:lemma	ošetriť
-01066787-s	slk:lemma	prevládajúci
+01066787-a	slk:lemma	prevládajúci
 14560612-n	slk:lemma	rozpad
 04569520-n	slk:lemma	klin
 05644527-n	slk:lemma	produktivita
@@ -42185,16 +42185,16 @@
 10513386-n	slk:lemma	nosič batožiny
 05017757-n	slk:lemma	optický rozsah
 01968569-v	slk:lemma	stúpnuť
-00176387-s	slk:lemma	sľubný
+00176387-a	slk:lemma	sľubný
 02240674-v	slk:lemma	pokúsiť sa o
 02965529-n	slk:lemma	zvony vo veži
 00965404-n	slk:lemma	násilie
 01194331-n	slk:lemma	legálne odňatie držby
 06832572-n	slk:lemma	enko
-01403760-s	slk:lemma	nezákonný
+01403760-a	slk:lemma	nezákonný
 00146856-n	slk:lemma	zbiehanie
 00210768-r	slk:lemma	obvykle
-00378892-s	slk:lemma	oranžový
+00378892-a	slk:lemma	oranžový
 00543114-n	slk:lemma	bojový tanec
 00158190-r	slk:lemma	predovšetkým
 08054076-n	slk:lemma	klinika
@@ -42225,7 +42225,7 @@
 02490004-v	slk:lemma	zobrať si
 08479095-n	slk:lemma	židovstvo
 00261797-n	slk:lemma	starostlivosť o krásu
-01114973-s	slk:lemma	štedrý
+01114973-a	slk:lemma	štedrý
 00450335-n	slk:lemma	krasojazda
 06956287-n	slk:lemma	ugrofínčina
 09431409-n	slk:lemma	Chari
@@ -42233,36 +42233,36 @@
 01209135-v	slk:lemma	postihovať
 09231361-n	slk:lemma	Caloosahatchee
 01071474-v	slk:lemma	oznámiť
-01916979-s	slk:lemma	diskutabilný
+01916979-a	slk:lemma	diskutabilný
 01047803-n	slk:lemma	renesancia
 01523654-v	slk:lemma	odmotať
 00789237-n	slk:lemma	duel
 02496816-v	slk:lemma	podmaňovať
 01545649-v	slk:lemma	kľaknúť si
-00550574-s	slk:lemma	definitívny
-01165943-s	slk:lemma	liečivý
+00550574-a	slk:lemma	definitívny
+01165943-a	slk:lemma	liečivý
 09289709-n	slk:lemma	gulička
 00889555-v	slk:lemma	zaviazať sa
 02260085-v	slk:lemma	vymeniť späť
 10289462-n	slk:lemma	riaditeľka
 11868814-n	slk:lemma	kapustovitá rastlina
-01757211-s	slk:lemma	provizórny
+01757211-a	slk:lemma	provizórny
 07655988-n	slk:lemma	zadná štvrť
 01975138-a	slk:lemma	relevantný
 00524682-v	slk:lemma	nadobudnúť
 03547658-n	slk:lemma	hlava kolesa
-01871473-s	slk:lemma	výnosný
-01483677-s	slk:lemma	mužný
+01871473-a	slk:lemma	výnosný
+01483677-a	slk:lemma	mužný
 07329568-n	slk:lemma	štart
 08715110-n	slk:lemma	Juhovýchodná Ázia
 03374570-n	slk:lemma	mucholapka
 15147598-n	slk:lemma	školské roky
-00837977-s	slk:lemma	vysiľujúci
+00837977-a	slk:lemma	vysiľujúci
 04149968-n	slk:lemma	bič
 13624873-n	slk:lemma	m³
-00097768-s	slk:lemma	zomretý
+00097768-a	slk:lemma	zomretý
 01392237-v	slk:lemma	utrieť
-01252714-s	slk:lemma	studený
+01252714-a	slk:lemma	studený
 10463714-n	slk:lemma	šibal
 00266401-n	slk:lemma	pokles
 00315390-n	slk:lemma	plavba na jachte
@@ -42278,8 +42278,8 @@
 01249724-v	slk:lemma	šúchať
 06889138-n	slk:lemma	videnie
 09815188-n	slk:lemma	somár
-02491171-s	slk:lemma	smerujúci k nebu
-00807399-s	slk:lemma	nevýrazný
+02491171-a	slk:lemma	smerujúci k nebu
+00807399-a	slk:lemma	nevýrazný
 01495725-a	slk:lemma	najväčší
 10426749-n	slk:lemma	fotograf
 02607455-a	slk:lemma	liečivý
@@ -42290,7 +42290,7 @@
 13280658-n	slk:lemma	výplata
 13354420-n	slk:lemma	prevádzkový kapitál
 09428628-n	slk:lemma	pobrežie
-01827766-s	slk:lemma	slabý
+01827766-a	slk:lemma	slabý
 13659419-n	slk:lemma	dekameter
 03366823-n	slk:lemma	podlahovina
 02752987-a	slk:lemma	justičný
@@ -42302,10 +42302,10 @@
 00232956-v	slk:lemma	ustupovať
 01985923-v	slk:lemma	padnúť
 01810447-v	slk:lemma	poburovať sa
-01698231-s	slk:lemma	zasnežený
+01698231-a	slk:lemma	zasnežený
 14586258-n	slk:lemma	zmes
 14984973-n	slk:lemma	zafarbenie
-01311605-s	slk:lemma	obývaný
+01311605-a	slk:lemma	obývaný
 02240674-v	slk:lemma	usilovať sa
 04721058-n	slk:lemma	nevhodnosť
 02779774-a	slk:lemma	fyzikálny
@@ -42324,12 +42324,12 @@
 05736149-n	slk:lemma	ocenenie
 05120116-n	slk:lemma	zvyšok
 02642238-v	slk:lemma	váhať
-00608791-s	slk:lemma	excentrický
+00608791-a	slk:lemma	excentrický
 14964129-n	slk:lemma	kyselina nukleová
 04512476-n	slk:lemma	Pensylvánska Univerzita
 00941990-v	slk:lemma	verbalizovať
 00282613-n	slk:lemma	profesionálna kariéra
-00850648-s	slk:lemma	estetický
+00850648-a	slk:lemma	estetický
 02629390-v	slk:lemma	nepripustiť
 00364221-r	slk:lemma	nehybne
 01321579-n	slk:lemma	mláďa
@@ -42377,7 +42377,7 @@
 11952900-n	slk:lemma	rod Cichorium
 00603367-a	slk:lemma	argumentačný
 02707251-v	slk:lemma	prestáť
-00858558-s	slk:lemma	stoický
+00858558-a	slk:lemma	stoický
 00144722-r	slk:lemma	určite
 06724559-n	slk:lemma	paradox
 00606093-v	slk:lemma	precvičovať (niečo)
@@ -42392,7 +42392,7 @@
 02331479-n	slk:lemma	čeľaď myšovité
 00729108-n	slk:lemma	domáca úloha
 00027384-r	slk:lemma	aj tak
-01936528-s	slk:lemma	imaginárny
+01936528-a	slk:lemma	imaginárny
 09299885-n	slk:lemma	záliv Tehuantepec
 01768402-n	slk:lemma	podkmeň Chelicerata
 02066939-v	slk:lemma	vtiecť
@@ -42400,7 +42400,7 @@
 00317569-v	slk:lemma	rozšíriť
 07221094-n	slk:lemma	rozprávanie
 02066510-v	slk:lemma	plynúť
-00260780-s	slk:lemma	malomeštiacky
+00260780-a	slk:lemma	malomeštiacky
 07367385-n	slk:lemma	zlom
 02396088-n	slk:lemma	prasnica
 06355705-n	slk:lemma	PSČ
@@ -42409,7 +42409,7 @@
 01214265-v	slk:lemma	zobrať
 10130686-n	slk:lemma	partnerka
 06335532-n	slk:lemma	meno súboru
-02112701-s	slk:lemma	spoločný
+02112701-a	slk:lemma	spoločný
 04753455-n	slk:lemma	istá vec
 06440313-n	slk:lemma	Nahum
 02762468-v	slk:lemma	horieť
@@ -42428,25 +42428,25 @@
 09759069-n	slk:lemma	člen fakulty
 09690864-n	slk:lemma	Anguilčan
 00896555-a	slk:lemma	jednoznačný
-01618376-s	slk:lemma	očividný
+01618376-a	slk:lemma	očividný
 00531489-v	slk:lemma	pokorovať
 00761713-v	slk:lemma	prejednať
 00406243-v	slk:lemma	prichystať
-00157268-s	slk:lemma	samotársky
-01176973-s	slk:lemma	sneťový
+00157268-a	slk:lemma	samotársky
+01176973-a	slk:lemma	sneťový
 00625774-a	slk:lemma	nereálny
-02152473-s	slk:lemma	vzájomný
+02152473-a	slk:lemma	vzájomný
 08178085-n	slk:lemma	štát blahobytu
 00729378-v	slk:lemma	hútať
-00977699-s	slk:lemma	priamy
-00929815-s	slk:lemma	očakávaný
+00977699-a	slk:lemma	priamy
+00929815-a	slk:lemma	očakávaný
 07520925-n	slk:lemma	nervozita
-01676026-s	slk:lemma	neobyčajný
+01676026-a	slk:lemma	neobyčajný
 14956523-n	slk:lemma	bahno
 08573472-n	slk:lemma	predok
 08559508-n	slk:lemma	bydlisko
 05275905-n	slk:lemma	čeľusť
-02101942-s	slk:lemma	šokujúci
+02101942-a	slk:lemma	šokujúci
 01384439-v	slk:lemma	pozbierať
 05057382-n	slk:lemma	LF
 02416030-v	slk:lemma	psuť
@@ -42457,14 +42457,14 @@
 04831031-n	slk:lemma	nemilosrdnosť
 02151966-v	slk:lemma	dávať si na niekoho bacha
 00607114-v	slk:lemma	prebrať (látku, učivo)
-00807399-s	slk:lemma	nudný
+00807399-a	slk:lemma	nudný
 00072068-n	slk:lemma	zlá hra
 02663643-v	slk:lemma	stavať na
 02629256-v	slk:lemma	eliminovať
 08327616-n	slk:lemma	sympózium
 01807170-v	slk:lemma	získať obľubu
 02387486-v	slk:lemma	poskytovať (vzdelanie)
-01385255-s	slk:lemma	desivý
+01385255-a	slk:lemma	desivý
 00611256-v	slk:lemma	spomenúť si
 00909219-v	slk:lemma	zahundrať
 06755947-n	slk:lemma	podmienka
@@ -42487,9 +42487,9 @@
 00254769-n	slk:lemma	holenie
 00947077-v	slk:lemma	určiť
 04892794-n	slk:lemma	prezieravosť
-01386234-s	slk:lemma	početný
+01386234-a	slk:lemma	početný
 00955601-v	slk:lemma	vypracúvať
-01226660-s	slk:lemma	veľavážený
+01226660-a	slk:lemma	veľavážený
 01846658-v	slk:lemma	doplaviť
 02790322-n	slk:lemma	hrot šípu
 02671780-n	slk:lemma	doplnok
@@ -42525,12 +42525,12 @@
 09438554-n	slk:lemma	Snake
 06441803-n	slk:lemma	Marek
 00770543-n	slk:lemma	porušenie
-00032733-s	slk:lemma	svižný
+00032733-a	slk:lemma	svižný
 01155090-v	slk:lemma	stíhať
 02063018-v	slk:lemma	nahnúť
 03895293-n	slk:lemma	cesta
-02474476-s	slk:lemma	organizovaný
-00848375-s	slk:lemma	povinný
+02474476-a	slk:lemma	organizovaný
+00848375-a	slk:lemma	povinný
 01338501-v	slk:lemma	prikryť
 04588739-n	slk:lemma	okno
 09483340-n	slk:lemma	Kanton
@@ -42538,7 +42538,7 @@
 02274482-v	slk:lemma	uzurpovať
 00630380-v	slk:lemma	pozorovať (zamyslene)
 15055633-n	slk:lemma	para
-00631798-s	slk:lemma	dôkladný
+00631798-a	slk:lemma	dôkladný
 01841079-v	slk:lemma	cestovať
 00291876-n	slk:lemma	voľný pochod
 02676261-n	slk:lemma	zvukové zariadenie
@@ -42585,7 +42585,7 @@
 10369528-n	slk:lemma	pozorovateľ
 02064887-v	slk:lemma	odchýliť sa
 01869196-v	slk:lemma	chodiť nebadane
-01384730-s	slk:lemma	obrovský
+01384730-a	slk:lemma	obrovský
 01896031-n	slk:lemma	perie
 02122725-n	slk:lemma	kocúr
 00532110-n	slk:lemma	spoločenské tancovanie
@@ -42619,7 +42619,7 @@
 06021761-n	slk:lemma	stredná hodnota
 05012272-n	slk:lemma	entalpia
 10228278-n	slk:lemma	porotkyňa
-01136248-s	slk:lemma	rozladený
+01136248-a	slk:lemma	rozladený
 01441100-v	slk:lemma	preniknúť cez (niečo)
 06777164-n	slk:lemma	irónia
 09447666-n	slk:lemma	pláž
@@ -42631,7 +42631,7 @@
 09535940-n	slk:lemma	matka Zem
 01158596-a	slk:lemma	alkoholický
 09006413-n	slk:lemma	Ruská federácia
-00547317-s	slk:lemma	presný
+00547317-a	slk:lemma	presný
 02061366-v	slk:lemma	odstúpiť sa
 13380820-n	slk:lemma	peňažná poukážka
 13838205-n	slk:lemma	právny vzťah
@@ -42657,13 +42657,13 @@
 03563460-n	slk:lemma	lopatka obežného kolesa
 09876892-n	slk:lemma	brat
 04440486-n	slk:lemma	cínový tovar
-01501821-s	slk:lemma	melodický
+01501821-a	slk:lemma	melodický
 01264283-v	slk:lemma	natierať
 01338368-v	slk:lemma	pokrývať bridlicami
 02764044-n	slk:lemma	sekera
 00061677-r	slk:lemma	zrazu
 01347138-a	slk:lemma	mimo mesta
-01274945-s	slk:lemma	oslabený
+01274945-a	slk:lemma	oslabený
 05558717-n	slk:lemma	chrbát
 10037385-n	slk:lemma	opilec
 09367203-n	slk:lemma	nutnosť
@@ -42677,10 +42677,10 @@
 02696795-a	slk:lemma	filmový
 01213886-n	slk:lemma	podpora
 06660396-n	slk:lemma	povinná maximálna výška vývozu alebo dovozu
-00579622-s	slk:lemma	popredný
+00579622-a	slk:lemma	popredný
 02249147-v	slk:lemma	prihlásiť sa
-00874226-s	slk:lemma	čulý
-01367431-s	slk:lemma	živý
+00874226-a	slk:lemma	čulý
+01367431-a	slk:lemma	živý
 02133185-v	slk:lemma	všímať si
 03601840-n	slk:lemma	stropnica
 00293650-r	slk:lemma	namrzene
@@ -42689,17 +42689,17 @@
 04486445-n	slk:lemma	bezvýznamná vec
 01461328-v	slk:lemma	spájať
 01437805-n	slk:lemma	Cypriniformes
-02081114-s	slk:lemma	prijatý
+02081114-a	slk:lemma	prijatý
 01205696-v	slk:lemma	spájať sa
 00270275-n	slk:lemma	zreštaurovanie
 08957212-n	slk:lemma	Laponsko
 09080554-n	slk:lemma	ostrov Oahu
-01277426-s	slk:lemma	najvyšší
+01277426-a	slk:lemma	najvyšší
 02070296-v	slk:lemma	naliať
 13470491-n	slk:lemma	úpadok
 00084738-v	slk:lemma	nadrogovať
 06667792-n	slk:lemma	právny kódex
-02515001-s	slk:lemma	mrzký
+02515001-a	slk:lemma	mrzký
 10613996-n	slk:lemma	kráska
 02561332-v	slk:lemma	uplatňovať
 00609683-v	slk:lemma	pamätať na
@@ -42717,7 +42717,7 @@
 01640855-v	slk:lemma	splniť
 02894605-n	slk:lemma	výstupok
 01803003-v	slk:lemma	zlostiť
-01212095-s	slk:lemma	posledný
+01212095-a	slk:lemma	posledný
 01098968-n	slk:lemma	finančné transakcie podniku
 08795974-n	slk:lemma	Gomora
 01669547-v	slk:lemma	používať (nástroj)
@@ -42737,7 +42737,7 @@
 02492362-v	slk:lemma	veseliť sa
 00180611-r	slk:lemma	samostatne
 00577525-n	slk:lemma	služby
-02114746-s	slk:lemma	infekčný
+02114746-a	slk:lemma	infekčný
 00054435-r	slk:lemma	prosto
 02796995-n	slk:lemma	bar
 09063673-n	slk:lemma	Los Angeles
@@ -42760,7 +42760,7 @@
 00305519-n	slk:lemma	núdzové pristátie
 09274500-n	slk:lemma	ústie rieky
 10601078-n	slk:lemma	hriešnik
-00324481-s	slk:lemma	motorický
+00324481-a	slk:lemma	motorický
 00690501-n	slk:lemma	plastická chirurgia
 02796623-n	slk:lemma	priehrada
 15251336-n	slk:lemma	sté jubileum
@@ -42772,11 +42772,11 @@
 09443641-n	slk:lemma	morská pena
 14552802-n	slk:lemma	zrakový defekt
 05567117-n	slk:lemma	konček prsta
-00635244-s	slk:lemma	zlepšiteľný
+00635244-a	slk:lemma	zlepšiteľný
 03414162-n	slk:lemma	herný nástroj
 09213565-n	slk:lemma	svah
 14435670-n	slk:lemma	kráľ
-00656507-s	slk:lemma	ústredný
+00656507-a	slk:lemma	ústredný
 04341686-n	slk:lemma	štruktúra
 08643933-n	slk:lemma	útulok
 04597066-n	slk:lemma	golfová palica
@@ -42796,16 +42796,16 @@
 00071178-v	slk:lemma	sužovať
 04018399-n	slk:lemma	hostinec
 04071102-n	slk:lemma	útočište
-01281695-s	slk:lemma	podradný
+01281695-a	slk:lemma	podradný
 08645318-n	slk:lemma	planina
-01933731-s	slk:lemma	skutočný
+01933731-a	slk:lemma	skutočný
 01171183-v	slk:lemma	spiť sa
 02066939-v	slk:lemma	dotekať
 09275016-n	slk:lemma	Eurázia
 10627082-n	slk:lemma	psycha
 00088655-r	slk:lemma	improvizovane
 01208597-n	slk:lemma	útočište
-01982957-s	slk:lemma	uznávaný
+01982957-a	slk:lemma	uznávaný
 00047534-r	slk:lemma	rovnako ako
 01322854-v	slk:lemma	zaklať
 00402308-n	slk:lemma	transfigurácia
@@ -42819,13 +42819,13 @@
 15166191-n	slk:lemma	popoludnie
 04222210-n	slk:lemma	jednoduchá posteľ
 00029378-n	slk:lemma	príhoda
-00627004-s	slk:lemma	materiálny
+00627004-a	slk:lemma	materiálny
 14207561-n	slk:lemma	infarkt
 00203922-r	slk:lemma	bezchybne
 05047279-n	slk:lemma	prednostné právo
 02133185-v	slk:lemma	pozorne sa pozerať
 00451186-n	slk:lemma	cezpoľná jazda cez prekážky
-00683531-s	slk:lemma	vulgárny
+00683531-a	slk:lemma	vulgárny
 00085811-r	slk:lemma	poďme, poďme
 05000342-n	slk:lemma	vykŕmenosť
 00900726-n	slk:lemma	zobrazenie
@@ -42835,12 +42835,12 @@
 00144722-r	slk:lemma	naisto
 13440063-n	slk:lemma	telesná funkcia
 07567707-n	slk:lemma	pokrm
-01462882-s	slk:lemma	prioritný
+01462882-a	slk:lemma	prioritný
 03706653-n	slk:lemma	disk
 05337178-n	slk:lemma	oblúková tepna obličiek
 04191943-n	slk:lemma	prístrešok
 02790322-n	slk:lemma	ozub
-01802774-s	slk:lemma	strašlivý
+01802774-a	slk:lemma	strašlivý
 03900509-n	slk:lemma	dláždený povrch
 00296178-v	slk:lemma	opravovať
 02696165-n	slk:lemma	krčma
@@ -42848,7 +42848,7 @@
 09440948-n	slk:lemma	Južný Atlantik
 11607392-n	slk:lemma	Coniferales
 03576779-n	slk:lemma	sacie potrubie
-00440292-s	slk:lemma	zadubený
+00440292-a	slk:lemma	zadubený
 08989697-n	slk:lemma	Francúzska Oceánia
 07304852-n	slk:lemma	nešťastná náhoda
 13398241-n	slk:lemma	obligácia
@@ -42858,13 +42858,13 @@
 08226699-n	slk:lemma	osada
 14061805-n	slk:lemma	nemoc
 05547396-n	slk:lemma	tylo
-02569558-s	slk:lemma	bystrý
+02569558-a	slk:lemma	bystrý
 02294436-v	slk:lemma	rozdávať
 09037133-n	slk:lemma	Tonžské kráľovstvo
 00805376-v	slk:lemma	zhodovať sa
 00512261-a	slk:lemma	nekvalifikovaný
-02372520-s	slk:lemma	pravidelný
-01709437-s	slk:lemma	poštovné zadarmo
+02372520-a	slk:lemma	pravidelný
+01709437-a	slk:lemma	poštovné zadarmo
 02942699-n	slk:lemma	fotoaparát
 02422026-v	slk:lemma	vyslobodiť
 00027384-r	slk:lemma	predsa však
@@ -42882,15 +42882,15 @@
 09230768-n	slk:lemma	kameň
 08303692-n	slk:lemma	federácia národov
 09955781-n	slk:lemma	poslanec
-00592880-s	slk:lemma	vratný
-00813589-s	slk:lemma	prastarý
+00592880-a	slk:lemma	vratný
+00813589-a	slk:lemma	prastarý
 06671484-n	slk:lemma	avízo
 05933638-n	slk:lemma	výhľadové pole
 01582645-v	slk:lemma	rysovať
 13125117-n	slk:lemma	koreň
-02316992-s	slk:lemma	točitý
+02316992-a	slk:lemma	točitý
 05098942-n	slk:lemma	veľkosť
-01062393-s	slk:lemma	suverénny
+01062393-a	slk:lemma	suverénny
 09203217-n	slk:lemma	rieka Araxes
 01181295-v	slk:lemma	ponúkať
 10289039-n	slk:lemma	každý
@@ -42912,13 +42912,13 @@
 03367663-n	slk:lemma	flotila
 13512725-n	slk:lemma	meióza
 04505036-n	slk:lemma	písací stroj
-01281695-s	slk:lemma	bezvýznamný
+01281695-a	slk:lemma	bezvýznamný
 00005205-a	slk:lemma	absolútny
 09283405-n	slk:lemma	podhorie
 01893988-v	slk:lemma	posúvať sa
 08965598-n	slk:lemma	Mali
 02447247-v	slk:lemma	predstierať prácu
-01279611-s	slk:lemma	závažný
+01279611-a	slk:lemma	závažný
 06199142-n	slk:lemma	náklonnosť
 04935528-n	slk:lemma	súdržnosť
 02470175-v	slk:lemma	združovať sa
@@ -42927,7 +42927,7 @@
 01523105-v	slk:lemma	nakrútiť
 05814291-n	slk:lemma	téma
 07927197-n	slk:lemma	nealkoholický nápoj
-01368464-s	slk:lemma	pohrebný
+01368464-a	slk:lemma	pohrebný
 03975035-n	slk:lemma	zahrotený oblúk
 09137032-n	slk:lemma	RI
 04615644-n	slk:lemma	chuligánske šaty
@@ -42936,7 +42936,7 @@
 02681795-v	slk:lemma	zachovať
 02671880-v	slk:lemma	spĺňať
 06278136-n	slk:lemma	zvuk
-00304949-s	slk:lemma	prudký
+00304949-a	slk:lemma	prudký
 09004358-n	slk:lemma	Astrakán
 07568706-n	slk:lemma	kukuričná múka
 00834198-a	slk:lemma	účinný
@@ -42959,7 +42959,7 @@
 01017826-v	slk:lemma	vymôcť
 06728331-n	slk:lemma	piaty dodatok k ústave USA o stíhaní zločinov len pred veľkou porotou
 08063446-n	slk:lemma	priekupník
-01635018-s	slk:lemma	neoficiálny
+01635018-a	slk:lemma	neoficiálny
 06361770-n	slk:lemma	slabičná abeceda
 02333546-n	slk:lemma	potkan hnedý
 04756635-n	slk:lemma	pravdepodobnosť
@@ -42994,19 +42994,19 @@
 06533648-n	slk:lemma	ústava
 05859071-n	slk:lemma	parameter
 00044861-r	slk:lemma	naproti
-01151740-s	slk:lemma	tuhý
+01151740-a	slk:lemma	tuhý
 05809192-n	slk:lemma	poznanie
 00674158-n	slk:lemma	vyhladzovanie vrások
 02326432-n	slk:lemma	zajac
 00027268-v	slk:lemma	natiahnuť
 02256354-v	slk:lemma	inkasovať
-00414518-s	slk:lemma	populárny
+00414518-a	slk:lemma	populárny
 00908621-v	slk:lemma	uprednostňovať
 02469588-n	slk:lemma	rad primáty
 02675935-v	slk:lemma	zabezpečovať
 02199999-n	slk:lemma	Culicidae
 09428967-n	slk:lemma	nános
-00798103-s	slk:lemma	naliaty
+00798103-a	slk:lemma	naliaty
 04123448-n	slk:lemma	voľný plášť
 09691279-n	slk:lemma	Austrálčan
 01019524-n	slk:lemma	kopírovanie
@@ -43034,7 +43034,7 @@
 01878466-a	slk:lemma	vhodný
 00154778-v	slk:lemma	zväčšiť
 07575076-n	slk:lemma	obed
-01642657-s	slk:lemma	revolucionistický
+01642657-a	slk:lemma	revolucionistický
 03516011-n	slk:lemma	heroín
 05725879-n	slk:lemma	pohoda prostredia
 00147876-r	slk:lemma	ľahko
@@ -43125,13 +43125,13 @@
 04152829-n	slk:lemma	premietacie plátno
 00996919-v	slk:lemma	potvrdzovať podpisom
 02376277-a	slk:lemma	sympatický
-02321809-s	slk:lemma	silný
+02321809-a	slk:lemma	silný
 01019372-n	slk:lemma	reduplikácia
 07511080-n	slk:lemma	očakávanie
 15172212-n	slk:lemma	interval
 01257145-n	slk:lemma	prednosť
 09811852-n	slk:lemma	kanonier
-02243255-s	slk:lemma	posiaty bradavicami
+02243255-a	slk:lemma	posiaty bradavicami
 01480149-v	slk:lemma	uloviť
 08672738-n	slk:lemma	kolónia
 07434102-n	slk:lemma	deformácia
@@ -43145,7 +43145,7 @@
 09167101-n	slk:lemma	Južná Rodézia
 00803325-v	slk:lemma	povoľovať
 02162947-v	slk:lemma	trblietať sa
-02331857-s	slk:lemma	fantastický
+02331857-a	slk:lemma	fantastický
 09040299-n	slk:lemma	Abydos
 08386555-n	slk:lemma	elita
 02641463-v	slk:lemma	odsúvať
@@ -43189,9 +43189,9 @@
 02333368-n	slk:lemma	rod potkan
 09090559-n	slk:lemma	Louisiana Purchase
 00037090-n	slk:lemma	majstrovský kúsok
-01151951-s	slk:lemma	kamenný
+01151951-a	slk:lemma	kamenný
 00988028-v	slk:lemma	stvárniť
-01199083-s	slk:lemma	rôzny
+01199083-a	slk:lemma	rôzny
 00040365-r	slk:lemma	zasa
 02655135-v	slk:lemma	byť
 01733661-a	slk:lemma	budúci
@@ -43199,9 +43199,9 @@
 00099712-r	slk:lemma	viacej
 04143897-n	slk:lemma	šatka
 02431320-v	slk:lemma	rozviesť sa
-00228294-s	slk:lemma	popredný
+00228294-a	slk:lemma	popredný
 03196598-n	slk:lemma	alfanumerická obrazovka
-00393683-s	slk:lemma	intenzívny
+00393683-a	slk:lemma	intenzívny
 00695226-v	slk:lemma	určovať cenu
 01237415-n	slk:lemma	zlučovanie
 00251408-r	slk:lemma	večer
@@ -43209,25 +43209,25 @@
 00928542-n	slk:lemma	urbanizmus
 03859495-n	slk:lemma	vonkajší odev
 02374924-v	slk:lemma	dovoliť si
-01439496-s	slk:lemma	dlhotrvajúci
+01439496-a	slk:lemma	dlhotrvajúci
 00270919-n	slk:lemma	rezervovanie
 00256309-n	slk:lemma	prepláchnutie
 14326880-n	slk:lemma	bolesť jazyka
 00027167-n	slk:lemma	miesto
 01000214-v	slk:lemma	zachytávať
-01756292-s	slk:lemma	dočasný
+01756292-a	slk:lemma	dočasný
 02413131-n	slk:lemma	ovca domáca
 03532342-n	slk:lemma	hák
 09370773-n	slk:lemma	Niagara
 00327824-n	slk:lemma	kolísanie
 04960277-n	slk:lemma	čerň
-01722140-s	slk:lemma	ospravedlniteľný
+01722140-a	slk:lemma	ospravedlniteľný
 08653474-n	slk:lemma	vákuum
 01782650-v	slk:lemma	nahnať (niekomu) strach
-01940472-s	slk:lemma	prozaický
+01940472-a	slk:lemma	prozaický
 01767949-v	slk:lemma	zapôsobiť na
 00230033-v	slk:lemma	zlepšiť
-00217428-s	slk:lemma	nosný
+00217428-a	slk:lemma	nosný
 13096677-n	slk:lemma	chlorenchým
 02704928-v	slk:lemma	pretrvávať
 07505676-n	slk:lemma	ľahostajnosť
@@ -43237,7 +43237,7 @@
 00589309-v	slk:lemma	pochopiť
 03121897-n	slk:lemma	halena
 02737351-n	slk:lemma	archa
-00978199-s	slk:lemma	bleskurýchly
+00978199-a	slk:lemma	bleskurýchly
 09294066-n	slk:lemma	Green
 00040547-r	slk:lemma	náhodou
 01557903-a	slk:lemma	nesmrteľný
@@ -43249,14 +43249,14 @@
 15022617-n	slk:lemma	svalová bielkovina
 00250181-v	slk:lemma	rásť
 00066862-v	slk:lemma	hulákať
-02101757-s	slk:lemma	krikľavý
+02101757-a	slk:lemma	krikľavý
 00749376-v	slk:lemma	ukázať cestu
 05510702-n	slk:lemma	senzorický systém v tele
 13290002-n	slk:lemma	refundácia
 05511286-n	slk:lemma	cievny systém
 00207668-r	slk:lemma	po jednom
 04335209-n	slk:lemma	ulica
-00792641-s	slk:lemma	hlavný
+00792641-a	slk:lemma	hlavný
 02005948-v	slk:lemma	dôjsť
 14493716-n	slk:lemma	núdza
 03398775-n	slk:lemma	služobná komunikácia
@@ -43277,7 +43277,7 @@
 01315613-v	slk:lemma	hľadať
 09431744-n	slk:lemma	rieka Shenandoah
 00984609-n	slk:lemma	rekognoskácia
-01648891-s	slk:lemma	juniorský
+01648891-a	slk:lemma	juniorský
 02405252-v	slk:lemma	odstaviť
 08613000-n	slk:lemma	obrys pobrežia
 00152727-n	slk:lemma	nález
@@ -43288,7 +43288,7 @@
 01857717-v	slk:lemma	naštartovať
 08684294-n	slk:lemma	nádvorie
 09777975-n	slk:lemma	obchodný agent
-00859949-s	slk:lemma	odpozorovaný
+00859949-a	slk:lemma	odpozorovaný
 02500775-v	slk:lemma	spustošiť
 06806469-n	slk:lemma	znak
 02968074-n	slk:lemma	prístrešok pre autá
@@ -43312,7 +43312,7 @@
 02767308-v	slk:lemma	vyžiariť
 03214253-n	slk:lemma	zákop
 00015946-v	slk:lemma	prezimovať
-01395821-s	slk:lemma	zachovávajúci zákony
+01395821-a	slk:lemma	zachovávajúci zákony
 01136519-n	slk:lemma	organizácia
 00203866-v	slk:lemma	zhoršiť
 09024844-n	slk:lemma	Malorka
@@ -43328,14 +43328,14 @@
 09231361-n	slk:lemma	rieka Caloosahatchee
 00353249-n	slk:lemma	zmierňovanie
 04657244-n	slk:lemma	neprístupnosť
-00888200-s	slk:lemma	chtivý
-01082115-s	slk:lemma	plodný
+00888200-a	slk:lemma	chtivý
+01082115-a	slk:lemma	plodný
 01659248-v	slk:lemma	vytvarovať
 09371151-n	slk:lemma	rieka Niger
 05021151-n	slk:lemma	pružnosť
 06601327-n	slk:lemma	dosah
 04328946-n	slk:lemma	úschovňa
-00051571-s	slk:lemma	kompetentný
+00051571-a	slk:lemma	kompetentný
 08733291-n	slk:lemma	Medellin
 02479323-v	slk:lemma	dodať
 13814336-n	slk:lemma	bratské puto
@@ -43367,10 +43367,10 @@
 02898121-a	slk:lemma	architektonický
 00059854-r	slk:lemma	čoraz viac
 07335716-n	slk:lemma	miznutie
-02395910-s	slk:lemma	nektárový
+02395910-a	slk:lemma	nektárový
 09354283-n	slk:lemma	Stredoatlantický podmorský chrbát
 01122754-n	slk:lemma	deficitné výdavky
-01816376-s	slk:lemma	obľúbený
+01816376-a	slk:lemma	obľúbený
 03070396-n	slk:lemma	uhoľná baňa
 00968211-v	slk:lemma	šíriť sa
 10245156-n	slk:lemma	prenajímateľka
@@ -43387,7 +43387,7 @@
 00633443-v	slk:lemma	teoretizovať
 00961328-n	slk:lemma	vybudovaná obrana
 00229605-v	slk:lemma	pozdvihnúť
-00567860-s	slk:lemma	oddelený
+00567860-a	slk:lemma	oddelený
 10356066-n	slk:lemma	novomanželia
 10698970-n	slk:lemma	bankový úradník
 05159725-n	slk:lemma	prospech
@@ -43421,22 +43421,22 @@
 05486510-n	slk:lemma	kortex
 02395406-n	slk:lemma	ošípaná
 00015953-r	slk:lemma	ťažko
-00974159-s	slk:lemma	staromódny
+00974159-a	slk:lemma	staromódny
 02613672-v	slk:lemma	chýbať
-00824509-s	slk:lemma	k západu
+00824509-a	slk:lemma	k západu
 09903153-n	slk:lemma	celebrita
 02220461-v	slk:lemma	presúvať
 10577284-n	slk:lemma	kšeftár
 00049003-n	slk:lemma	príchod
 11879505-n	slk:lemma	kapusta čierna
-01384730-s	slk:lemma	nesmierny
+01384730-a	slk:lemma	nesmierny
 00326440-n	slk:lemma	zoskok
 03574816-n	slk:lemma	zariadenie
-01474942-s	slk:lemma	prístupný
+01474942-a	slk:lemma	prístupný
 00658052-v	slk:lemma	určovať
 10490557-n	slk:lemma	verejný obhajca
 00199130-n	slk:lemma	premena
-01159907-s	slk:lemma	neškodný
+01159907-a	slk:lemma	neškodný
 05698982-n	slk:lemma	pochybnosť
 01134479-n	slk:lemma	zlé hospodárenie
 02344381-v	slk:lemma	odplácať
@@ -43463,7 +43463,7 @@
 01062253-v	slk:lemma	vyniesť (rozsudok, verdikt)
 02400218-a	slk:lemma	podliehajúci dani
 07201365-n	slk:lemma	popis
-02558767-s	slk:lemma	organický
+02558767-a	slk:lemma	organický
 02769358-a	slk:lemma	nominálny
 03953416-n	slk:lemma	chrám Boží
 03456854-n	slk:lemma	Veľký most v New Orleans
@@ -43482,13 +43482,13 @@
 00021878-r	slk:lemma	zavše
 08278324-n	slk:lemma	akadémia
 05308310-n	slk:lemma	koreň zuba
-00721371-s	slk:lemma	pochybný
+00721371-a	slk:lemma	pochybný
 05616246-n	slk:lemma	schopnosť
 02700064-n	slk:lemma	alternátor
 00356926-a	slk:lemma	vzorový
 02578235-v	slk:lemma	oklamať
 05513020-n	slk:lemma	uretra
-02466566-s	slk:lemma	podozrivý
+02466566-a	slk:lemma	podozrivý
 02046572-v	slk:lemma	otáčať sa (okolo osi)
 01578821-n	slk:lemma	rod Corvus
 00512843-n	slk:lemma	hlúposť
@@ -43497,8 +43497,8 @@
 02015598-v	slk:lemma	opustiť
 00854420-v	slk:lemma	podvádzať
 12892226-n	slk:lemma	čeľaď ľuľkovité
-02097480-s	slk:lemma	príťažlivý
-01439155-s	slk:lemma	príliš dlhý
+02097480-a	slk:lemma	príťažlivý
+01439155-a	slk:lemma	príliš dlhý
 00725775-n	slk:lemma	bek
 06314808-n	slk:lemma	vedľajšia veta
 01776974-a	slk:lemma	pôsobiaci na psychiku
@@ -43511,15 +43511,15 @@
 05057485-n	slk:lemma	stredná frekvencia
 03505504-n	slk:lemma	šál na hlavu
 00027705-v	slk:lemma	naťahovať
-02347086-s	slk:lemma	mizerný
+02347086-a	slk:lemma	mizerný
 00847340-n	slk:lemma	párenie
 02500775-v	slk:lemma	zbičovať
 14532816-n	slk:lemma	alergická reakcia
 06892534-n	slk:lemma	dobročinná akcia
 00502847-r	slk:lemma	láskavo
-02460964-s	slk:lemma	skutočný
+02460964-a	slk:lemma	skutočný
 02027612-v	slk:lemma	natlačiť
-00507292-s	slk:lemma	surový
+00507292-a	slk:lemma	surový
 00672433-v	slk:lemma	stanoviť
 00054950-r	slk:lemma	veľmi
 01725530-v	slk:lemma	zahrať znovu
@@ -43529,7 +43529,7 @@
 05749619-n	slk:lemma	vkus
 02723016-v	slk:lemma	vyvádzať
 05695232-n	slk:lemma	pokušenie
-00461609-s	slk:lemma	hmlový
+00461609-a	slk:lemma	hmlový
 05031560-n	slk:lemma	spoľahlivosť
 01117454-n	slk:lemma	predaj kúpeného tovaru
 03724870-n	slk:lemma	maska
@@ -43545,7 +43545,7 @@
 02928066-a	slk:lemma	indiánsky
 13338960-n	slk:lemma	garančná poistka na splnenie zmluvy
 08565506-n	slk:lemma	zasľúbená zem
-00719328-s	slk:lemma	zvrchovaný
+00719328-a	slk:lemma	zvrchovaný
 01325777-a	slk:lemma	objasňujúci
 00564695-v	slk:lemma	skladať (prehýnať)
 03844815-n	slk:lemma	plášť do dažďa
@@ -43556,8 +43556,8 @@
 02028366-v	slk:lemma	dovaliť sa
 13414849-n	slk:lemma	cenný papier
 03679712-n	slk:lemma	obývačka
-01842468-s	slk:lemma	občasný
-00997036-s	slk:lemma	nepriaznivý
+01842468-a	slk:lemma	občasný
+00997036-a	slk:lemma	nepriaznivý
 06208751-n	slk:lemma	pozícia
 03259505-n	slk:lemma	domov
 08881256-n	slk:lemma	Berkshire
@@ -43568,9 +43568,9 @@
 08374049-n	slk:lemma	kolónia
 04210390-n	slk:lemma	svätyňa
 13959931-n	slk:lemma	nejestvovanie
-01440889-s	slk:lemma	výhľadový
+01440889-a	slk:lemma	výhľadový
 02759614-v	slk:lemma	podpaľovať
-02500590-s	slk:lemma	prázdny
+02500590-a	slk:lemma	prázdny
 02999272-n	slk:lemma	ochranný obal na laná
 01096097-v	slk:lemma	kritizovať
 14769760-n	slk:lemma	austenit
@@ -43589,7 +43589,7 @@
 05015678-n	slk:lemma	chlad
 00269140-v	slk:lemma	znehybniť
 00002724-v	slk:lemma	dusiť sa
-01153141-s	slk:lemma	vlnený
+01153141-a	slk:lemma	vlnený
 00086809-n	slk:lemma	obývanie
 00384802-n	slk:lemma	odluka
 15247110-n	slk:lemma	chvíľka
@@ -43608,7 +43608,7 @@
 01790020-v	slk:lemma	znepokojovať
 02061495-v	slk:lemma	upaľovať
 00229605-v	slk:lemma	zlepšovať
-01046226-s	slk:lemma	bežný
+01046226-a	slk:lemma	bežný
 06078327-n	slk:lemma	morfológia
 06624161-n	slk:lemma	úradný list
 07539790-n	slk:lemma	nuda
@@ -43619,7 +43619,7 @@
 08647354-n	slk:lemma	cintorín
 00233335-v	slk:lemma	obmedziť
 08679972-n	slk:lemma	smerovanie
-00421590-s	slk:lemma	odporný
+00421590-a	slk:lemma	odporný
 09155306-n	slk:lemma	West Virginia
 05517837-n	slk:lemma	pľuzgier
 00335182-r	slk:lemma	bez prípravy
@@ -43637,7 +43637,7 @@
 07305098-n	slk:lemma	škoda
 01267098-v	slk:lemma	pokrývať (cestu, chodník)
 00020926-v	slk:lemma	uviesť do extázy
-02336109-s	slk:lemma	primeraný
+02336109-a	slk:lemma	primeraný
 00605128-a	slk:lemma	nevyhovujúci
 02396088-n	slk:lemma	sviňa
 02157731-v	slk:lemma	zatiahnuť sa
@@ -43647,7 +43647,7 @@
 05098620-n	slk:lemma	hladina šumu
 02219094-v	slk:lemma	podporovať
 06065819-n	slk:lemma	agronómia
-01136248-s	slk:lemma	zlej nálady
+01136248-a	slk:lemma	zlej nálady
 00199659-v	slk:lemma	opraviť
 13338960-n	slk:lemma	garančná poistka
 05153520-n	slk:lemma	kompetentnosť
@@ -43659,7 +43659,7 @@
 01171183-v	slk:lemma	chľastať
 00955115-a	slk:lemma	hrateľný
 09729271-n	slk:lemma	obyvateľ Samoy
-01336837-s	slk:lemma	stupídny
+01336837-a	slk:lemma	stupídny
 01280488-v	slk:lemma	ohýnať sa
 01523986-v	slk:lemma	stáčať si
 00897241-v	slk:lemma	pozdraviť
@@ -43672,7 +43672,7 @@
 02205896-n	slk:lemma	rad Hymenoptera
 05808218-n	slk:lemma	zásadný objav
 03935698-n	slk:lemma	špička
-00440579-s	slk:lemma	tupý
+00440579-a	slk:lemma	tupý
 00305283-r	slk:lemma	ochotne rád
 10400437-n	slk:lemma	poslanec
 03510072-n	slk:lemma	ochranný štít proti teplu
@@ -43695,7 +43695,7 @@
 01770903-a	slk:lemma	varovný
 00125629-n	slk:lemma	zásah
 06605897-n	slk:lemma	úmysel
-00011327-s	slk:lemma	tvrdohlavý
+00011327-a	slk:lemma	tvrdohlavý
 00345454-n	slk:lemma	otáčanie
 07944050-n	slk:lemma	mládež
 00797697-v	slk:lemma	prijať
@@ -43705,12 +43705,12 @@
 05830527-n	slk:lemma	oštara
 01437888-v	slk:lemma	odosielať
 01068773-n	slk:lemma	abstinencia
-01574925-s	slk:lemma	mátožný
-00861216-s	slk:lemma	predpokladaný
+01574925-a	slk:lemma	mátožný
+00861216-a	slk:lemma	predpokladaný
 12144313-n	slk:lemma	kukurica
 03007354-a	slk:lemma	spôsobujúci upchávanie
 04039848-n	slk:lemma	rádiolokátor
-02341864-s	slk:lemma	poriadny
+02341864-a	slk:lemma	poriadny
 15020974-n	slk:lemma	staré železo
 13110915-n	slk:lemma	orech
 03145147-n	slk:lemma	kukučkové hodiny
@@ -43724,7 +43724,7 @@
 08072837-n	slk:lemma	trh s cennými papiermi
 05941423-n	slk:lemma	presvedčenie
 03325481-n	slk:lemma	perina
-01781076-s	slk:lemma	psychický
+01781076-a	slk:lemma	psychický
 02475922-v	slk:lemma	vymenovať
 00010435-v	slk:lemma	počať si
 00967129-a	slk:lemma	nezvyčajný
@@ -43746,7 +43746,7 @@
 09306840-n	slk:lemma	rieka Hudson
 00112090-r	slk:lemma	mlčky
 07417644-n	slk:lemma	kríza
-02119213-s	slk:lemma	vážny
+02119213-a	slk:lemma	vážny
 05797597-n	slk:lemma	prieskum
 07557165-n	slk:lemma	lahôdka
 00181676-r	slk:lemma	v zahraničí
@@ -43785,8 +43785,8 @@
 05750163-n	slk:lemma	módny smer
 01532589-v	slk:lemma	vyleštiť
 13559177-n	slk:lemma	pôvod
-01022785-s	slk:lemma	ohybný
-01007258-s	slk:lemma	limitovaný
+01022785-a	slk:lemma	ohybný
+01007258-a	slk:lemma	limitovaný
 03862984-n	slk:lemma	žiaruvzdorná keramika
 14490319-n	slk:lemma	záväznosť
 03132261-n	slk:lemma	kriketový výstroj
@@ -43794,7 +43794,7 @@
 15227846-n	slk:lemma	hodinka
 02499312-v	slk:lemma	posielať do vyhnanstva
 01855606-v	slk:lemma	presťahovať sa
-02226979-s	slk:lemma	majstrovský
+02226979-a	slk:lemma	majstrovský
 01993549-v	slk:lemma	prehnať sa
 08579487-n	slk:lemma	veľká kružnica
 07196075-n	slk:lemma	interview
@@ -43806,7 +43806,7 @@
 08101937-n	slk:lemma	rodokmeň
 01016832-n	slk:lemma	triedenie
 08511241-n	slk:lemma	spodok
-02075321-s	slk:lemma	pomätený
+02075321-a	slk:lemma	pomätený
 03859495-n	slk:lemma	šaty
 09215437-n	slk:lemma	kotlina
 02001858-v	slk:lemma	naháňať sa
@@ -43817,7 +43817,7 @@
 05298988-n	slk:lemma	vnútornosti
 01186208-v	slk:lemma	usporadúvať (hostinu)
 00531077-n	slk:lemma	kankán
-00768397-s	slk:lemma	rozvláčny
+00768397-a	slk:lemma	rozvláčny
 10079399-n	slk:lemma	poľnohospodár
 13779804-n	slk:lemma	populácia
 13626789-n	slk:lemma	chybný blok
@@ -43828,7 +43828,7 @@
 01445407-v	slk:lemma	bodnúť
 02281093-v	slk:lemma	skladovať
 02620466-v	slk:lemma	vzdať sa
-01715287-s	slk:lemma	popísaný
+01715287-a	slk:lemma	popísaný
 07420991-n	slk:lemma	pulz
 05855125-n	slk:lemma	veličina
 15244650-n	slk:lemma	moment
@@ -43839,7 +43839,7 @@
 04190052-n	slk:lemma	regál
 00589904-v	slk:lemma	pochopiť
 03153375-n	slk:lemma	príbor
-01465214-s	slk:lemma	erotický
+01465214-a	slk:lemma	erotický
 00721437-v	slk:lemma	zistiť
 02066510-v	slk:lemma	pohnúť sa
 00872886-v	slk:lemma	poradiť
@@ -43854,16 +43854,16 @@
 02666239-v	slk:lemma	líšiť sa
 00140751-v	slk:lemma	prehadzovať
 13365698-n	slk:lemma	opora
-01440641-s	slk:lemma	trvanlivý
+01440641-a	slk:lemma	trvanlivý
 10334782-n	slk:lemma	šarlatán
 00426757-n	slk:lemma	novokolonializmus
 00259894-n	slk:lemma	odškodnenie
-00337172-s	slk:lemma	presvedčený
+00337172-a	slk:lemma	presvedčený
 00105603-r	slk:lemma	rýchlo
 00349369-n	slk:lemma	ťah
 03183080-n	slk:lemma	prostriedok
 01170962-n	slk:lemma	boj
-00411353-s	slk:lemma	podobajúci sa na Krista
+00411353-a	slk:lemma	podobajúci sa na Krista
 00223983-n	slk:lemma	hromadná vražda
 00173338-v	slk:lemma	dať preč
 07670731-n	slk:lemma	kožka
@@ -43881,7 +43881,7 @@
 00391417-v	slk:lemma	potlačiť
 00817311-v	slk:lemma	uznať
 02019574-v	slk:lemma	porušovať
-02280333-s	slk:lemma	živý
+02280333-a	slk:lemma	živý
 06655388-n	slk:lemma	zásada
 03667829-n	slk:lemma	svetelný mikroskop
 00695761-v	slk:lemma	podceniť
@@ -43894,7 +43894,7 @@
 10230801-n	slk:lemma	zlodej
 00797430-v	slk:lemma	zamietať
 08240169-n	slk:lemma	partia
-02035086-s	slk:lemma	mravný
+02035086-a	slk:lemma	mravný
 04836268-n	slk:lemma	ambicióznosť
 04380346-n	slk:lemma	nôž stolový
 03420935-n	slk:lemma	garota
@@ -43942,7 +43942,7 @@
 05000913-n	slk:lemma	guľatosť
 12996841-n	slk:lemma	trieda Basidiomycetes
 14859838-n	slk:lemma	organické hnojivo
-01704420-s	slk:lemma	podobný perám
+01704420-a	slk:lemma	podobný perám
 05858936-n	slk:lemma	nemenná
 03795580-n	slk:lemma	pohyblivá bariéra
 11418750-n	slk:lemma	organický jav
@@ -43968,7 +43968,7 @@
 15242719-n	slk:lemma	svätodušné sviatky
 02771756-v	slk:lemma	vysychať
 10151760-n	slk:lemma	gitarista
-01593079-s	slk:lemma	bežný
+01593079-a	slk:lemma	bežný
 11894327-n	slk:lemma	reďkev
 00308370-n	slk:lemma	výlet
 01482228-a	slk:lemma	neženatý
@@ -43978,7 +43978,7 @@
 01909042-v	slk:lemma	otočiť sa čelom vzad
 05893356-n	slk:lemma	domnienka
 04332243-n	slk:lemma	hrubý filter
-00900071-s	slk:lemma	tajný
+00900071-a	slk:lemma	tajný
 00365709-n	slk:lemma	zväčšenie
 01803936-v	slk:lemma	ovládať (niekoho)
 02722207-v	slk:lemma	figurovať
@@ -43989,7 +43989,7 @@
 10346015-n	slk:lemma	vlastenec
 08053260-n	slk:lemma	pápežstvo
 04847482-n	slk:lemma	čnosť
-00624576-s	slk:lemma	poriadny
+00624576-a	slk:lemma	poriadny
 03133538-n	slk:lemma	keramické nádoby
 00596807-n	slk:lemma	prezidentstvo
 02699941-v	slk:lemma	prislúchať
@@ -44001,23 +44001,23 @@
 13855828-n	slk:lemma	opak
 05694791-n	slk:lemma	vnadidlo
 00435103-v	slk:lemma	povoliť
-00966753-s	slk:lemma	neznámy
+00966753-a	slk:lemma	neznámy
 02058994-v	slk:lemma	svišťať
 14524849-n	slk:lemma	atmosféra
 00282050-n	slk:lemma	vývoj
-00360950-s	slk:lemma	slobodný
+00360950-a	slk:lemma	slobodný
 00992518-v	slk:lemma	triasť hlavou
-00488998-s	slk:lemma	nezvyklý
+00488998-a	slk:lemma	nezvyklý
 00016702-v	slk:lemma	kývnuť
 07509996-n	slk:lemma	počudovanie
 07516997-n	slk:lemma	zlosť
 00800242-v	slk:lemma	odstúpiť od (sľubu, zmluvy)
-01537448-s	slk:lemma	gotický
+01537448-a	slk:lemma	gotický
 02413480-v	slk:lemma	odmakať
 05669934-n	slk:lemma	stav mysle
 01835496-v	slk:lemma	presúvať sa
 08763193-n	slk:lemma	Dominika
-01461292-s	slk:lemma	príjemný
+01461292-a	slk:lemma	príjemný
 09020961-n	slk:lemma	Tadžikistan
 00192511-r	slk:lemma	presvedčivo
 04587648-n	slk:lemma	okno


### PR DESCRIPTION
This PR does two things:

* Replaces any `-s` synset IDs with `-a` for nld, lit, and slk. This happened anyway during conversion to WN-LMF, but for some reason the `.tab` files still retained the `-s` IDs. I confirmed that the resulting XML files had no diffs.
* Removes entries (see list below) from tab files where the offset does not match anything in WordNet 3.0. Some of these had lemmas in other synsets, but many did not. Of those that did not, some do not appear to be good candidates as the POS was wrong or the lemma was a phrase. It would be unfortunate if some useful data were lost, but: (1) we have version control; (2) if the entries do not match a WordNet 3.0 ID, they do not have much value; (3) some lemmas are represented by other entries; and (4) examples without lemmas probably aren't very useful (I did not check if any examples without lemmas exist for actual WordNet 3.0 synsets IDs).

The list of removed entries, from #24, is as follows:
```text
wns/mcr/wn-data-cat.tab:00001837-n      cat:exe 0       187 DC
wns/hrv/wn-data-hrv.tab:01498548-a      hrv:lemma       amoralan
wns/hrv/wn-data-hrv.tab:01498548-a      hrv:lemma       nemoralan
wns/hrv/wn-data-hrv.tab:01505508-a      hrv:lemma       mnogo više
wns/hrv/wn-data-hrv.tab:01505508-a      hrv:lemma       puno više
wns/hrv/wn-data-hrv.tab:02002046-a      hrv:lemma       izuzev
wns/hrv/wn-data-hrv.tab:02002046-a      hrv:lemma       izuzevši
wns/hrv/wn-data-hrv.tab:02002046-a      hrv:lemma       izuzimajući
wns/hrv/wn-data-hrv.tab:02002046-a      hrv:lemma       osim
wns/hrv/wn-data-hrv.tab:02917945-a      hrv:lemma       mahunast
wns/hrv/wn-data-hrv.tab:03202339-n      hrv:lemma       modne potrepštine
wns/cow/wn-data-cmn.tab:14869976-n      cmn:lemma       污点
wns/cow/wn-data-cmn.tab:14869977-n      cmn:lemma       小斑
wns/cow/wn-data-cmn.tab:15168570-n      cmn:lemma       规定的睡觉时间
wns/cow/wn-data-cmn.tab:15171146-n      cmn:lemma       节日
wns/cow/wn-data-cmn.tab:15171147-n      cmn:lemma       纪念日
wns/cow/wn-data-cmn.tab:15171739-n      cmn:lemma       竞技状态不佳的日子
wns/cow/wn-data-cmn.tab:15171858-n      cmn:lemma       存取时间
wns/cow/wn-data-cmn.tab:15172882-n      cmn:lemma       选举日
wns/cow/wn-data-cmn.tab:15173065-n      cmn:lemma       教会年
wns/cow/wn-data-cmn.tab:15176162-n      cmn:lemma       雾月
wns/cow/wn-data-cmn.tab:15177867-n      cmn:lemma       希伯来历
wns/cow/wn-data-cmn.tab:15178842-n      cmn:lemma       回历
wns/mcr/wn-data-glg.tab:15300653-n      glg:lemma       métopa
wns/mcr/wn-data-spa.tab:15300823-n      spa:exe 0       En 1850, el Dr. Green publicó un artículo en la revista Lancet en el cual niega la relación del "asma del heno" con el heno.
```

The removals are noted in the `*-changes.tab` files, but the `-s` to `-a` modifications are not (it's trivial, and there are thousands of them).