### PR TITLE
Release 2.0

### DIFF
--- a/build-en.sh
+++ b/build-en.sh
@@ -153,6 +153,7 @@ elif [ "$VER" = "2.1" ]; then
     fi
 
 elif [ "$VER" = "3.0" ]; then
+    WNID="omw-en"  # override omw-en30
     LICENSE="https://wordnet.princeton.edu/license-and-commercial-use"
     ILIMAP="${CILIDIR}/ili-map-pwn${SHORTVER}.tab"
     if [ ! -d "${WNDIR}" ]; then

--- a/index.toml
+++ b/index.toml
@@ -21,7 +21,7 @@ Francis Bond and Ryan Foster. 2013. \
 email = "bond@ieee.org"
 url = "https://github.com/omwn/omw-data"
 # to unset requires use: requires = {}
-requires = { id = "omw-en30", version = "1.5" }
+requires = { id = "omw-en", version = "1.5" }
 
 [packages]
 
@@ -478,7 +478,7 @@ citation = """
 Christiane Fellbaum. (ed.). 1998.\
   *WordNet: An Electronic Lexical Database*, MIT Press."""
 
-[extra.omw-en30]
+[extra.omw-en]
 
 label = "OMW English Wordnet based on WordNet 3.0"
 language = "en"


### PR DESCRIPTION
This branch is for final changes before producing the release.

- Go back to using `omw-en` instead of `omw-en30` for WordNet 3.0. I no longer think the benefit of clarity and consistency outweighs the disruption caused by the change.